### PR TITLE
[ci] Make cells.yaml the source of truth for the recipe cache. 

### DIFF
--- a/.github/workflows/prune-cache.yml
+++ b/.github/workflows/prune-cache.yml
@@ -1,0 +1,155 @@
+name: prune-cache
+
+# Converges the Releases cache to what cells.yaml says should be there.
+# Runs after every successful publish-recipe completion (so newly
+# uploaded assets exist in their canonical key form before pruning),
+# plus weekly on a schedule as a watchdog, plus manually.
+#
+# Algorithm:
+#   1. Compute expected_keys = { compute-key for each cell in cells.yaml }.
+#   2. List existing assets on the rolling Release.
+#   3. orphans = existing − expected.
+#   4. Drop orphans whose age > caps.grace_days (so in-flight PRs that
+#      reference an old key aren't broken mid-run by the prune).
+#   5. Tally remaining storage; warn over caps.soft_gb, fail over
+#      caps.hard_gb.
+#
+# What grace_days protects: when a recipe build.sh is edited, the
+# cache key for every affected cell moves. The next push warms the new
+# keys; the old assets become orphans. A PR opened a day before the
+# edit and tested a day after still references the old key and pulls
+# the old asset. Holding orphans for `grace_days` (default 7) lets
+# those in-flight PRs finish before the asset disappears.
+on:
+  workflow_run:
+    workflows: [publish-recipe]
+    types: [completed]
+  schedule:
+    # Weekly watchdog. UTC; pick a low-traffic time.
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write   # delete release assets
+
+jobs:
+  prune:
+    # Don't prune on a *failed* publish-recipe run — bad data could mean
+    # we'd evict still-needed assets. The schedule and dispatch paths
+    # always run.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute expected keys
+        id: expected
+        run: |
+          set -euo pipefail
+          : > /tmp/expected_keys.txt
+          while IFS= read -r cell; do
+            [ -z "$cell" ] && continue
+            recipe=$(echo "$cell" | jq -r .recipe)
+            version=$(echo "$cell" | jq -r .version)
+            os=$(echo "$cell"     | jq -r .os)
+            arch=$(echo "$cell"   | jq -r .arch)
+            key=$(bash actions/setup-recipe/compute-key.sh \
+                    "$recipe" "$version" "$os" "$arch" | sed 's/^key=//')
+            echo "$key" >> /tmp/expected_keys.txt
+          done < <(yq -o=json -I=0 '.cells[]' cells.yaml)
+          sort -u -o /tmp/expected_keys.txt /tmp/expected_keys.txt
+          n=$(wc -l < /tmp/expected_keys.txt | tr -d ' ')
+          echo "::notice::expected $n key(s) from cells.yaml"
+          cat /tmp/expected_keys.txt
+
+      - name: List existing release assets
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # No Release yet → nothing to prune. Exit cleanly.
+          if ! gh release view cache -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::notice::no 'cache' release yet; nothing to prune"
+            : > /tmp/existing_assets.jsonl
+            exit 0
+          fi
+          # `--jq` over `.assets[]` flattens to one JSON object per line.
+          gh release view cache -R "$GITHUB_REPOSITORY" \
+            --json assets \
+            --jq '.assets[] | {name, size, createdAt}' \
+            > /tmp/existing_assets.jsonl
+          n=$(wc -l < /tmp/existing_assets.jsonl | tr -d ' ')
+          echo "::notice::found $n asset(s) on cache release"
+
+      - name: Compute orphans + drop those past grace
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ ! -s /tmp/existing_assets.jsonl ]; then
+            echo "::notice::no existing assets; nothing to do"
+            exit 0
+          fi
+          grace_days=$(yq '.caps.grace_days' cells.yaml)
+          now=$(date -u +%s)
+          # For every .tar.zst whose key (filename minus .tar.zst)
+          # isn't in /tmp/expected_keys.txt and whose age exceeds
+          # grace_days, delete it and its sibling .manifest.json.
+          dropped=0
+          kept=0
+          while IFS= read -r asset; do
+            name=$(echo "$asset" | jq -r .name)
+            case "$name" in
+              *.tar.zst)        key="${name%.tar.zst}" ;;
+              *.manifest.json)  continue ;;  # handled with its tarball
+              *)                echo "::warning::unexpected asset: $name"; continue ;;
+            esac
+            if grep -qxF "$key" /tmp/expected_keys.txt; then
+              kept=$((kept + 1))
+              continue
+            fi
+            created=$(echo "$asset" | jq -r .createdAt)
+            created_epoch=$(date -u -d "$created" +%s 2>/dev/null || true)
+            if [ -z "$created_epoch" ]; then
+              echo "::warning::could not parse createdAt='$created' for $key; keeping"
+              kept=$((kept + 1))
+              continue
+            fi
+            age_days=$(( (now - created_epoch) / 86400 ))
+            if [ "$age_days" -lt "$grace_days" ]; then
+              echo "::notice::orphan within grace ($age_days/$grace_days days): $key"
+              kept=$((kept + 1))
+              continue
+            fi
+            echo "::notice::dropping orphan ($age_days days old): $key"
+            gh release delete-asset cache "${key}.tar.zst" \
+              -R "$GITHUB_REPOSITORY" --yes || true
+            gh release delete-asset cache "${key}.manifest.json" \
+              -R "$GITHUB_REPOSITORY" --yes || true
+            dropped=$((dropped + 1))
+          done < /tmp/existing_assets.jsonl
+          echo "::notice::prune summary: dropped=$dropped kept=$kept"
+
+      - name: Enforce caps
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! gh release view cache -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            exit 0
+          fi
+          soft=$(yq '.caps.soft_gb' cells.yaml)
+          hard=$(yq '.caps.hard_gb' cells.yaml)
+          total_bytes=$(gh release view cache -R "$GITHUB_REPOSITORY" \
+            --json assets --jq '[.assets[].size] | add // 0')
+          # Convert to GB (binary GiB so 1024^3 — close enough for caps).
+          total_gb=$(( total_bytes / 1073741824 ))
+          echo "::notice::cache size: ${total_gb} GiB (soft cap ${soft}, hard cap ${hard})"
+          if [ "$total_gb" -gt "$hard" ]; then
+            echo "::error::cache size ${total_gb} GiB exceeds hard cap ${hard} GiB"
+            exit 1
+          fi
+          if [ "$total_gb" -gt "$soft" ]; then
+            echo "::warning::cache size ${total_gb} GiB exceeds soft cap ${soft} GiB"
+          fi

--- a/.github/workflows/publish-recipe.yml
+++ b/.github/workflows/publish-recipe.yml
@@ -3,13 +3,14 @@ name: publish-recipe
 # Two trigger paths:
 #   workflow_dispatch — operator-driven, single cell from inputs.
 #   push to main      — auto-warm the recipe cache after a merge that
-#                       touched the recipe directory or actions. Each
-#                       cell goes through the same publish-recipe
-#                       action, which skip-if-exists internally so the
-#                       steady state cost is one HEAD probe per cell.
-#
-# When cells.yaml lands the push matrix becomes derived from that file
-# rather than hardcoded.
+#                       touched the recipe directory or actions. The
+#                       push matrix is derived from cells.yaml; a
+#                       preflight job reads cells.yaml, probes the
+#                       Releases cache for each cell, and emits *only*
+#                       the cells whose key is missing. So the
+#                       steady-state cost on a no-op push is one
+#                       preflight runner (~30 s) and zero per-cell
+#                       runners.
 on:
   workflow_dispatch:
     inputs:
@@ -37,6 +38,7 @@ on:
   push:
     branches: [main]
     paths:
+      - 'cells.yaml'
       - 'recipes/**'
       - 'actions/setup-recipe/**'
       - 'actions/publish-recipe/**'
@@ -60,17 +62,60 @@ jobs:
           os: ${{ inputs.os }}
           arch: ${{ inputs.arch }}
 
-  publish-on-push:
+  read-cells:
     if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    outputs:
+      # Matrix `include:` JSON. Empty when every cell is already
+      # published — the publish-on-push job skips itself in that case.
+      matrix: ${{ steps.compute.outputs.matrix }}
+      empty: ${{ steps.compute.outputs.empty }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: compute
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          todo=()
+          # `yq -o=json -I=0 '.cells[]'` emits one compact JSON object per
+          # cell, one per line — safe to read with `while IFS= read -r`.
+          while IFS= read -r cell; do
+            [ -z "$cell" ] && continue
+            recipe=$(echo "$cell" | jq -r .recipe)
+            version=$(echo "$cell" | jq -r .version)
+            os=$(echo "$cell"     | jq -r .os)
+            arch=$(echo "$cell"   | jq -r .arch)
+            key=$(bash actions/setup-recipe/compute-key.sh \
+                    "$recipe" "$version" "$os" "$arch" | sed 's/^key=//')
+            url="https://github.com/${REPO}/releases/download/cache/${key}.tar.zst"
+            if curl -fsLI "$url" >/dev/null 2>&1; then
+              echo "::notice::cache hit, skipping: ${key}"
+            else
+              echo "::notice::needs build: ${key}"
+              todo+=("$cell")
+            fi
+          done < <(yq -o=json -I=0 '.cells[]' cells.yaml)
+
+          if [ ${#todo[@]} -eq 0 ]; then
+            echo "matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
+            echo "empty=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::all cells already cached; no per-cell jobs to spawn"
+          else
+            matrix=$(printf '%s\n' "${todo[@]}" | jq -s -c '{include: .}')
+            echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+            echo "empty=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::${#todo[@]} cell(s) to (re)build"
+          fi
+
+  publish-on-push:
+    needs: read-cells
+    if: github.event_name == 'push' && needs.read-cells.outputs.empty != 'true'
     name: ${{ matrix.recipe }} v${{ matrix.version }} (${{ matrix.os }}/${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      # Hardcoded one-cell matrix for now. Replace with a fromJson
-      # over cells.yaml when that lands.
-      matrix:
-        include:
-          - { recipe: llvm-asan, version: '22', os: ubuntu-24.04, arch: x86_64 }
+      matrix: ${{ fromJson(needs.read-cells.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-build-deps

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,6 +9,7 @@ name: verify
 on:
   pull_request:
     paths:
+      - 'cells.yaml'
       - 'recipes/**'
       - 'actions/**'
       - 'bin/**'
@@ -108,6 +109,85 @@ jobs:
             done
           done
           exit $fail
+
+  cells-yaml-integrity:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Schema parse
+        # cells.yaml is the single source of truth for what publish-recipe
+        # warms and what prune-cache keeps. All later checks here build
+        # on a successful parse; no point validating fields if the YAML
+        # itself is malformed.
+        run: yq -o=json '.' cells.yaml >/dev/null
+      - name: Required fields present
+        run: |
+          set -euo pipefail
+          for f in support_window caps cells; do
+            if ! yq -e "has(\"$f\")" cells.yaml >/dev/null; then
+              echo "::error file=cells.yaml::missing required top-level field: $f"
+              exit 1
+            fi
+          done
+          for f in soft_gb hard_gb grace_days; do
+            if ! yq -e ".caps | has(\"$f\")" cells.yaml >/dev/null; then
+              echo "::error file=cells.yaml::caps missing field: $f"
+              exit 1
+            fi
+          done
+      - name: caps sanity
+        run: |
+          set -euo pipefail
+          soft=$(yq '.caps.soft_gb' cells.yaml)
+          hard=$(yq '.caps.hard_gb' cells.yaml)
+          grace=$(yq '.caps.grace_days' cells.yaml)
+          [ "$soft" -lt "$hard" ] || { echo "::error file=cells.yaml::soft_gb ($soft) must be < hard_gb ($hard)"; exit 1; }
+          [ "$grace" -gt 0 ]      || { echo "::error file=cells.yaml::grace_days must be > 0"; exit 1; }
+      - name: No duplicate cells
+        run: |
+          set -euo pipefail
+          # Serialise each cell to a single JSON line, then look for repeats.
+          dupes=$(yq -o=json -I=0 '.cells[]' cells.yaml | sort | uniq -d)
+          if [ -n "$dupes" ]; then
+            echo "::error file=cells.yaml::duplicate cells found:"
+            echo "$dupes"
+            exit 1
+          fi
+      - name: Referenced recipes exist with required files
+        run: |
+          set -euo pipefail
+          fail=0
+          for r in $(yq '.cells[].recipe' cells.yaml | sort -u); do
+            dir="recipes/$r"
+            if [ ! -d "$dir" ]; then
+              echo "::error file=cells.yaml::references recipe '$r' but $dir does not exist"
+              fail=1
+              continue
+            fi
+            for f in recipe.yaml build.sh; do
+              if [ ! -f "$dir/$f" ]; then
+                echo "::error file=$dir::recipe '$r' missing $f"
+                fail=1
+              fi
+            done
+          done
+          exit $fail
+      - name: No orphan recipe directories
+        # Catches recipes/ subdirs that aren't referenced by cells.yaml.
+        # An orphan recipe directory is dead weight — it's never built,
+        # never published, but its contents still feed compute-key parity
+        # tests etc. Force the maintainer to either add a cell or remove
+        # the directory.
+        run: |
+          set -euo pipefail
+          referenced=$(yq '.cells[].recipe' cells.yaml | sort -u)
+          actual=$(for d in recipes/*/; do [ -d "$d" ] && basename "$d"; done | sort -u)
+          orphans=$(comm -23 <(echo "$actual") <(echo "$referenced"))
+          if [ -n "$orphans" ]; then
+            echo "::error::recipe directories not referenced by any cell in cells.yaml:"
+            echo "$orphans"
+            exit 1
+          fi
 
   tar-zstd-round-trip:
     runs-on: ubuntu-24.04

--- a/actions/publish-recipe/action.yml
+++ b/actions/publish-recipe/action.yml
@@ -157,6 +157,18 @@ runs:
       run: |
         source actions/lib/cache-io.sh
         cd "${{ github.workspace }}/_recipe_out"
-        tar -cf - llvm-project | zstd -19 --long > "${KEY}.tar.zst"
+        echo "::notice::input tree size:"
+        du -sh llvm-project
+        # Why `-T0`: zstd is single-threaded by default. -T0 fans out to
+        # all vCPUs, which on a 4-vCPU GHA runner brings the compress
+        # phase from ~8 min to ~2 min on a 4 GB tree. -19 stays —
+        # smaller asset wins more on the upload + every later download.
+        # Tar checkpoints emit one stderr line every ~50 MB of input so
+        # the log shows liveness during the otherwise-silent pipe.
+        echo "::notice::compressing ${KEY}.tar.zst (zstd -19 --long -T0)"
+        tar -cf - llvm-project \
+            --checkpoint=100000 --checkpoint-action=echo='%T tar checkpoint' \
+          | zstd -19 --long -T0 > "${KEY}.tar.zst"
         ls -lh "${KEY}.tar.zst"
+        echo "::notice::uploading to $BASE"
         cache_upload "$BASE" "$KEY" "${KEY}.tar.zst" "${KEY}.manifest.json"

--- a/cells.yaml
+++ b/cells.yaml
@@ -1,0 +1,33 @@
+# cells.yaml — single source of truth for what the recipe cache holds.
+#
+# Every entry under `cells:` is a (recipe, version, os, arch) tuple that
+# publish-recipe.yml's push trigger will warm on every relevant push,
+# and that prune-cache will *not* drop. Anything in Releases whose key
+# doesn't correspond to an entry here is an orphan and gets pruned
+# after `caps.grace_days`.
+#
+# Editing this file:
+#   - Add a row → next push to main warms it (or just dispatch
+#     publish-recipe manually).
+#   - Remove a row → next push to main prunes the asset after the
+#     grace period (so in-flight PRs that still reference the old key
+#     don't break mid-run).
+#   - Change build inputs (recipe directory content) → the cache key
+#     moves; the old asset becomes an orphan, the new one gets warmed.
+
+# Major LLVM versions we currently support. Informational here;
+# package-catchup-probe will key off this list.
+support_window:
+  - 22
+
+caps:
+  # Soft cap: prune-cache emits ::warning:: when total Release storage
+  # is over this. Hard cap: workflow fails. Grace days: how long to
+  # leave an orphan asset around so in-flight PRs don't break when
+  # the cell is removed from this file or the recipe content changes.
+  soft_gb: 20
+  hard_gb: 30
+  grace_days: 7
+
+cells:
+  - { recipe: llvm-asan, version: '22', os: ubuntu-24.04, arch: x86_64 }

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -39,7 +39,7 @@ recipe produces, the next push to `main` rebuilds them, the cache
 repopulates. Bump the LLVM version in your client repo's matrix
 from `'22'` to `'23'` — the key changes (different `version`
 input), `publish-recipe` builds the new cell, leaves the old one
-alone until `prune-cache` (TODO) garbage-collects it.
+alone until `prune-cache` garbage-collects it after `caps.grace_days`.
 
 Things that *don't* move the key, deliberately:
 
@@ -188,11 +188,11 @@ priority until then.
 **Recipe builds aren't host-portable for free.** The first cell
 of a new recipe needs verification on each platform you intend to
 publish for — cmake flag differences, ninja target name
-differences, available libraries. `cells.yaml` (TODO) will
-eventually enumerate which combinations are first-class; until
-then, every cell expansion is a manual integration step done by
-adding a row to the matrix in `publish-recipe.yml` and running
-the workflow once.
+differences, available libraries. `cells.yaml` enumerates which
+combinations are first-class; every cell expansion is a manual
+integration step done by adding a row to `cells.yaml` and either
+dispatching `publish-recipe` once for that cell or letting the
+push trigger pick it up.
 
 ## Adding a new recipe
 
@@ -237,7 +237,8 @@ client repo's matrix. The key changes; on the first PR run after
 the bump, the recipe builds inline (`build-on-miss: true` does
 the right thing); on the next push to ci-workflows main the new
 cell gets warmed. The previous version's cell stays cached until
-`prune-cache` (TODO) drops it.
+either it ages past `caps.grace_days` or you remove it from
+`cells.yaml`, at which point `prune-cache` drops it.
 
 ## Inspecting a published asset
 


### PR DESCRIPTION
Introduces cells.yaml as the participation list of (recipe, version, os, arch) tuples that publish-recipe warms and prune-cache keeps. Editing this file is now the single way to expand or contract the cached set; everything else converges to it automatically.