### PR TITLE
[recipes/llvm-asan] Drop CMakeFiles + ninja state from the trim. NFC

### DIFF
--- a/recipes/llvm-asan/build.sh
+++ b/recipes/llvm-asan/build.sh
@@ -114,13 +114,38 @@ fi
 
 # Trim the tree before rsync — keeps Releases asset under the per-asset
 # 2 GB cap and matches what downstream consumers actually link against.
+#
+# What we keep:
+#   - top-level build/, llvm/, clang/ (the only dirs consumers reach into)
+#   - llvm/{include,lib,cmake} and clang/{include,lib,cmake} on the source side
+#   - build/lib/*.{a,so,dylib} (link targets)
+#   - build/lib/cmake/{llvm,clang}/ (find_package(LLVM)/find_package(Clang))
+#   - build/include/ (generated config + tablegen .inc headers)
+#   - build/tools/clang/include/ (clang's generated headers)
+#   - build/bin/ (FileCheck, llvm-config, etc. that downstream tests need)
+#
+# What we drop, beyond the obvious source-side trim:
+#   - build/**/CMakeFiles/   intermediate build state — every per-target
+#                            *.dir/ subdir under here holds .o, .d, and
+#                            cmake metadata. On asan builds these alone
+#                            are 1-2 GB because asan-instrumented .o
+#                            files are 3-5x the size of regular ones.
+#                            Consumers never need them; we don't do
+#                            incremental rebuilds (cache-or-rebuild model),
+#                            so cmake's incremental scaffolding is dead
+#                            weight in the artifact.
+#   - build/.ninja_deps      ninja's incremental dep graph. Hundreds of
+#     build/.ninja_log       MB on big builds; only useful for `ninja`
+#                            re-runs we never do.
 cd ..
 
 shopt -s extglob
 rm -rf -- !(build|llvm|clang)
 ( cd llvm  && rm -rf -- !(include|lib|cmake) )
 ( cd clang && rm -rf -- !(include|lib|cmake) )
-( cd build && rm -f compile_commands.json build.ninja )
+( cd build && \
+  rm -f compile_commands.json build.ninja .ninja_deps .ninja_log
+  find . -name CMakeFiles -type d -prune -exec rm -rf {} + )
 shopt -u extglob
 
 rsync -a --delete \


### PR DESCRIPTION
The strip step inside `build/` only removed `compile_commands.json` and `build.ninja`, leaving every per-target `CMakeFiles/*.dir/` subdirectory in place. Those hold the build's intermediate state: `.o` object files, `.d` dependency files, cmake's per-target metadata. Multiple GB on asan builds because asan-instrumented `.o` files are 3-5x the size of regular ones — that's where the 6.2 GB observed on the live cell came from.

None of it is needed by downstream consumers. They read `build/lib/*.a`, `build/lib/cmake/{llvm,clang}/`, `build/bin/*`, `build/include/`, and `build/tools/clang/include/`. Everything under `CMakeFiles/` is incremental-rebuild scaffolding for cmake and ninja, and we never do incremental rebuilds — the cache model is rebuild-from-scratch on a key miss.

Same story for `.ninja_deps` and `.ninja_log` (ninja's own incremental state, hundreds of MB on big builds).

Estimated win: 6.2 GB stripped tree → ~2.5-3 GB. Compressed asset shrinks proportionally; the upload phase drops by minutes per cell.

NFC: the artifact's exposed surface to downstream is unchanged (same libs, same headers, same cmake config), only the on-disk size shrinks.

Side effect on the cache: build.sh content is part of the recipe directory hash, so the asan key moves once. The current cell's asset becomes an orphan; the next push to main rebuilds and republishes under the new key; prune-cache evicts the old after caps.grace_days.

The same trim should apply to llvm-vanilla once that recipe lands on main — addressed in the setup-system-llvm branch's follow-up rebase rather than here, since vanilla isn't on main yet.