### PR TITLE
[ci] Pin Clang as the host toolchain in install-build-deps.

### DIFF
--- a/.github/actions/install-build-deps/action.yml
+++ b/.github/actions/install-build-deps/action.yml
@@ -1,8 +1,21 @@
 name: 'Install build dependencies'
 description: |
   Installs the host-side packages a recipe build needs (ninja, zstd,
-  ccache, rsync). Pulled out of publish-recipe.yml so the dispatch
-  and push jobs share the same install logic.
+  ccache, rsync) and a Clang host toolchain. Pulled out of
+  publish-recipe.yml so the dispatch and push jobs share the same
+  install logic.
+
+  Why Clang: recipes that set LLVM_USE_SANITIZER (e.g. llvm-asan)
+  rely on Clang-specific UBSan flags such as `-fno-sanitize=function`
+  and `-fsanitize-blacklist=`, which gcc rejects. Forcing Clang as
+  the host compiler keeps every recipe on a uniformly-supported
+  toolchain rather than picking up whatever the runner image's
+  default `c++` happens to be (gcc on Ubuntu).
+
+  macOS already provides Clang via the Xcode CLT preinstalled on
+  GHA runners; we just point CC/CXX at it explicitly. Windows uses
+  clang-cl from Chocolatey when needed by individual recipes; the
+  default here installs only ninja and zstandard.
 
 runs:
   using: composite
@@ -12,13 +25,18 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y ninja-build zstd ccache rsync
+        sudo apt-get install -y ninja-build zstd ccache rsync clang
+        # Pin the host compiler for every subsequent step in this job.
+        echo "CC=clang" >> "$GITHUB_ENV"
+        echo "CXX=clang++" >> "$GITHUB_ENV"
 
     - name: Install build dependencies (macOS)
       if: runner.os == 'macOS'
       shell: bash
       run: |
         brew install ninja zstd ccache rsync
+        echo "CC=clang" >> "$GITHUB_ENV"
+        echo "CXX=clang++" >> "$GITHUB_ENV"
 
     - name: Install build dependencies (Windows)
       if: runner.os == 'Windows'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -126,6 +126,29 @@ jobs:
           cat /tmp/c.tar.zst | zstd -d | tar -xf - -C dest
           diff -r src/llvm-project dest/llvm-project
 
+  # Smoke-tests recipes/llvm-asan against the install-build-deps
+  # toolchain by running the recipe's own build.sh in
+  # RECIPE_QUICK_CHECK mode. Catches the publish-time failure mode
+  # where the runner's default c++ rejects LLVM_USE_SANITIZER's
+  # Clang-only UBSan flags. Costs a git clone + cmake configure +
+  # one tiny library compile (~3-5 min); slower than the other
+  # verify jobs but cheap insurance against another 30-min publish
+  # blowing up post-merge.
+  llvm-asan-smoke:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-build-deps
+      - name: Configure + build LLVMDemangle (RECIPE_QUICK_CHECK)
+        env:
+          RECIPE_VERSION: '22'
+          WORK_DIR: ${{ github.workspace }}/_recipe_work
+          OUT_DIR: ${{ github.workspace }}/_recipe_out
+          RECIPE_QUICK_CHECK: '1'
+        run: |
+          mkdir -p "$WORK_DIR" "$OUT_DIR"
+          bash recipes/llvm-asan/build.sh
+
   end-to-end-fixture:
     runs-on: ubuntu-24.04
     steps:

--- a/recipes/llvm-asan/build.sh
+++ b/recipes/llvm-asan/build.sh
@@ -69,6 +69,20 @@ cmake -G Ninja \
   "${cmake_extra[@]}" \
   ../llvm
 
+# RECIPE_QUICK_CHECK=1 builds only the smallest LLVM library (LLVMDemangle)
+# and exits successfully. Used by verify.yml as a PR-time smoke check
+# that catches host-toolchain mismatches in ~3 min — the actual mode
+# this guards against was a real publish failure post-merge where the
+# runner picked up gcc by default and rejected Clang-only UBSan flags.
+# Building LLVMDemangle exercises the same compiler invocation as the
+# first ~30 source files of the full build without paying the rest of
+# the ~30 min.
+if [[ "${RECIPE_QUICK_CHECK:-0}" == "1" ]]; then
+  ninja -j "${NCPUS}" LLVMDemangle
+  echo "build.sh: RECIPE_QUICK_CHECK passed (cmake configure + LLVMDemangle)."
+  exit 0
+fi
+
 ninja -j "${NCPUS}" clang clangInterpreter clangStaticAnalyzerCore
 
 # compiler-rt is enabled solely for the OOP-JIT runtime that CppInterOp's


### PR DESCRIPTION
The first push-triggered publish run failed at
`[1/3215] Building CXX object lib/Demangle/...` because the runner's default `c++` is g++, which rejects the Clang-only UBSan flags that LLVM_USE_SANITIZER injects:

    c++: error: unrecognized argument to '-fno-sanitize=' option:
      'function'
    c++: error: unrecognized command-line option
      '-fsanitize-blacklist=...'

Force Clang as the host compiler in install-build-deps and export CC/CXX so every subsequent step in the job (cmake, ninja via build.sh, ccache wrappers) sees the right toolchain. macOS already has Clang via Xcode CLT — only the env export is needed there. Windows continues with whatever clang-cl recipes pick up on their own; no Windows recipes consume install-build-deps yet.