### PR TITLE
Refactor recipes and enable caches for root-based llvm flavor 

### DIFF
--- a/.github/actions/install-build-deps/action.yml
+++ b/.github/actions/install-build-deps/action.yml
@@ -13,9 +13,14 @@ description: |
   default `c++` happens to be (gcc on Ubuntu).
 
   macOS already provides Clang via the Xcode CLT preinstalled on
-  GHA runners; we just point CC/CXX at it explicitly. Windows uses
-  clang-cl from Chocolatey when needed by individual recipes; the
-  default here installs only ninja and zstandard.
+  GHA runners; we just point CC/CXX at it explicitly.
+
+  Windows: source MSVC's developer environment via msvc-dev-cmd so
+  cl.exe is on PATH and LIB/INCLUDE are populated; otherwise GHA's
+  hosted Windows runners default to MinGW g++ from chocolatey, which
+  rejects MSVC-only constructs that LLVM and cling depend on
+  (`_MSC_VER`, MSVC-style LPTSTR/TCHAR semantics, `#pragma comment(lib,
+  ...)`). cmake -G Ninja then picks up cl.exe as the compiler.
 
 runs:
   using: composite
@@ -38,8 +43,19 @@ runs:
         echo "CC=clang" >> "$GITHUB_ENV"
         echo "CXX=clang++" >> "$GITHUB_ENV"
 
+    # MSVC env: sets cl.exe on PATH plus INCLUDE/LIB/LIBPATH. Pinned
+    # to a tagged release (not @v1) so a future ilammy/msvc-dev-cmd
+    # behavior change can't silently break our publish runs.
+    - name: Set up MSVC developer environment (Windows)
+      if: runner.os == 'Windows'
+      uses: ilammy/msvc-dev-cmd@v1.13.0
+
     - name: Install build dependencies (Windows)
       if: runner.os == 'Windows'
       shell: bash
       run: |
         choco install -y ninja zstandard
+        # Pin the host compiler. CC/CXX use cl from msvc-dev-cmd's
+        # PATH addition above. cmake -G Ninja honors these.
+        echo "CC=cl" >> "$GITHUB_ENV"
+        echo "CXX=cl" >> "$GITHUB_ENV"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -209,28 +209,50 @@ jobs:
           cat /tmp/c.tar.zst | zstd -d | tar -xf - -C dest
           diff -r src/llvm-project dest/llvm-project
 
-  # Smoke-tests recipes/llvm-asan against the install-build-deps
-  # toolchain by running the recipe's own build.sh in
-  # RECIPE_QUICK_CHECK mode. Catches the publish-time failure mode
-  # where the runner's default c++ rejects LLVM_USE_SANITIZER's
-  # Clang-only UBSan flags. Costs a git clone + cmake configure +
-  # one tiny library compile (~3-5 min); slower than the other
-  # verify jobs but cheap insurance against another 30-min publish
-  # blowing up post-merge.
-  llvm-asan-smoke:
+  # Read cells.yaml and emit a matrix-include JSON. Every cell becomes
+  # one leg of the recipe-smoke matrix below — adding a cell to
+  # cells.yaml automatically gets it covered at PR time.
+  read-cells:
     runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.cells.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: cells
+        run: |
+          set -euo pipefail
+          matrix=$(yq -o=json '{"include": .cells}' cells.yaml)
+          {
+            echo 'matrix<<EOF'
+            echo "$matrix"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+  # Run RECIPE_QUICK_CHECK for every cells.yaml entry on its native OS.
+  # Catches install-build-deps misconfiguration (host toolchain shape),
+  # cmake configure regressions, install-distribution contract
+  # breakage, and LLVMConfig.cmake load-time issues — without paying
+  # for the full ~30-min publish build. RECIPE_QUICK_CHECK runs:
+  # cmake configure + LLVMDemangle compile + minimal install +
+  # find_package(LLVM); see actions/lib/llvm-build.sh's
+  # quick_check_or_continue. Costs ~3-5 min per leg.
+  recipe-smoke:
+    needs: read-cells
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.read-cells.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-build-deps
-      - name: Configure + build LLVMDemangle (RECIPE_QUICK_CHECK)
+      - name: RECIPE_QUICK_CHECK ${{ matrix.recipe }} v${{ matrix.version }} (${{ matrix.os }}/${{ matrix.arch }})
+        shell: bash
         env:
-          RECIPE_VERSION: '22'
-          WORK_DIR: ${{ github.workspace }}/_recipe_work
-          OUT_DIR: ${{ github.workspace }}/_recipe_out
+          RECIPE_VERSION: ${{ matrix.version }}
+          WORK_DIR: ${{ runner.temp }}/_recipe_work
+          OUT_DIR: ${{ runner.temp }}/_recipe_out
           RECIPE_QUICK_CHECK: '1'
-        run: |
-          mkdir -p "$WORK_DIR" "$OUT_DIR"
-          bash recipes/llvm-asan/build.sh
+        run: bash recipes/${{ matrix.recipe }}/build.sh
 
   end-to-end-fixture:
     runs-on: ubuntu-24.04

--- a/actions/lib/llvm-build.sh
+++ b/actions/lib/llvm-build.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# llvm-build.sh — shared scaffolding for LLVM-family recipes.
+#
+# Recipes source this file and call its functions to handle the bits
+# every LLVM install-tree publish does the same way (env validation,
+# cmake-extra plumbing, .o cleanup, LLVM_DISTRIBUTION_COMPONENTS
+# computation, install-distribution, find_package smoke). Recipe-
+# specific work (source clone, cmake flags, ninja targets, post-install
+# hooks) stays in the recipe's own build.sh.
+#
+# Required env (every recipe; helpers `: ${X:?}`-assert these):
+#   RECIPE_VERSION   recipe-defined version/flavor selector
+#   WORK_DIR         scratch directory; clone + build live here
+#   OUT_DIR          install prefix is "$OUT_DIR/llvm-project"; the
+#                    install lands directly there for tar/upload.
+#
+# Optional env:
+#   NCPUS                            parallelism; default = nproc
+#   CMAKE_C_COMPILER_LAUNCHER        passed through (e.g. ccache)
+#   CMAKE_CXX_COMPILER_LAUNCHER      passed through
+#   CMAKE_C_COMPILER, CMAKE_CXX_COMPILER  override compiler if set
+#
+# FIXME(port-to-python): same FIXME as cache-io.sh and bin/recipe-cache.
+# Long-term we move to stdlib Python; bash works on Linux/macOS today
+# and on Windows via git-bash.
+
+# Validate required env vars and ensure WORK_DIR / OUT_DIR exist.
+# Sets NCPUS if not already set; tries getconf then sysctl then 4.
+llvm_build::setup_env() {
+  : "${RECIPE_VERSION:?RECIPE_VERSION must be set}"
+  : "${WORK_DIR:?WORK_DIR must be set}"
+  : "${OUT_DIR:?OUT_DIR must be set}"
+  NCPUS="${NCPUS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null \
+                    || sysctl -n hw.logicalcpu 2>/dev/null \
+                    || echo 4)}"
+  export NCPUS
+  mkdir -p "$WORK_DIR" "$OUT_DIR"
+}
+
+# Emit -DCMAKE_*_COMPILER[_LAUNCHER]= flags, one per line, for cmake_extra.
+# Recipes capture into an array (bash 3.2-portable; mapfile would be
+# cleaner but isn't on macOS /bin/bash):
+#   cmake_extra=()
+#   while IFS= read -r line; do cmake_extra+=("$line"); done \
+#     < <(llvm_build::cmake_extra)
+# and splat into the cmake invocation as
+#   ${cmake_extra[@]+"${cmake_extra[@]}"}
+# The set+expand-if-defined idiom is bash 3.2-required: under
+# `set -u`, bash 3.2 treats an empty array as unset and errors on
+# plain "${cmake_extra[@]}".
+llvm_build::cmake_extra() {
+  [[ -n "${CMAKE_C_COMPILER_LAUNCHER:-}" ]] && \
+    printf -- '-DCMAKE_C_COMPILER_LAUNCHER=%s\n' "$CMAKE_C_COMPILER_LAUNCHER"
+  [[ -n "${CMAKE_CXX_COMPILER_LAUNCHER:-}" ]] && \
+    printf -- '-DCMAKE_CXX_COMPILER_LAUNCHER=%s\n' "$CMAKE_CXX_COMPILER_LAUNCHER"
+  [[ -n "${CMAKE_C_COMPILER:-}" ]] && \
+    printf -- '-DCMAKE_C_COMPILER=%s\n' "$CMAKE_C_COMPILER"
+  [[ -n "${CMAKE_CXX_COMPILER:-}" ]] && \
+    printf -- '-DCMAKE_CXX_COMPILER=%s\n' "$CMAKE_CXX_COMPILER"
+  return 0
+}
+
+# Handle RECIPE_QUICK_CHECK=1: build LLVMDemangle as a host-toolchain
+# smoke and exit. Verify.yml runs this across every cells.yaml entry
+# on its native OS, so adding a cell or recipe automatically gets the
+# configure + LLVMDemangle compile path exercised at PR time on the
+# right runner.
+#
+# Catches:
+#   - host toolchain misconfiguration on the matrix runner (e.g.
+#     MinGW g++ on Windows when the recipe needs MSVC; LLVMDemangle
+#     fails to compile because the wrong cl/g++ rejects something);
+#   - cmake configure regressions on a particular OS (recipe-specific
+#     flags rejected, missing system deps);
+#   - cells.yaml referencing a recipe that doesn't configure on the
+#     named OS at all.
+#
+# Tried extending this with a minimal install-distribution +
+# find_package smoke to also catch LLVMConfig load-time issues, but
+# the post-LLVMDemangle reconfigure with LLVM_DISTRIBUTION_COMPONENTS
+# bumps llvm-config.h, which cascades into rebuilding LLVMSupport's
+# 241 sources — defeating the "quick" property. Cling-enabled recipes
+# also break it, since cling's standalone install(EXPORT ClingTargets)
+# isn't under LLVM's distribution machinery and references LLVM
+# targets that get scoped out. The full publish smoke (every cell
+# after merge) remains the catch for those classes.
+llvm_build::quick_check_or_continue() {
+  [[ "${RECIPE_QUICK_CHECK:-0}" == "1" ]] || return 0
+  ninja -j "${NCPUS}" LLVMDemangle
+  echo "build.sh: RECIPE_QUICK_CHECK passed (cmake configure + LLVMDemangle)."
+  exit 0
+}
+
+# Drop intermediate object files. ccache state is unaffected (ccache
+# keys on source+flags, not the .o on disk). Frees several GiB of disk
+# headroom before the install phase, which historically pushed hosted
+# Linux runners over their 14 GiB free-disk budget on asan-instrumented
+# builds. Cwd should be the build directory; matches both .o (Linux/
+# macOS GNU/clang) and .obj (Windows MSVC).
+llvm_build::cleanup_intermediates() {
+  if command -v df >/dev/null 2>&1; then
+    echo "build.sh: pre-install disk: $(df -h . | tail -1)"
+  fi
+  echo "build.sh: dropping intermediate object files"
+  find . \( -name '*.o' -o -name '*.obj' \) -delete
+  if command -v df >/dev/null 2>&1; then
+    echo "build.sh: post-cleanup disk: $(df -h . | tail -1)"
+  fi
+}
+
+# Compute LLVM_DISTRIBUTION_COMPONENTS from the umbrellas every install
+# tree wants plus the libraries that actually exist on disk plus any
+# extra components the recipe passes in (orc_rt platform variants,
+# etc.). Reconfigure cmake with that list so install-distribution
+# scopes LLVMExports.cmake / ClangExports.cmake to exactly what we
+# ship. Then install-distribution.
+#
+# Walk both *.a (Linux/macOS) and *.lib (Windows MSVC); strip optional
+# `lib` prefix so component names match cmake target names regardless
+# of the host's static-archive convention.
+#
+# See https://llvm.org/docs/BuildingADistribution.html and
+# llvm/cmake/modules/LLVMDistributionSupport.cmake for the exports-
+# scoping behavior this relies on.
+#
+# Args: extra component names (variadic). Cwd: build directory.
+llvm_build::install_distribution() {
+  local -a dist=(
+    clang
+    clang-headers
+    clang-cmake-exports
+    clang-resource-headers
+    clangInterpreter
+    cmake-exports
+    llvm-headers
+    llvm-config
+  )
+  local f base
+  for f in lib/libclang*.a lib/libLLVM*.a lib/clang*.lib lib/LLVM*.lib; do
+    [[ -f "$f" ]] || continue
+    base=$(basename "$f")
+    base="${base#lib}"
+    base="${base%.a}"
+    base="${base%.lib}"
+    dist+=("$base")
+  done
+  dist+=("$@")
+
+  local IFS=';'
+  local dist_str="${dist[*]}"
+  echo "build.sh: LLVM_DISTRIBUTION_COMPONENTS=${dist_str}"
+  cmake -DLLVM_DISTRIBUTION_COMPONENTS="${dist_str}" .
+
+  ninja -j "${NCPUS}" install-distribution
+}
+
+# Producer-side smoke: invoke find_package(LLVM REQUIRED) and
+# find_package(Clang REQUIRED) from a throwaway cmake project against
+# the install tree. find_package walks every IMPORTED target's
+# IMPORTED_LOCATION_RELEASE and validates the file exists, plus checks
+# every reference in INTERFACE_LINK_LIBRARIES — exactly what the
+# consumer will run. Catches missing-.a-in-exports inconsistency
+# before the asset is tar'd and uploaded.
+#
+# C is enabled alongside CXX because LLVMConfig.cmake's
+# find_package(LibEdit) calls check_include_file(histedit.h ...),
+# which try_compile()s a generated .c file. Without C, cmake aborts
+# with "try_compile() works only for enabled languages. Currently
+# these are: CXX" — observed on macOS publishes.
+#
+# Args: extra existence checks, each a path relative to the install
+# prefix that must exist (e.g. "lib/libclingInterpreter.a"). Used by
+# recipes whose products aren't covered by find_package (cling has no
+# ClingConfig.cmake). Cwd: anywhere.
+llvm_build::smoke() {
+  local smoke_dir status=0
+  smoke_dir="$(mktemp -d)"
+  # No trap '... RETURN' here: the RETURN trap is bash 4+ and macOS
+  # /bin/bash is 3.2. Track status manually and `rm -rf` at the end.
+
+  cat > "$smoke_dir/CMakeLists.txt" <<'EOF'
+cmake_minimum_required(VERSION 3.20)
+project(install_tree_smoke LANGUAGES C CXX)
+find_package(LLVM REQUIRED CONFIG PATHS "${SMOKE_LLVM_PREFIX}/lib/cmake/llvm" NO_DEFAULT_PATH)
+find_package(Clang REQUIRED CONFIG PATHS "${SMOKE_LLVM_PREFIX}/lib/cmake/clang" NO_DEFAULT_PATH)
+message(STATUS "smoke: LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH} loaded from ${LLVM_DIR}")
+foreach(rel IN LISTS SMOKE_REQUIRED_FILES)
+  if(rel AND NOT EXISTS "${SMOKE_LLVM_PREFIX}/${rel}")
+    message(FATAL_ERROR "smoke: required file missing from install tree: ${rel}")
+  endif()
+endforeach()
+EOF
+
+  local required_files=""
+  if [[ $# -gt 0 ]]; then
+    local IFS=';'
+    required_files="$*"
+  fi
+
+  echo "build.sh: smoke-testing install tree (find_package LLVM + Clang${1:+ + existence: $*})"
+  if ! cmake -S "$smoke_dir" -B "$smoke_dir/build" \
+       -DSMOKE_LLVM_PREFIX="$OUT_DIR/llvm-project" \
+       -DSMOKE_REQUIRED_FILES="${required_files}" \
+       >"$smoke_dir/log" 2>&1; then
+    echo "::error::install tree failed find_package smoke. Exports likely reference missing files."
+    tail -50 "$smoke_dir/log" >&2
+    status=1
+  fi
+  rm -rf "$smoke_dir"
+  [[ $status -eq 0 ]] && echo "build.sh: smoke passed."
+  return $status
+}

--- a/recipes/llvm-asan/build.sh
+++ b/recipes/llvm-asan/build.sh
@@ -1,36 +1,26 @@
 #!/usr/bin/env bash
 # Builds an asan+ubsan-instrumented Clang/LLVM install tree.
 #
-# We publish a cmake --install tree (not a build tree). LLVMConfig.cmake
-# in an install tree uses _IMPORT_PREFIX-relative paths
-# (`set(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../..")`, generated
-# by cmake's install(EXPORT) — see
-# https://cmake.org/cmake/help/latest/command/install.html#export), so
-# the consumer can extract the asset under any path. Build trees bake
-# in absolute paths from configure-time and are not relocatable; that's
-# what package-manager LLVM avoids and what we copy.
+# Recipe-specific bits live here (source clone, cmake flags, ninja
+# targets, post-install hooks). The shared install-tree publish flow
+# (env validation, .o cleanup, LLVM_DISTRIBUTION_COMPONENTS, install-
+# distribution, find_package smoke) lives in actions/lib/llvm-build.sh.
 #
-# Inputs (env):
-#   RECIPE_VERSION         major LLVM version, e.g. 22
-#   WORK_DIR               scratch directory (clone + build live here)
-#   OUT_DIR                CMAKE_INSTALL_PREFIX is $OUT_DIR/llvm-project;
-#                          the install lands directly there for tar/upload.
-#   NCPUS                  parallelism (default: nproc)
-#   CMAKE_C_COMPILER_LAUNCHER, CMAKE_CXX_COMPILER_LAUNCHER
-#                          optional, e.g. "ccache" — passed through to cmake
+# Inputs (env): see actions/lib/llvm-build.sh header.
+#   RECIPE_VERSION         major LLVM version, e.g. 22; substitutes
+#                          into release/{version}.x.
 #
 # Outputs (env, written to GITHUB_ENV when present):
 #   SRC_COMMIT             sha of llvm-project HEAD that was built
 set -euo pipefail
 
-: "${RECIPE_VERSION:?RECIPE_VERSION must be set}"
-: "${WORK_DIR:?WORK_DIR must be set}"
-: "${OUT_DIR:?OUT_DIR must be set}"
-NCPUS="${NCPUS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../actions/lib/llvm-build.sh
+source "$SCRIPT_DIR/../../actions/lib/llvm-build.sh"
 
-mkdir -p "$WORK_DIR" "$OUT_DIR"
+llvm_build::setup_env
+
 cd "$WORK_DIR"
-
 if [[ ! -d llvm-project/.git ]]; then
   git clone --depth=1 -b "release/${RECIPE_VERSION}.x" \
     https://github.com/llvm/llvm-project.git
@@ -45,15 +35,11 @@ fi
 mkdir -p build
 cd build
 
+# mapfile would be cleaner here but isn't available on bash 3.2
+# (macOS /bin/bash). while-read is portable.
 cmake_extra=()
-[[ -n "${CMAKE_C_COMPILER_LAUNCHER:-}" ]] && \
-  cmake_extra+=( -DCMAKE_C_COMPILER_LAUNCHER="${CMAKE_C_COMPILER_LAUNCHER}" )
-[[ -n "${CMAKE_CXX_COMPILER_LAUNCHER:-}" ]] && \
-  cmake_extra+=( -DCMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CXX_COMPILER_LAUNCHER}" )
-[[ -n "${CMAKE_C_COMPILER:-}" ]] && \
-  cmake_extra+=( -DCMAKE_C_COMPILER="${CMAKE_C_COMPILER}" )
-[[ -n "${CMAKE_CXX_COMPILER:-}" ]] && \
-  cmake_extra+=( -DCMAKE_CXX_COMPILER="${CMAKE_CXX_COMPILER}" )
+while IFS= read -r line; do cmake_extra+=("$line"); done \
+  < <(llvm_build::cmake_extra)
 
 cmake -G Ninja \
   -DCMAKE_INSTALL_PREFIX="$OUT_DIR/llvm-project" \
@@ -77,44 +63,24 @@ cmake -G Ninja \
   -DCOMPILER_RT_BUILD_XRAY=OFF \
   -DCOMPILER_RT_BUILD_GWP_ASAN=OFF \
   -DCOMPILER_RT_BUILD_CTX_PROFILE=OFF \
-  "${cmake_extra[@]}" \
+  ${cmake_extra[@]+"${cmake_extra[@]}"} \
   ../llvm
 
-# RECIPE_QUICK_CHECK=1 builds only the smallest LLVM library (LLVMDemangle)
-# and exits successfully. Used by verify.yml as a PR-time smoke check
-# that catches host-toolchain mismatches in ~3 min — the actual mode
-# this guards against was a real publish failure post-merge where the
-# runner picked up gcc by default and rejected Clang-only UBSan flags.
-# Building LLVMDemangle exercises the same compiler invocation as the
-# first ~30 source files of the full build without paying the rest of
-# the ~30 min.
-if [[ "${RECIPE_QUICK_CHECK:-0}" == "1" ]]; then
-  ninja -j "${NCPUS}" LLVMDemangle
-  echo "build.sh: RECIPE_QUICK_CHECK passed (cmake configure + LLVMDemangle)."
-  exit 0
-fi
+llvm_build::quick_check_or_continue
 
 ninja -j "${NCPUS}" clang clangInterpreter clangStaticAnalyzerCore
 
 # compiler-rt is enabled solely for the OOP-JIT runtime that CppInterOp's
-# clang-repl-based driver uses. We deliberately turn off every other
-# compiler-rt component (sanitizers, fuzzer, profile, memprof, xray,
-# gwp_asan, ctx_profile, builtins) so the build stays cheap — the asan
-# *runtime* CppInterOp links against is whatever ships with the host
-# clang, not what we'd be building here. The orc_rt target name varies
-# per platform (orc_rt_osx, orc_rt_linux_x86_64, …); enumerate via
+# clang-repl-based driver uses. The orc_rt target name varies per
+# platform (orc_rt_osx, orc_rt_linux_x86_64, …); enumerate via
 # `ninja -t targets` and build whatever matches, plus the executor.
 #
-# Why: `LLVM_USE_SANITIZER=Address;Undefined` propagates to *every* C/C++
-# target in the build, including orc_rt and llvm-jitlink-executor.
-# The OOP runtime artifacts therefore ship with asan/ubsan
-# instrumentation baked in. This works in practice because CppInterOp's
-# pre-existing asan row goes through the same path (see
-# `Build_LLVM/action.yml` in CppInterOp before this migration), but be
-# aware: a future change that lets the OOP runtime call into untrusted
-# JIT'd code could expose double-instrumentation surprises. If a
-# downstream consumer reports doubled asan reports, this is the place
-# to start looking.
+# Why: LLVM_USE_SANITIZER=Address;Undefined propagates to *every* C/C++
+# target, including orc_rt and llvm-jitlink-executor. The OOP runtime
+# artifacts therefore ship with asan/ubsan instrumentation baked in.
+# A future change that lets the OOP runtime call into untrusted JIT'd
+# code could expose double-instrumentation surprises; if a downstream
+# consumer reports doubled asan reports, this is the place to start.
 OOP_TARGETS=$(ninja -t targets all 2>/dev/null | \
   awk -F: '/^orc_rt[^:]*:/{print $1}' | sort -u | tr '\n' ' ')
 if [[ -n "${OOP_TARGETS}" ]]; then
@@ -123,104 +89,21 @@ else
   echo "build.sh: no orc_rt targets matched; OOP-JIT runtime won't be in the artifact." >&2
 fi
 
-# Free disk before the install phase. asan-instrumented .o files are
-# the bulk of the build tree (3-5x larger than vanilla); a hosted
-# Linux runner has ~14 GiB free disk and the recipe's intermediate
-# state crowds it. ccache has already captured every compile we care
-# about by this point — its hit/miss key is the source + flags, not
-# the .o on disk — so deleting *.o doesn't lose ccache state. The
-# install phase below copies .a / binaries / headers / cmake-exports
-# only; none of it reaches into .o.
-echo "build.sh: pre-install disk: $(df -h . | tail -1)"
-echo "build.sh: dropping intermediate .o files"
-find . -name '*.o' -delete
-echo "build.sh: post-cleanup disk: $(df -h . | tail -1)"
+llvm_build::cleanup_intermediates
 
-# Drive the install through LLVM_DISTRIBUTION_COMPONENTS, not raw
-# `cmake --install --component`. The naive per-component approach
-# installs only built libraries, but `cmake-exports` always emits a
-# *complete* LLVMExports.cmake that lists every LLVM library the build
-# tree configured (including ones we never built — LLVMSupportLSP,
-# LLVMDiff, LLVMDebuginfod, …). find_package(LLVM) walks
-# LLVMExports.cmake at consumer time and aborts on any IMPORTED target
-# whose .a is missing, which is exactly what bit CppInterOp's asan row
-# the first time it tried to consume the install tree.
-#
-# LLVM_DISTRIBUTION_COMPONENTS scopes the cmake-exports output: when
-# set, install_distribution_exports() in LLVMDistributionSupport.cmake
-# emits an LLVMExports.cmake containing only the listed components. So
-# we compute the list from what we actually built (libclang*.a +
-# libLLVM*.a + OOP_TARGETS + the umbrella headers/exports), reconfigure
-# with that as DISTRIBUTION_COMPONENTS, then `ninja install-distribution`
-# installs only those and writes a self-consistent exports file.
-#
-# Reconfigure cost is ~3-5 s (cmake re-emits build.ninja); install-
-# distribution is fast because every listed component is already built.
-#
-# See https://llvm.org/docs/BuildingADistribution.html#options-for-building-an-llvm-distribution
-# and llvm/cmake/modules/LLVMDistributionSupport.cmake.
+# Pass the OOP_TARGETS as extra DIST_COMPONENTS so install-distribution
+# installs them and LLVMExports.cmake stays self-consistent.
+# shellcheck disable=SC2086  # OOP_TARGETS is a space-separated list, splat intentionally
+llvm_build::install_distribution ${OOP_TARGETS}
 
-# Umbrellas + computed per-library list. Headers/cmake-exports umbrellas
-# don't suffer the missing-.a problem because they install source-tree
-# or generated files, not built libraries.
-declare -a DIST_COMPONENTS=(
-  clang
-  clang-headers
-  clang-cmake-exports
-  clang-resource-headers
-  clangInterpreter
-  cmake-exports
-  llvm-headers
-  llvm-config
-)
-for f in lib/libclang*.a lib/libLLVM*.a; do
-  [[ -f "$f" ]] || continue
-  DIST_COMPONENTS+=("$(basename "$f" | sed 's/^lib//; s/\.a$//')")
-done
-for tgt in ${OOP_TARGETS}; do
-  DIST_COMPONENTS+=("$tgt")
-done
-
-DIST_STR=$(IFS=';'; echo "${DIST_COMPONENTS[*]}")
-echo "build.sh: LLVM_DISTRIBUTION_COMPONENTS=${DIST_STR}"
-cmake -DLLVM_DISTRIBUTION_COMPONENTS="${DIST_STR}" .
-
-ninja -j "${NCPUS}" install-distribution
-
-# llvm-jitlink-executor's CMakeLists registers an install() rule but
-# its COMPONENT defaults to "Unspecified", so it can't be in
+# llvm-jitlink-executor's CMakeLists registers an install() rule with
+# COMPONENT defaulting to "Unspecified", so it can't be in
 # DISTRIBUTION_COMPONENTS. Copy by hand into the install bin/ so
-# consumers that need the OOP executor find it next to clang at
-# $LLVM/bin/llvm-jitlink-executor.
+# consumers find it next to clang at $LLVM/bin/llvm-jitlink-executor.
 if [[ -x bin/llvm-jitlink-executor ]]; then
   install -m 0755 bin/llvm-jitlink-executor "$OUT_DIR/llvm-project/bin/"
 fi
 
-# Producer-side smoke: invoke find_package(LLVM) and find_package(Clang)
-# from a throwaway cmake project against the install tree we just
-# produced. find_package walks every IMPORTED target's
-# IMPORTED_LOCATION_RELEASE and validates the file exists, plus checks
-# every reference in INTERFACE_LINK_LIBRARIES — exactly what the
-# consumer will run. Catches missing-.a-in-exports (the bug that broke
-# CppInterOp's first install-tree consume) and any other inconsistency
-# before the asset is tar'd and uploaded. Costs ~5 s.
-SMOKE_DIR="$(mktemp -d)"
-trap 'rm -rf "$SMOKE_DIR"' EXIT
-cat > "$SMOKE_DIR/CMakeLists.txt" <<'EOF'
-cmake_minimum_required(VERSION 3.20)
-project(install_tree_smoke LANGUAGES CXX)
-find_package(LLVM REQUIRED CONFIG PATHS "${SMOKE_LLVM_PREFIX}/lib/cmake/llvm" NO_DEFAULT_PATH)
-find_package(Clang REQUIRED CONFIG PATHS "${SMOKE_LLVM_PREFIX}/lib/cmake/clang" NO_DEFAULT_PATH)
-message(STATUS "smoke: LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH} loaded from ${LLVM_DIR}")
-EOF
-echo "build.sh: smoke-testing install tree (find_package LLVM + Clang)"
-cmake -S "$SMOKE_DIR" -B "$SMOKE_DIR/build" \
-  -DSMOKE_LLVM_PREFIX="$OUT_DIR/llvm-project" \
-  >"$SMOKE_DIR/log" 2>&1 || {
-  echo "::error::install tree failed find_package smoke. Exports likely reference missing files."
-  tail -50 "$SMOKE_DIR/log" >&2
-  exit 1
-}
-echo "build.sh: smoke passed."
+llvm_build::smoke
 
 echo "build.sh: done. SRC_COMMIT=${SRC_COMMIT}"

--- a/recipes/llvm-root/build.sh
+++ b/recipes/llvm-root/build.sh
@@ -3,13 +3,13 @@
 # LLVM_EXTERNAL_PROJECT. Source repos and branches are read from
 # recipe.yaml so a tag bump there is the single point of edit.
 #
-# We publish a cmake --install tree (not a build tree). LLVMConfig.cmake
-# in an install tree uses _IMPORT_PREFIX-relative paths so the consumer
-# can extract the asset under any path; build trees bake in absolute
-# paths from configure-time and are not relocatable. See the
-# llvm-asan recipe for the pattern this is modelled on.
+# Recipe-specific bits live here (source clones, cmake flags, ninja
+# targets, cling-specific post-install). The shared install-tree publish
+# flow (env validation, .o cleanup, LLVM_DISTRIBUTION_COMPONENTS,
+# install-distribution, find_package smoke) lives in
+# actions/lib/llvm-build.sh.
 #
-# Inputs (env):
+# Inputs (env): see actions/lib/llvm-build.sh header.
 #   RECIPE_VERSION         flavor selector. Substitutes into
 #                          recipe.yaml's source.branch_template
 #                          ({version} → branch). Today this is one of
@@ -17,30 +17,24 @@
 #                          'ROOT-llvm20' (ROOT superset). Factored
 #                          into the cache key, so each flavor has its
 #                          own asset.
-#   WORK_DIR               scratch directory (clones + build live here)
-#   OUT_DIR                CMAKE_INSTALL_PREFIX is $OUT_DIR/llvm-project
-#   NCPUS                  parallelism (default: nproc)
-#   CMAKE_C_COMPILER_LAUNCHER, CMAKE_CXX_COMPILER_LAUNCHER
-#                          optional; passed through to cmake (ccache).
 #
 # Outputs (env, written to GITHUB_ENV when present):
 #   SRC_COMMIT             sha of llvm-project HEAD that was built
 set -euo pipefail
 
-: "${RECIPE_VERSION:?RECIPE_VERSION must be set}"
-: "${WORK_DIR:?WORK_DIR must be set}"
-: "${OUT_DIR:?OUT_DIR must be set}"
-NCPUS="${NCPUS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../actions/lib/llvm-build.sh
+source "$SCRIPT_DIR/../../actions/lib/llvm-build.sh"
 
-RECIPE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+llvm_build::setup_env
 
 # Pull source coordinates from recipe.yaml. Mirrors build-manifest.sh's
 # grep approach — keeps the recipe.yaml content the single source of
 # truth without dragging a YAML parser into the script.
-LLVM_REPO=$(grep -E '^\s*repo:' "$RECIPE_DIR/recipe.yaml" | sed -n '1p' | sed -E 's/.*repo:[[:space:]]*//' | tr -d '"')
-LLVM_BRANCH_TPL=$(grep -E '^\s*branch_template:' "$RECIPE_DIR/recipe.yaml" | head -1 | sed -E 's/.*branch_template:[[:space:]]*//' | tr -d "'\"")
-CLING_REPO=$(grep -E '^\s*repo:' "$RECIPE_DIR/recipe.yaml" | sed -n '2p' | sed -E 's/.*repo:[[:space:]]*//' | tr -d '"')
-CLING_BRANCH=$(grep -E '^\s*branch:' "$RECIPE_DIR/recipe.yaml" | head -1 | sed -E 's/.*branch:[[:space:]]*//' | tr -d '"')
+LLVM_REPO=$(grep -E '^\s*repo:' "$SCRIPT_DIR/recipe.yaml" | sed -n '1p' | sed -E 's/.*repo:[[:space:]]*//' | tr -d '"')
+LLVM_BRANCH_TPL=$(grep -E '^\s*branch_template:' "$SCRIPT_DIR/recipe.yaml" | head -1 | sed -E 's/.*branch_template:[[:space:]]*//' | tr -d "'\"")
+CLING_REPO=$(grep -E '^\s*repo:' "$SCRIPT_DIR/recipe.yaml" | sed -n '2p' | sed -E 's/.*repo:[[:space:]]*//' | tr -d '"')
+CLING_BRANCH=$(grep -E '^\s*branch:' "$SCRIPT_DIR/recipe.yaml" | head -1 | sed -E 's/.*branch:[[:space:]]*//' | tr -d '"')
 
 [[ -n "$LLVM_REPO"       ]] || { echo "build.sh: source.repo missing in recipe.yaml" >&2; exit 1; }
 [[ -n "$LLVM_BRANCH_TPL" ]] || { echo "build.sh: source.branch_template missing in recipe.yaml" >&2; exit 1; }
@@ -51,9 +45,7 @@ CLING_BRANCH=$(grep -E '^\s*branch:' "$RECIPE_DIR/recipe.yaml" | head -1 | sed -
 LLVM_BRANCH="${LLVM_BRANCH_TPL//\{version\}/$RECIPE_VERSION}"
 echo "build.sh: flavor=${RECIPE_VERSION}; cloning ${LLVM_REPO}@${LLVM_BRANCH}"
 
-mkdir -p "$WORK_DIR" "$OUT_DIR"
 cd "$WORK_DIR"
-
 if [[ ! -d cling/.git ]]; then
   git clone --depth=1 -b "$CLING_BRANCH" "$CLING_REPO" cling
 fi
@@ -70,20 +62,18 @@ fi
 mkdir -p build
 cd build
 
+# mapfile would be cleaner here but isn't available on bash 3.2
+# (macOS /bin/bash). while-read is portable.
 cmake_extra=()
-[[ -n "${CMAKE_C_COMPILER_LAUNCHER:-}" ]] && \
-  cmake_extra+=( -DCMAKE_C_COMPILER_LAUNCHER="${CMAKE_C_COMPILER_LAUNCHER}" )
-[[ -n "${CMAKE_CXX_COMPILER_LAUNCHER:-}" ]] && \
-  cmake_extra+=( -DCMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CXX_COMPILER_LAUNCHER}" )
-[[ -n "${CMAKE_C_COMPILER:-}" ]] && \
-  cmake_extra+=( -DCMAKE_C_COMPILER="${CMAKE_C_COMPILER}" )
-[[ -n "${CMAKE_CXX_COMPILER:-}" ]] && \
-  cmake_extra+=( -DCMAKE_CXX_COMPILER="${CMAKE_CXX_COMPILER}" )
+while IFS= read -r line; do cmake_extra+=("$line"); done \
+  < <(llvm_build::cmake_extra)
 
 # LLVM_EXTERNAL_PROJECTS=cling pulls cling's CMakeLists into the same
-# build tree. cling's libraries (clingInterpreter, clingMetaProcessor,
-# clingUtils) get added to LLVM's install machinery and become
-# install-X umbrella targets like any in-tree clang library.
+# build tree. cling's libraries get added to the build but cling uses
+# raw `install(TARGETS ...)` rather than LLVM's add_llvm_install_targets,
+# so its components have no install-X umbrellas — they're installed
+# separately below via cmake --install --component, which doesn't
+# require the umbrella.
 cmake -G Ninja \
   -DCMAKE_INSTALL_PREFIX="$OUT_DIR/llvm-project" \
   -DLLVM_ENABLE_PROJECTS="clang" \
@@ -99,121 +89,69 @@ cmake -G Ninja \
   -DLLVM_INCLUDE_BENCHMARKS=OFF \
   -DLLVM_INCLUDE_EXAMPLES=OFF \
   -DLLVM_INCLUDE_TESTS=OFF \
-  "${cmake_extra[@]}" \
+  ${cmake_extra[@]+"${cmake_extra[@]}"} \
   ../llvm
 
-if [[ "${RECIPE_QUICK_CHECK:-0}" == "1" ]]; then
-  ninja -j "${NCPUS}" LLVMDemangle
-  echo "build.sh: RECIPE_QUICK_CHECK passed (cmake configure + LLVMDemangle)."
-  exit 0
-fi
+llvm_build::quick_check_or_continue
 
-# Build the clang driver, the clang-repl Interpreter library
-# (downstream ROOT consumes it via libclangInterpreter.a even though
-# clang-the-binary doesn't depend on it transitively), the
-# StaticAnalyzerCore library (cling-bundled clang dragged it into
-# CppInterOp's link in the past), LLVMOrcDebugging (cling pulls it
-# in via LIBS in current cling tip), and the cling library itself
-# (clingInterpreter; the `cling` binary follows transitively).
+# Build clang driver + clang-repl Interpreter library (downstream ROOT
+# consumes libclangInterpreter.a even though the clang driver doesn't
+# depend on it transitively) + StaticAnalyzerCore (cling-bundled clang
+# pulled it into CppInterOp's link in the past) + LLVMOrcDebugging
+# (cling pulls it via LIBS) + clingInterpreter (the cling library; the
+# `cling` binary follows transitively).
 ninja -j "${NCPUS}" clang clangInterpreter clangStaticAnalyzerCore \
                     LLVMOrcDebugging clingInterpreter
 
-# Free disk before the install phase. Same reasoning as llvm-asan:
-# ccache has captured every compile by this point, so deleting *.o
-# doesn't lose any cache state, and the install phase only copies
-# .a / binaries / headers / cmake-exports.
-echo "build.sh: pre-install disk: $(df -h . | tail -1)"
-echo "build.sh: dropping intermediate .o files"
-find . -name '*.o' -delete
-echo "build.sh: post-cleanup disk: $(df -h . | tail -1)"
+llvm_build::cleanup_intermediates
 
-# Drive the LLVM/Clang install through LLVM_DISTRIBUTION_COMPONENTS so
-# the generated LLVMExports.cmake / ClangExports.cmake only reference
-# libraries we actually shipped. Same pattern as llvm-asan.
-#
-# Cling's cmake uses raw `install(TARGETS ...)` instead of LLVM's
-# `add_llvm_install_targets`, which means cling components have no
-# `install-X` umbrella targets. install-distribution requires those
-# umbrellas, so cling components must NOT be in DIST_COMPONENTS — we
-# install them separately below via `cmake --install --component`,
-# which runs the install rule directly without needing an umbrella.
-# Likewise, the per-library walk skips lib/libcling*.a.
-declare -a DIST_COMPONENTS=(
-  clang
-  clang-headers
-  clang-cmake-exports
-  clang-resource-headers
-  clangInterpreter
-  cmake-exports
-  llvm-headers
-  llvm-config
-)
-for f in lib/libclang*.a lib/libLLVM*.a; do
-  [[ -f "$f" ]] || continue
-  DIST_COMPONENTS+=("$(basename "$f" | sed 's/^lib//; s/\.a$//')")
-done
-
-DIST_STR=$(IFS=';'; echo "${DIST_COMPONENTS[*]}")
-echo "build.sh: LLVM_DISTRIBUTION_COMPONENTS=${DIST_STR}"
-cmake -DLLVM_DISTRIBUTION_COMPONENTS="${DIST_STR}" .
-
-ninja -j "${NCPUS}" install-distribution
+# Cling components must NOT be in DIST_COMPONENTS — install-distribution
+# requires install-X umbrellas that cling's raw install(TARGETS) doesn't
+# create. Pass no extras here; install LLVM/clang via the helper, then
+# install cling separately below.
+llvm_build::install_distribution
 
 # Cling components — installed separately because cling's cmake doesn't
 # create install-X umbrellas. cmake --install --component runs the
-# install rule directly. Walk libcling*.a to discover what cling built;
-# the cling binary lands via its own component.
-for f in lib/libcling*.a; do
+# install rule directly. Walk libcling*.a / cling*.lib (the latter is
+# Windows-MSVC convention) to discover what cling built.
+for f in lib/libcling*.a lib/cling*.lib; do
   [[ -f "$f" ]] || continue
-  comp=$(basename "$f" | sed 's/^lib//; s/\.a$//')
+  comp=$(basename "$f")
+  comp="${comp#lib}"; comp="${comp%.a}"; comp="${comp%.lib}"
   cmake --install . --component "$comp" 2>/dev/null \
     || echo "build.sh: cling component $comp install rule absent" >&2
 done
 # `cling` binary: cling's CMakeLists install(TARGETS cling RUNTIME ...)
-# uses COMPONENT cling. If that path doesn't exist (older cling),
-# fall back to a manual copy.
+# uses COMPONENT cling. If that path doesn't exist (older cling), fall
+# back to a manual copy.
 if cmake --install . --component cling 2>/dev/null; then
   :
 elif [[ -x bin/cling ]]; then
   install -m 0755 bin/cling "$OUT_DIR/llvm-project/bin/"
+elif [[ -f bin/cling.exe ]]; then
+  cp bin/cling.exe "$OUT_DIR/llvm-project/bin/"
 fi
 # Cling headers — cling's install rules typically don't ship them
-# (consumers historically read from the source tree via include path).
-# Stage them under include/cling/ in the install tree so consumers
-# find them without an extra source clone.
+# (consumers historically read from the source tree). Stage them under
+# include/cling/ in the install tree so consumers find them without an
+# extra source clone.
 if [[ -d "$WORK_DIR/cling/include/cling" ]]; then
   mkdir -p "$OUT_DIR/llvm-project/include"
   cp -R "$WORK_DIR/cling/include/cling" "$OUT_DIR/llvm-project/include/"
 fi
 
-# Producer-side smoke: find_package(LLVM)+(Clang) from a throwaway
-# cmake project against the install tree. Catches any missing-.a-in-
-# exports inconsistency before the asset is tar'd. Cling does not
-# ship a ClingConfig.cmake (cling is consumed via header includes +
-# direct linkage against libclingInterpreter.a, not find_package), so
-# we don't add it to the smoke. ~5 s.
-SMOKE_DIR="$(mktemp -d)"
-trap 'rm -rf "$SMOKE_DIR"' EXIT
-cat > "$SMOKE_DIR/CMakeLists.txt" <<'EOF'
-cmake_minimum_required(VERSION 3.20)
-project(install_tree_smoke LANGUAGES CXX)
-find_package(LLVM REQUIRED CONFIG PATHS "${SMOKE_LLVM_PREFIX}/lib/cmake/llvm" NO_DEFAULT_PATH)
-find_package(Clang REQUIRED CONFIG PATHS "${SMOKE_LLVM_PREFIX}/lib/cmake/clang" NO_DEFAULT_PATH)
-message(STATUS "smoke: LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH} loaded from ${LLVM_DIR}")
-# Spot-check that libclingInterpreter.a actually shipped — find_package(LLVM)
-# alone doesn't validate cling-specific files since cling has no Config.cmake.
-if(NOT EXISTS "${SMOKE_LLVM_PREFIX}/lib/libclingInterpreter.a")
-  message(FATAL_ERROR "smoke: libclingInterpreter.a missing from install tree")
-endif()
-EOF
-echo "build.sh: smoke-testing install tree (find_package LLVM + Clang + cling lib)"
-cmake -S "$SMOKE_DIR" -B "$SMOKE_DIR/build" \
-  -DSMOKE_LLVM_PREFIX="$OUT_DIR/llvm-project" \
-  >"$SMOKE_DIR/log" 2>&1 || {
-  echo "::error::install tree failed find_package smoke. Exports likely reference missing files."
-  tail -50 "$SMOKE_DIR/log" >&2
+# Producer-side smoke. find_package(LLVM)+(Clang) covers the LLVM/clang
+# install; cling has no Config.cmake, so add a libclingInterpreter
+# existence check (the matching .lib name on Windows MSVC is
+# clingInterpreter.lib — without the lib prefix).
+if [[ -f "$OUT_DIR/llvm-project/lib/libclingInterpreter.a" ]]; then
+  llvm_build::smoke "lib/libclingInterpreter.a"
+elif [[ -f "$OUT_DIR/llvm-project/lib/clingInterpreter.lib" ]]; then
+  llvm_build::smoke "lib/clingInterpreter.lib"
+else
+  echo "::error::neither libclingInterpreter.a nor clingInterpreter.lib found in install"
   exit 1
-}
-echo "build.sh: smoke passed."
+fi
 
 echo "build.sh: done. SRC_COMMIT=${SRC_COMMIT}"


### PR DESCRIPTION
Refactors recipe `build.sh` files to share a single LLVM install-tree publish helper, fixes the Windows publish toolchain, and turns the PR-time smoke into 
  a cells.yaml-driven matrix so every (recipe, OS, arch) cell gets actual cross-platform coverage before merge.