### PR TITLE
[ci] Publish llvm-asan as a relocatable install tree.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -198,9 +198,12 @@ jobs:
       - name: Tiny tree round-trip via the publish/consume pipelines
         run: |
           set -euo pipefail
-          mkdir -p src/llvm-project/build/lib src/llvm-project/llvm/include
-          echo "header" > src/llvm-project/llvm/include/foo.h
-          printf 'binary\x00\x01\x02' > src/llvm-project/build/lib/libfoo.a
+          # Mirror the install-tree shape that real recipes produce:
+          # bin/, lib/, include/, lib/cmake/llvm/. The contents here are
+          # synthetic — what we're testing is tar+zstd, not the layout.
+          mkdir -p src/llvm-project/lib src/llvm-project/include
+          echo "header" > src/llvm-project/include/foo.h
+          printf 'binary\x00\x01\x02' > src/llvm-project/lib/libfoo.a
           ( cd src && tar -cf - llvm-project | zstd -19 --long > /tmp/c.tar.zst )
           mkdir dest
           cat /tmp/c.tar.zst | zstd -d | tar -xf - -C dest
@@ -254,17 +257,17 @@ jobs:
           cat > recipes/__verify_fixture/build.sh <<'EOF'
           #!/usr/bin/env bash
           set -euo pipefail
-          mkdir -p "$OUT_DIR/llvm-project/build/bin"
+          mkdir -p "$OUT_DIR/llvm-project/bin"
           echo "fake clang built by recipe v${RECIPE_VERSION}" \
-            > "$OUT_DIR/llvm-project/build/bin/clang"
+            > "$OUT_DIR/llvm-project/bin/clang"
           EOF
           chmod +x recipes/__verify_fixture/build.sh
           bin/recipe-cache build __verify_fixture 1 ubuntu-24.04 x86_64
           bin/recipe-cache list
           mkdir /tmp/out
           bin/recipe-cache get __verify_fixture 1 ubuntu-24.04 x86_64 --out /tmp/out
-          test -f /tmp/out/llvm-project/build/bin/clang
-          grep -q "fake clang built by recipe v1" /tmp/out/llvm-project/build/bin/clang
+          test -f /tmp/out/llvm-project/bin/clang
+          grep -q "fake clang built by recipe v1" /tmp/out/llvm-project/bin/clang
           # Manifest sanity
           jq -e .recipe "/tmp/cache/$(bin/recipe-cache key __verify_fixture 1 ubuntu-24.04 x86_64).manifest.json"
       - name: Negative — get on uncached key fails

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ bin/recipe-cache pack llvm-asan 22 darwin arm64 \
 
 # Fetch + extract.
 bin/recipe-cache get llvm-asan 22 ubuntu-24.04 x86_64 --out /tmp/llvm
-ls /tmp/llvm/llvm-project/build/lib/cmake/llvm/
+# Recipes publish a cmake --install tree, so LLVMConfig.cmake lives at
+# the standard install path — pass this directory to find_package(LLVM).
+ls /tmp/llvm/llvm-project/lib/cmake/llvm/
 
 # Inspect cached cells.
 bin/recipe-cache list

--- a/actions/setup-recipe/action.yml
+++ b/actions/setup-recipe/action.yml
@@ -195,14 +195,17 @@ runs:
       shell: bash
       env:
         RECIPE_VERSION: ${{ inputs.version }}
-        WORK_DIR: ${{ github.workspace }}
+        WORK_DIR: ${{ github.workspace }}/_recipe_work
         OUT_DIR: ${{ github.workspace }}/_recipe_out
       run: |
-        mkdir -p "$OUT_DIR"
+        mkdir -p "$WORK_DIR" "$OUT_DIR"
         bash __ci_workflows__/recipes/${{ inputs.recipe }}/build.sh
-        # build.sh produces $OUT_DIR/llvm-project; surface it at workspace root.
+        # build.sh installs to $OUT_DIR/llvm-project. The install tree is
+        # relocatable (cmake configs use _IMPORT_PREFIX-relative paths),
+        # so move it under the workspace where consumers expect to find it.
         if [[ -d "$OUT_DIR/llvm-project" ]]; then
-          rsync -a "$OUT_DIR/llvm-project/" "$GITHUB_WORKSPACE/llvm-project/"
+          rm -rf "$GITHUB_WORKSPACE/llvm-project"
+          mv "$OUT_DIR/llvm-project" "$GITHUB_WORKSPACE/llvm-project"
         fi
 
     - name: Fail on miss when build-on-miss=false

--- a/recipes/llvm-asan/build.sh
+++ b/recipes/llvm-asan/build.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
-# Builds an asan+ubsan-instrumented Clang/LLVM tree.
+# Builds an asan+ubsan-instrumented Clang/LLVM install tree.
+#
+# We publish a cmake --install tree (not a build tree). LLVMConfig.cmake
+# in an install tree uses _IMPORT_PREFIX-relative paths
+# (`set(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../..")`, generated
+# by cmake's install(EXPORT) — see
+# https://cmake.org/cmake/help/latest/command/install.html#export), so
+# the consumer can extract the asset under any path. Build trees bake
+# in absolute paths from configure-time and are not relocatable; that's
+# what package-manager LLVM avoids and what we copy.
 #
 # Inputs (env):
 #   RECIPE_VERSION         major LLVM version, e.g. 22
 #   WORK_DIR               scratch directory (clone + build live here)
-#   OUT_DIR                final tree is rsync'd here for tar/upload
+#   OUT_DIR                CMAKE_INSTALL_PREFIX is $OUT_DIR/llvm-project;
+#                          the install lands directly there for tar/upload.
 #   NCPUS                  parallelism (default: nproc)
 #   CMAKE_C_COMPILER_LAUNCHER, CMAKE_CXX_COMPILER_LAUNCHER
 #                          optional, e.g. "ccache" — passed through to cmake
@@ -46,6 +56,7 @@ cmake_extra=()
   cmake_extra+=( -DCMAKE_CXX_COMPILER="${CMAKE_CXX_COMPILER}" )
 
 cmake -G Ninja \
+  -DCMAKE_INSTALL_PREFIX="$OUT_DIR/llvm-project" \
   -DLLVM_ENABLE_PROJECTS="clang;compiler-rt" \
   -DLLVM_TARGETS_TO_BUILD="host;NVPTX" \
   -DCMAKE_BUILD_TYPE=Release \
@@ -79,7 +90,24 @@ cmake -G Ninja \
 # the ~30 min.
 if [[ "${RECIPE_QUICK_CHECK:-0}" == "1" ]]; then
   ninja -j "${NCPUS}" LLVMDemangle
-  echo "build.sh: RECIPE_QUICK_CHECK passed (cmake configure + LLVMDemangle)."
+  # Dry-run every install umbrella we depend on. ninja -n parses the
+  # build graph and exits non-zero on an unknown target, without doing
+  # any work — so an upstream LLVM rename of `install-clang-libraries`,
+  # `install-cmake-exports`, etc. fails this 5-second smoke instead of
+  # the ~30-min publish post-merge.
+  ninja -n \
+    install-clang \
+    install-clang-libraries \
+    install-clang-headers \
+    install-clang-cmake-exports \
+    install-clang-resource-headers \
+    install-clangInterpreter \
+    install-llvm-libraries \
+    install-llvm-headers \
+    install-cmake-exports \
+    install-llvm-config \
+    >/dev/null
+  echo "build.sh: RECIPE_QUICK_CHECK passed (cmake configure + LLVMDemangle + install-target dry-run)."
   exit 0
 fi
 
@@ -112,43 +140,38 @@ else
   echo "build.sh: no orc_rt targets matched; OOP-JIT runtime won't be in the artifact." >&2
 fi
 
-# Trim the tree before rsync — keeps Releases asset under the per-asset
-# 2 GB cap and matches what downstream consumers actually link against.
-#
-# What we keep:
-#   - top-level build/, llvm/, clang/ (the only dirs consumers reach into)
-#   - llvm/{include,lib,cmake} and clang/{include,lib,cmake} on the source side
-#   - build/lib/*.{a,so,dylib} (link targets)
-#   - build/lib/cmake/{llvm,clang}/ (find_package(LLVM)/find_package(Clang))
-#   - build/include/ (generated config + tablegen .inc headers)
-#   - build/tools/clang/include/ (clang's generated headers)
-#   - build/bin/ (FileCheck, llvm-config, etc. that downstream tests need)
-#
-# What we drop, beyond the obvious source-side trim:
-#   - build/**/CMakeFiles/   intermediate build state — every per-target
-#                            *.dir/ subdir under here holds .o, .d, and
-#                            cmake metadata. On asan builds these alone
-#                            are 1-2 GB because asan-instrumented .o
-#                            files are 3-5x the size of regular ones.
-#                            Consumers never need them; we don't do
-#                            incremental rebuilds (cache-or-rebuild model),
-#                            so cmake's incremental scaffolding is dead
-#                            weight in the artifact.
-#   - build/.ninja_deps      ninja's incremental dep graph. Hundreds of
-#     build/.ninja_log       MB on big builds; only useful for `ninja`
-#                            re-runs we never do.
-cd ..
+# Install the umbrella components consumers reach into. Each `install-X`
+# is a phony ninja target that copies one component group's headers,
+# libraries, cmake-exports, etc. into $CMAKE_INSTALL_PREFIX. Cherry-
+# picked rather than running plain `ninja install` so the asset doesn't
+# pull in LLVM tooling (opt, llc, llvm-dis, …) we never load. See
+# https://llvm.org/docs/BuildingADistribution.html for the umbrella
+# convention.
+INSTALL_TARGETS=(
+  install-clang
+  install-clang-libraries
+  install-clang-headers
+  install-clang-cmake-exports
+  install-clang-resource-headers
+  install-clangInterpreter
+  install-llvm-libraries
+  install-llvm-headers
+  install-cmake-exports
+  install-llvm-config
+)
+# install-orc_rt_<platform> targets mirror the OOP_TARGETS we just built.
+for tgt in ${OOP_TARGETS}; do
+  INSTALL_TARGETS+=("install-${tgt}")
+done
 
-shopt -s extglob
-rm -rf -- !(build|llvm|clang)
-( cd llvm  && rm -rf -- !(include|lib|cmake) )
-( cd clang && rm -rf -- !(include|lib|cmake) )
-( cd build && \
-  rm -f compile_commands.json build.ninja .ninja_deps .ninja_log
-  find . -name CMakeFiles -type d -prune -exec rm -rf {} + )
-shopt -u extglob
+ninja -j "${NCPUS}" "${INSTALL_TARGETS[@]}"
 
-rsync -a --delete \
-  "$WORK_DIR/llvm-project/" "$OUT_DIR/llvm-project/"
+# llvm-jitlink-executor's CMakeLists registers an install() rule but no
+# `install-llvm-jitlink-executor` umbrella target. Copy by hand into the
+# install bin/ so consumers that need the OOP executor find it next to
+# clang at $LLVM/bin/llvm-jitlink-executor.
+if [[ -x bin/llvm-jitlink-executor ]]; then
+  install -m 0755 bin/llvm-jitlink-executor "$OUT_DIR/llvm-project/bin/"
+fi
 
 echo "build.sh: done. SRC_COMMIT=${SRC_COMMIT}"


### PR DESCRIPTION
Build trees aren't relocatable: cmake bakes the configure-time absolute path into LLVMExports.cmake (`include(.../LLVMExports.cmake)`) and into IMPORTED-target locations. When the publisher's runner path doesn't match the consumer's, find_package(LLVM) fails with

  CMake Error at .../LLVMConfig.cmake:269 (include):
    include could not find requested file:
      <publisher's old workspace>/.../LLVMExports.cmake

— exactly what CppInterOp's asan row hit on its first non-publisher consumer.

Replace the manual extglob trim + rsync with `cmake --install`. Install trees use _IMPORT_PREFIX-relative paths (`set(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../..")`, generated by cmake's install(EXPORT)), so the asset extracts cleanly anywhere — same property package-manager LLVM has.

Cherry-pick the install-X umbrella targets that map to components consumers actually link against, rather than `ninja install`, so the asset doesn't drag in LLVM tooling (opt, llc, llvm-dis, …) no recipe consumer loads. See
https://llvm.org/docs/BuildingADistribution.html for the umbrella convention. llvm-jitlink-executor's CMakeLists registers an install() rule but no install-X umbrella; copy by hand.

Extend RECIPE_QUICK_CHECK to ninja-dry-run every install umbrella we depend on. `ninja -n` exits non-zero on an unknown target without doing any work, so an upstream rename of install-clang-libraries, install-cmake-exports, etc. now fails the ~3-min PR smoke instead of a ~30-min publish post-merge. Measured at <1 s on a configured tree.

setup-recipe inline-build path: WORK_DIR is now _recipe_work (distinct from the eventual workspace llvm-project location) so build.sh's clone target doesn't alias the move destination. `mv` replaces the rsync since install trees move cleanly.

Asset shape changes: lib/cmake/llvm replaces build/lib/cmake/llvm, and bin/ replaces build/bin/. CppInterOp's asan-row LLVM_DIR pin needs to follow in a separate PR; existing pins stay on 8819431 and keep loading the old build-tree asset until they bump.