### PR TITLE
[ci] Show release-page URL in publish-recipe upload notice.

### DIFF
--- a/actions/publish-recipe/action.yml
+++ b/actions/publish-recipe/action.yml
@@ -170,5 +170,19 @@ runs:
             --checkpoint=100000 --checkpoint-action=echo='%T tar checkpoint' \
           | zstd -19 --long -T0 > "${KEY}.tar.zst"
         ls -lh "${KEY}.tar.zst"
-        echo "::notice::uploading to $BASE"
+        # The notice URL: $BASE is the asset *prefix*
+        # (https://.../releases/download/cache/) which 404s when clicked
+        # because that exact path doesn't serve content. Show the
+        # release-page URL (.../releases/tag/cache) so a reviewer
+        # clicking the notice in the GHA log lands on the actual
+        # release. file:// backends fall through to the raw $BASE.
+        if [[ "$BASE" == https://github.com/*/releases/download/*/ ]]; then
+          parsed="$(gh_release_url_parse "$BASE")"
+          owner_repo="${parsed%$'\t'*}"
+          tag="${parsed#*$'\t'}"
+          release_url="https://github.com/${owner_repo}/releases/tag/${tag}"
+        else
+          release_url="$BASE"
+        fi
+        echo "::notice::uploading ${KEY} to ${release_url}"
         cache_upload "$BASE" "$KEY" "${KEY}.tar.zst" "${KEY}.manifest.json"


### PR DESCRIPTION
The "uploading to ${BASE}" notice was logging the asset *prefix* URL (https://.../releases/download/cache/) which 404s when clicked because that exact path doesn't serve content (it's a download-namespace prefix, not a viewable page). Reviewers who clicked the link from the GHA log saw a confusing 404 instead of the release.

Convert to the release-page form (.../releases/tag/cache) for the notice. Asset I/O continues to use the download URL — that part of the contract is correct. file:// backends fall through to the raw $BASE since they don't have a separate "viewable" form.