### PR TITLE
[ci] Default setup-recipe's build-on-miss to false.

### DIFF
--- a/actions/setup-recipe/action.yml
+++ b/actions/setup-recipe/action.yml
@@ -30,8 +30,13 @@ inputs:
       Must match what publish-recipe used.
   build-on-miss:
     required: false
-    default: 'true'
-    description: 'On cache miss, build the recipe inline. When false, fail with a copy-pasteable publish-recipe invocation.'
+    default: 'false'
+    description: |
+      On cache miss, build the recipe inline. Default is 'false':
+      consumers usually want a hard fail with a copy-pasteable
+      publish-recipe invocation, not a silent ~30-min inline rebuild
+      that doubles every PR run after a recipe-content change. Set
+      to 'true' for the producer-of-record row that warms the cell.
   cache-base:
     required: false
     default: ''


### PR DESCRIPTION
The previous default ('true') silently rebuilt the recipe inline on a cache miss — useful when you're bootstrapping a new cell, but the wrong default for steady state. Most consumers (CppInterOp's asan row, anything keying off a published cell) want fail-fast on miss with a copy-pasteable `gh workflow run publish-recipe.yml ...` hint, not a ~30-min inline rebuild that doubles every PR run after a recipe-content edit.

The producer-of-record row that warms the cell is the one place that genuinely wants 'true'; that row should opt in explicitly. Today no consumer uses the default — every caller passes the value explicitly — so flipping the default is a no-op for current behavior and a correctness improvement for callers that didn't realize they had to think about it.