### PR TITLE
[recipes] Add llvm-root recipe with cling-llvm20 / ROOT-llvm20 flavors.

### DIFF
--- a/cells.yaml
+++ b/cells.yaml
@@ -18,6 +18,7 @@
 # Major LLVM versions we currently support. Informational here;
 # package-catchup-probe will key off this list.
 support_window:
+  - 20
   - 22
 
 caps:
@@ -30,4 +31,18 @@ caps:
   grace_days: 7
 
 cells:
-  - { recipe: llvm-asan, version: '22', os: ubuntu-24.04, arch: x86_64 }
+  - { recipe: llvm-asan, version: '22',            os: ubuntu-24.04,    arch: x86_64 }
+  # llvm-root: `version` doubles as a flavor selector and substitutes
+  # into recipes/llvm-root/recipe.yaml's branch_template. Two flavors
+  # track root-project/llvm-project's paired branches:
+  #   cling-llvm20 = cling's patches alone (CppInterOp's cppyy/cling row).
+  #                  Linux-only today; macOS / Windows cling rows still
+  #                  share the ROOT-llvm20 superset to keep one cell warm.
+  #   ROOT-llvm20  = cling + ROOT's extra clang patches. Built across
+  #                  the full CppInterOp matrix so every cling-using
+  #                  consumer has a ready cell.
+  - { recipe: llvm-root, version: 'cling-llvm20',  os: ubuntu-24.04,    arch: x86_64 }
+  - { recipe: llvm-root, version: 'ROOT-llvm20',   os: ubuntu-24.04,    arch: x86_64 }
+  - { recipe: llvm-root, version: 'ROOT-llvm20',   os: macos-26,        arch: arm64  }
+  - { recipe: llvm-root, version: 'ROOT-llvm20',   os: macos-26-intel,  arch: x86_64 }
+  - { recipe: llvm-root, version: 'ROOT-llvm20',   os: windows-2025,    arch: x86_64 }

--- a/recipes/llvm-root/build.sh
+++ b/recipes/llvm-root/build.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Builds an LLVM/Clang install tree with cling integrated as an
+# LLVM_EXTERNAL_PROJECT. Source repos and branches are read from
+# recipe.yaml so a tag bump there is the single point of edit.
+#
+# We publish a cmake --install tree (not a build tree). LLVMConfig.cmake
+# in an install tree uses _IMPORT_PREFIX-relative paths so the consumer
+# can extract the asset under any path; build trees bake in absolute
+# paths from configure-time and are not relocatable. See the
+# llvm-asan recipe for the pattern this is modelled on.
+#
+# Inputs (env):
+#   RECIPE_VERSION         flavor selector. Substitutes into
+#                          recipe.yaml's source.branch_template
+#                          ({version} → branch). Today this is one of
+#                          'cling-llvm20' (minimal cling patches) or
+#                          'ROOT-llvm20' (ROOT superset). Factored
+#                          into the cache key, so each flavor has its
+#                          own asset.
+#   WORK_DIR               scratch directory (clones + build live here)
+#   OUT_DIR                CMAKE_INSTALL_PREFIX is $OUT_DIR/llvm-project
+#   NCPUS                  parallelism (default: nproc)
+#   CMAKE_C_COMPILER_LAUNCHER, CMAKE_CXX_COMPILER_LAUNCHER
+#                          optional; passed through to cmake (ccache).
+#
+# Outputs (env, written to GITHUB_ENV when present):
+#   SRC_COMMIT             sha of llvm-project HEAD that was built
+set -euo pipefail
+
+: "${RECIPE_VERSION:?RECIPE_VERSION must be set}"
+: "${WORK_DIR:?WORK_DIR must be set}"
+: "${OUT_DIR:?OUT_DIR must be set}"
+NCPUS="${NCPUS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)}"
+
+RECIPE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+# Pull source coordinates from recipe.yaml. Mirrors build-manifest.sh's
+# grep approach — keeps the recipe.yaml content the single source of
+# truth without dragging a YAML parser into the script.
+LLVM_REPO=$(grep -E '^\s*repo:' "$RECIPE_DIR/recipe.yaml" | sed -n '1p' | sed -E 's/.*repo:[[:space:]]*//' | tr -d '"')
+LLVM_BRANCH_TPL=$(grep -E '^\s*branch_template:' "$RECIPE_DIR/recipe.yaml" | head -1 | sed -E 's/.*branch_template:[[:space:]]*//' | tr -d "'\"")
+CLING_REPO=$(grep -E '^\s*repo:' "$RECIPE_DIR/recipe.yaml" | sed -n '2p' | sed -E 's/.*repo:[[:space:]]*//' | tr -d '"')
+CLING_BRANCH=$(grep -E '^\s*branch:' "$RECIPE_DIR/recipe.yaml" | head -1 | sed -E 's/.*branch:[[:space:]]*//' | tr -d '"')
+
+[[ -n "$LLVM_REPO"       ]] || { echo "build.sh: source.repo missing in recipe.yaml" >&2; exit 1; }
+[[ -n "$LLVM_BRANCH_TPL" ]] || { echo "build.sh: source.branch_template missing in recipe.yaml" >&2; exit 1; }
+[[ -n "$CLING_REPO"      ]] || { echo "build.sh: cling.repo missing in recipe.yaml" >&2; exit 1; }
+[[ -n "$CLING_BRANCH"    ]] || { echo "build.sh: cling.branch missing in recipe.yaml" >&2; exit 1; }
+
+# {version} → flavor name. Same substitution build-manifest.sh does.
+LLVM_BRANCH="${LLVM_BRANCH_TPL//\{version\}/$RECIPE_VERSION}"
+echo "build.sh: flavor=${RECIPE_VERSION}; cloning ${LLVM_REPO}@${LLVM_BRANCH}"
+
+mkdir -p "$WORK_DIR" "$OUT_DIR"
+cd "$WORK_DIR"
+
+if [[ ! -d cling/.git ]]; then
+  git clone --depth=1 -b "$CLING_BRANCH" "$CLING_REPO" cling
+fi
+if [[ ! -d llvm-project/.git ]]; then
+  git clone --depth=1 -b "$LLVM_BRANCH" "$LLVM_REPO" llvm-project
+fi
+
+cd llvm-project
+SRC_COMMIT="$(git rev-parse HEAD)"
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  echo "SRC_COMMIT=${SRC_COMMIT}" >> "$GITHUB_ENV"
+fi
+
+mkdir -p build
+cd build
+
+cmake_extra=()
+[[ -n "${CMAKE_C_COMPILER_LAUNCHER:-}" ]] && \
+  cmake_extra+=( -DCMAKE_C_COMPILER_LAUNCHER="${CMAKE_C_COMPILER_LAUNCHER}" )
+[[ -n "${CMAKE_CXX_COMPILER_LAUNCHER:-}" ]] && \
+  cmake_extra+=( -DCMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CXX_COMPILER_LAUNCHER}" )
+[[ -n "${CMAKE_C_COMPILER:-}" ]] && \
+  cmake_extra+=( -DCMAKE_C_COMPILER="${CMAKE_C_COMPILER}" )
+[[ -n "${CMAKE_CXX_COMPILER:-}" ]] && \
+  cmake_extra+=( -DCMAKE_CXX_COMPILER="${CMAKE_CXX_COMPILER}" )
+
+# LLVM_EXTERNAL_PROJECTS=cling pulls cling's CMakeLists into the same
+# build tree. cling's libraries (clingInterpreter, clingMetaProcessor,
+# clingUtils) get added to LLVM's install machinery and become
+# install-X umbrella targets like any in-tree clang library.
+cmake -G Ninja \
+  -DCMAKE_INSTALL_PREFIX="$OUT_DIR/llvm-project" \
+  -DLLVM_ENABLE_PROJECTS="clang" \
+  -DLLVM_EXTERNAL_PROJECTS=cling \
+  -DLLVM_EXTERNAL_CLING_SOURCE_DIR="$WORK_DIR/cling" \
+  -DLLVM_TARGETS_TO_BUILD="host;NVPTX" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DCLANG_ENABLE_STATIC_ANALYZER=OFF \
+  -DCLANG_ENABLE_ARCMT=OFF \
+  -DCLANG_ENABLE_FORMAT=OFF \
+  -DCLANG_ENABLE_BOOTSTRAP=OFF \
+  -DLLVM_INCLUDE_BENCHMARKS=OFF \
+  -DLLVM_INCLUDE_EXAMPLES=OFF \
+  -DLLVM_INCLUDE_TESTS=OFF \
+  "${cmake_extra[@]}" \
+  ../llvm
+
+if [[ "${RECIPE_QUICK_CHECK:-0}" == "1" ]]; then
+  ninja -j "${NCPUS}" LLVMDemangle
+  echo "build.sh: RECIPE_QUICK_CHECK passed (cmake configure + LLVMDemangle)."
+  exit 0
+fi
+
+# Build the clang driver, the clang-repl Interpreter library
+# (downstream ROOT consumes it via libclangInterpreter.a even though
+# clang-the-binary doesn't depend on it transitively), the
+# StaticAnalyzerCore library (cling-bundled clang dragged it into
+# CppInterOp's link in the past), LLVMOrcDebugging (cling pulls it
+# in via LIBS in current cling tip), and the cling library itself
+# (clingInterpreter; the `cling` binary follows transitively).
+ninja -j "${NCPUS}" clang clangInterpreter clangStaticAnalyzerCore \
+                    LLVMOrcDebugging clingInterpreter
+
+# Free disk before the install phase. Same reasoning as llvm-asan:
+# ccache has captured every compile by this point, so deleting *.o
+# doesn't lose any cache state, and the install phase only copies
+# .a / binaries / headers / cmake-exports.
+echo "build.sh: pre-install disk: $(df -h . | tail -1)"
+echo "build.sh: dropping intermediate .o files"
+find . -name '*.o' -delete
+echo "build.sh: post-cleanup disk: $(df -h . | tail -1)"
+
+# Drive the install through LLVM_DISTRIBUTION_COMPONENTS so the
+# generated LLVMExports.cmake only references libraries we actually
+# shipped. Same pattern as llvm-asan; see that recipe's build.sh and
+# https://llvm.org/docs/BuildingADistribution.html for the rationale.
+declare -a DIST_COMPONENTS=(
+  clang
+  clang-headers
+  clang-cmake-exports
+  clang-resource-headers
+  clangInterpreter
+  cmake-exports
+  llvm-headers
+  llvm-config
+  cling
+  clingInterpreter
+)
+for f in lib/libclang*.a lib/libLLVM*.a lib/libcling*.a; do
+  [[ -f "$f" ]] || continue
+  DIST_COMPONENTS+=("$(basename "$f" | sed 's/^lib//; s/\.a$//')")
+done
+
+DIST_STR=$(IFS=';'; echo "${DIST_COMPONENTS[*]}")
+echo "build.sh: LLVM_DISTRIBUTION_COMPONENTS=${DIST_STR}"
+cmake -DLLVM_DISTRIBUTION_COMPONENTS="${DIST_STR}" .
+
+ninja -j "${NCPUS}" install-distribution
+
+# Producer-side smoke: find_package(LLVM)+(Clang) from a throwaway
+# cmake project against the install tree. Catches any missing-.a-in-
+# exports inconsistency before the asset is tar'd. Cling does not
+# ship a ClingConfig.cmake (cling is consumed via header includes +
+# direct linkage against libclingInterpreter.a, not find_package), so
+# we don't add it to the smoke. ~5 s.
+SMOKE_DIR="$(mktemp -d)"
+trap 'rm -rf "$SMOKE_DIR"' EXIT
+cat > "$SMOKE_DIR/CMakeLists.txt" <<'EOF'
+cmake_minimum_required(VERSION 3.20)
+project(install_tree_smoke LANGUAGES CXX)
+find_package(LLVM REQUIRED CONFIG PATHS "${SMOKE_LLVM_PREFIX}/lib/cmake/llvm" NO_DEFAULT_PATH)
+find_package(Clang REQUIRED CONFIG PATHS "${SMOKE_LLVM_PREFIX}/lib/cmake/clang" NO_DEFAULT_PATH)
+message(STATUS "smoke: LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH} loaded from ${LLVM_DIR}")
+# Spot-check that libclingInterpreter.a actually shipped — find_package(LLVM)
+# alone doesn't validate cling-specific files since cling has no Config.cmake.
+if(NOT EXISTS "${SMOKE_LLVM_PREFIX}/lib/libclingInterpreter.a")
+  message(FATAL_ERROR "smoke: libclingInterpreter.a missing from install tree")
+endif()
+EOF
+echo "build.sh: smoke-testing install tree (find_package LLVM + Clang + cling lib)"
+cmake -S "$SMOKE_DIR" -B "$SMOKE_DIR/build" \
+  -DSMOKE_LLVM_PREFIX="$OUT_DIR/llvm-project" \
+  >"$SMOKE_DIR/log" 2>&1 || {
+  echo "::error::install tree failed find_package smoke. Exports likely reference missing files."
+  tail -50 "$SMOKE_DIR/log" >&2
+  exit 1
+}
+echo "build.sh: smoke passed."
+
+echo "build.sh: done. SRC_COMMIT=${SRC_COMMIT}"

--- a/recipes/llvm-root/recipe.yaml
+++ b/recipes/llvm-root/recipe.yaml
@@ -1,0 +1,26 @@
+recipe: llvm-root
+description: |
+  LLVM/Clang built with cling integrated as an LLVM_EXTERNAL_PROJECT,
+  against root-project/llvm-project's cling-llvm20 (cling's patches
+  alone) or ROOT-llvm20 (cling's patches + ROOT's extra clang patches)
+  branches. Consumed via setup-recipe by:
+    - CppInterOp's cppyy/cling rows (need cling-llvm20),
+    - CppInterOp's ROOT integration job (needs ROOT-llvm20).
+  Each flavor maps to a `version` value below; the cache key partitions
+  on it, so the same recipe directory ships two distinct artifacts.
+
+# `version` doubles as the flavor selector here — each value maps to a
+# branch on root-project/llvm-project under the same date-stamped
+# ladder (currently 20260408-01). When ROOT or cling cuts a new patch
+# set, edit the date stamp here; the cache key moves and the new
+# asset republishes for both flavors.
+source:
+  repo: https://github.com/root-project/llvm-project
+  branch_template: '{version}-20260408-01'
+
+# cling lives in its own repo and is pulled in at cmake time via
+# LLVM_EXTERNAL_PROJECTS. Bumping the cling tag is a recipe edit:
+# changes recipe.yaml, moves the cache key, republishes.
+cling:
+  repo: https://github.com/root-project/cling
+  branch: v1.3


### PR DESCRIPTION
Two CppInterOp matrix paths currently rely on a hand-maintained GHA Actions-cache slot pairing root-project/llvm-project@<tag> with root-project/cling@v1.3:

  - cppyy/cling row in main.yml (needs cling's patches alone)
  - ROOT integration row in root.yml (needs cling's patches plus ROOT's extra clang patches; today shares the cppyy row's slot keyed off the ROOT-llvm20 superset)

The Actions-cache slot isn't reachable from bin/dev-shell, so a ROOT-side bug is push-and-wait to reproduce. Migrating to a recipe publishes the same artifact on Releases, where bin/dev-shell can fetch it for a local container repro.

Pattern is the llvm-asan recipe with three deltas:

  1. `version` doubles as the flavor selector. recipe.yaml's branch_template is `{version}-20260408-01`; setting RECIPE_VERSION to either `cling-llvm20` or `ROOT-llvm20` selects the corresponding patch set on root-project/llvm-project. compute-key.sh hashes version, so each flavor gets its own asset under one recipe directory.

  2. cling enters via LLVM_EXTERNAL_PROJECTS=cling + LLVM_EXTERNAL_CLING_SOURCE_DIR pointing at a sibling clone of root-project/cling@v1.3. cling's libraries get added to LLVM's install machinery as install-X umbrellas; the dynamic LLVM_DISTRIBUTION_COMPONENTS enumeration walks lib/libcling*.a alongside libclang*.a and libLLVM*.a so they ride the same scoped-exports path.

  3. ninja line: clang, clangInterpreter, clangStaticAnalyzerCore, LLVMOrcDebugging, clingInterpreter — the same set Build_LLVM ninjas for cling rows. No OOP-JIT runtime (this recipe targets LLVM 20; OOP lands at LLVM 22+).

Cling has no ClingConfig.cmake, so the producer-side smoke covers find_package(LLVM)+(Clang) plus a cheap `EXISTS libclingInterpreter.a` assertion to catch a missing-cling-lib regression before upload.

Cell partition (cells.yaml):

  - cling-llvm20: ubuntu-24.04 / x86_64 only. The non-Linux cling rows in CppInterOp share the ROOT-llvm20 superset already (one warm cell instead of two), so a separate cling-only build for them isn't needed.
  - ROOT-llvm20: ubuntu-24.04, macos-26 (arm64), macos-26-intel (x86_64), windows-2025 — the full cling-row platform set in CppInterOp's main.yml.

Source coordinates are read out of recipe.yaml via the same grep approach build-manifest.sh already uses, so bumping a tag is purely a recipe.yaml edit and moves the cache key in the expected way. support_window in cells.yaml widens to include 20 alongside 22.

Risk: macOS and Windows publishes are unverified. The existing recipe pipeline ran only on Linux; first-publish on those runners may surface install-build-deps gaps (Xcode CLT differences, clang-cl on Windows, missing rsync) or build.sh portability issues (GNU vs BSD sed, cmake generator selection). Tracked as a follow-up if the publish-recipe push run on either platform fails.

See also https://llvm.org/docs/BuildingADistribution.html and llvm/cmake/modules/LLVMDistributionSupport.cmake for the LLVM_DISTRIBUTION_COMPONENTS scoping mechanism inherited from the llvm-asan recipe.