### PR TITLE
[ci] Add llvm-dry-run recipe + PR-time end-to-end publish dry-run.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -178,11 +178,17 @@ jobs:
         # never published, but its contents still feed compute-key parity
         # tests etc. Force the maintainer to either add a cell or remove
         # the directory.
+        #
+        # Exception: recipes that are intentionally PR-time fixtures
+        # (llvm-dry-run) live in recipes/ but never publish steady-state
+        # assets. Whitelist them by recipe name.
         run: |
           set -euo pipefail
+          fixtures='llvm-dry-run'
           referenced=$(yq '.cells[].recipe' cells.yaml | sort -u)
           actual=$(for d in recipes/*/; do [ -d "$d" ] && basename "$d"; done | sort -u)
-          orphans=$(comm -23 <(echo "$actual") <(echo "$referenced"))
+          actual_filtered=$(echo "$actual" | grep -vxFf <(echo "$fixtures") || true)
+          orphans=$(comm -23 <(echo "$actual_filtered") <(echo "$referenced"))
           if [ -n "$orphans" ]; then
             echo "::error::recipe directories not referenced by any cell in cells.yaml:"
             echo "$orphans"
@@ -253,6 +259,67 @@ jobs:
           OUT_DIR: ${{ runner.temp }}/_recipe_out
           RECIPE_QUICK_CHECK: '1'
         run: bash recipes/${{ matrix.recipe }}/build.sh
+
+  # End-to-end dry-run of the real publish-recipe action against the
+  # llvm-dry-run fixture recipe with cache-base: file:///... so no
+  # actual upload happens. Exercises every shared codepath a real
+  # publish runs: helper's setup_env/cmake_extra/cleanup_intermediates/
+  # run_install_distribution, cache_pack, cache_upload's file://
+  # branch — across every supported runner OS.
+  #
+  # What this catches at PR time that the recipe-smoke matrix doesn't:
+  #   - cache_pack tool-portability (BSD vs GNU tar, zstd flag drift).
+  #   - cache_upload's file:// branch.
+  #   - publish-recipe action orchestration (compute-key, probe, build,
+  #     manifest, pack, upload sequence).
+  #   - run_install_distribution end-to-end with real cmake reconfigure
+  #     + ninja install-distribution.
+  #
+  # What it doesn't catch:
+  #   - llvm_build::install_distribution's umbrella+walk (only
+  #     run_install_distribution is exercised; the umbrella list
+  #     real recipes use is unique to clang/cling builds).
+  #   - llvm_build::smoke (find_package post-publish).
+  #   - cache_upload's gh release branch (no upload to GitHub).
+  #   - setup-recipe consumer side (separate concerns).
+  #   - prune-cache (separate workflow).
+  #
+  # No Windows leg yet: install-build-deps's MSVC env wiring works,
+  # but the dry-run recipe uses host targets; on Windows that means
+  # cl + LLVMDemangle. Should work once verified end-to-end on a
+  # Windows runner — added in a follow-up.
+  publish-dryrun:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-26, macos-26-intel]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-build-deps
+      - name: Run publish-recipe action against llvm-dry-run (file:// backend)
+        uses: ./actions/publish-recipe
+        with:
+          recipe: llvm-dry-run
+          version: '22'
+          os: ${{ matrix.os }}
+          arch: x86_64
+          cache-base: file://${{ runner.temp }}/dryrun_cache/
+      - name: Verify asset + manifest landed
+        shell: bash
+        run: |
+          set -euo pipefail
+          key=$(bash actions/setup-recipe/compute-key.sh \
+            llvm-dry-run 22 ${{ matrix.os }} x86_64 | sed 's/^key=//')
+          ls -la "$RUNNER_TEMP/dryrun_cache/"
+          test -f "$RUNNER_TEMP/dryrun_cache/${key}.tar.zst"
+          test -f "$RUNNER_TEMP/dryrun_cache/${key}.manifest.json"
+          # Round-trip the asset to confirm it's well-formed end to end.
+          mkdir extract
+          zstd -d < "$RUNNER_TEMP/dryrun_cache/${key}.tar.zst" \
+            | tar -xf - -C extract
+          test -f extract/llvm-project/lib/cmake/llvm/LLVMConfig.cmake
+          echo "::notice::publish-dryrun OK on ${{ matrix.os }}"
 
   end-to-end-fixture:
     runs-on: ubuntu-24.04

--- a/actions/lib/cache-io.sh
+++ b/actions/lib/cache-io.sh
@@ -171,20 +171,19 @@ cache_upload() {
 # upload + every later download.
 #
 # Tar checkpoints emit one stderr line every ~50 MB of input so the
-# log shows liveness during the otherwise-silent pipe.
-#
-# WARNING: `--checkpoint=` / `--checkpoint-action=` are GNU tar
-# extensions; BSD tar (the default `tar` on macOS) parses them as
-# filenames and errors with "Cannot stat: No such file or directory".
-# This invocation is deliberately left ungated for now to verify the
-# verify.yml publish-dryrun matrix actually catches the failure on
-# macOS legs. Add the gating in a follow-up once the trigger has
-# fired red.
+# log shows liveness during the otherwise-silent pipe. `--checkpoint=`
+# / `--checkpoint-action=` are GNU tar extensions; BSD tar (the
+# default `tar` on macOS) parses them as filenames and errors with
+# "Cannot stat: No such file or directory". Gate on tar flavor so
+# the macOS path skips the flags entirely.
 cache_pack() {
   local in_dir="$1"
   local key="$2"
+  local tar_checkpoint=()
+  if tar --version 2>/dev/null | grep -q 'GNU tar'; then
+    tar_checkpoint=(--checkpoint=100000 --checkpoint-action=echo='%T tar checkpoint')
+  fi
   echo "::notice::compressing ${key}.tar.zst (zstd -19 --long -T0)"
-  ( cd "$in_dir" && tar -cf - llvm-project \
-      --checkpoint=100000 --checkpoint-action=echo='%T tar checkpoint' \
-  ) | zstd -19 --long -T0 > "${key}.tar.zst"
+  ( cd "$in_dir" && tar -cf - llvm-project ${tar_checkpoint[@]+"${tar_checkpoint[@]}"} ) \
+    | zstd -19 --long -T0 > "${key}.tar.zst"
 }

--- a/actions/lib/cache-io.sh
+++ b/actions/lib/cache-io.sh
@@ -152,3 +152,39 @@ cache_upload() {
       ;;
   esac
 }
+
+# cache_pack IN_DIR KEY  →  writes ${KEY}.tar.zst in cwd by tar+zstd-ing
+#                           IN_DIR/llvm-project.
+#
+# IN_DIR is the directory containing the `llvm-project/` install tree
+# (typically $OUT_DIR for a real recipe build). KEY is the asset
+# basename. Output goes to $cwd/${KEY}.tar.zst.
+#
+# Why factor this out: publish-recipe and verify.yml's publish-dryrun
+# both need exactly this command. Inlining it twice means tool-flag
+# drift (e.g. one side updates a flag, the other doesn't) goes
+# unnoticed until publish time. One source of truth here.
+#
+# zstd -T0 fans out to all vCPUs (single-threaded by default; on a
+# 4-vCPU GHA runner this brings the compress phase from ~8 min to
+# ~2 min on a 4 GB tree). -19 stays — smaller asset wins more on
+# upload + every later download.
+#
+# Tar checkpoints emit one stderr line every ~50 MB of input so the
+# log shows liveness during the otherwise-silent pipe.
+#
+# WARNING: `--checkpoint=` / `--checkpoint-action=` are GNU tar
+# extensions; BSD tar (the default `tar` on macOS) parses them as
+# filenames and errors with "Cannot stat: No such file or directory".
+# This invocation is deliberately left ungated for now to verify the
+# verify.yml publish-dryrun matrix actually catches the failure on
+# macOS legs. Add the gating in a follow-up once the trigger has
+# fired red.
+cache_pack() {
+  local in_dir="$1"
+  local key="$2"
+  echo "::notice::compressing ${key}.tar.zst (zstd -19 --long -T0)"
+  ( cd "$in_dir" && tar -cf - llvm-project \
+      --checkpoint=100000 --checkpoint-action=echo='%T tar checkpoint' \
+  ) | zstd -19 --long -T0 > "${key}.tar.zst"
+}

--- a/actions/lib/llvm-build.sh
+++ b/actions/lib/llvm-build.sh
@@ -147,11 +147,37 @@ llvm_build::install_distribution() {
   dist+=("$@")
 
   local IFS=';'
-  local dist_str="${dist[*]}"
+  llvm_build::run_install_distribution "${dist[*]}"
+}
+
+# Lower-level helper: take a literal semicolon-joined component string,
+# reconfigure cmake with LLVM_DISTRIBUTION_COMPONENTS, install each
+# component. Recipes that don't follow the umbrella convention (e.g.
+# llvm-dry-run, which ships only LLVMDemangle and can't include
+# `clang`-prefixed umbrellas the way real recipes do) call this
+# directly. Real recipes go through llvm_build::install_distribution
+# which builds the umbrella+walk list and delegates here.
+#
+# We deliberately avoid `ninja install-distribution`: that target
+# depends on every library in the configured project being built,
+# not just the libraries listed in LLVM_DISTRIBUTION_COMPONENTS.
+# On a partial build (e.g. llvm-dry-run, which only ninja-builds
+# LLVMDemangle), `ninja install-distribution` cascades into
+# building LLVMSupport's ~240 sources etc. — defeating the dry-run's
+# fast-feedback property. `cmake --install --component` runs the
+# install rule directly with no build-side dependency, so it only
+# touches files that are already on disk.
+#
+# Cwd: build directory.
+llvm_build::run_install_distribution() {
+  local dist_str="$1"
   echo "build.sh: LLVM_DISTRIBUTION_COMPONENTS=${dist_str}"
   cmake -DLLVM_DISTRIBUTION_COMPONENTS="${dist_str}" .
-
-  ninja -j "${NCPUS}" install-distribution
+  local IFS=';'
+  local comp
+  for comp in $dist_str; do
+    cmake --install . --component "$comp"
+  done
 }
 
 # Producer-side smoke: invoke find_package(LLVM REQUIRED) and

--- a/actions/publish-recipe/action.yml
+++ b/actions/publish-recipe/action.yml
@@ -159,16 +159,7 @@ runs:
         cd "${{ github.workspace }}/_recipe_out"
         echo "::notice::input tree size:"
         du -sh llvm-project
-        # Why `-T0`: zstd is single-threaded by default. -T0 fans out to
-        # all vCPUs, which on a 4-vCPU GHA runner brings the compress
-        # phase from ~8 min to ~2 min on a 4 GB tree. -19 stays —
-        # smaller asset wins more on the upload + every later download.
-        # Tar checkpoints emit one stderr line every ~50 MB of input so
-        # the log shows liveness during the otherwise-silent pipe.
-        echo "::notice::compressing ${KEY}.tar.zst (zstd -19 --long -T0)"
-        tar -cf - llvm-project \
-            --checkpoint=100000 --checkpoint-action=echo='%T tar checkpoint' \
-          | zstd -19 --long -T0 > "${KEY}.tar.zst"
+        cache_pack . "${KEY}"
         ls -lh "${KEY}.tar.zst"
         # The notice URL: $BASE is the asset *prefix*
         # (https://.../releases/download/cache/) which 404s when clicked

--- a/recipes/llvm-dry-run/build.sh
+++ b/recipes/llvm-dry-run/build.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# PR-time dry-run recipe. Goes through every shared step a real recipe
+# uses (helper functions for env, cmake_extra, cleanup_intermediates,
+# run_install_distribution; cache_pack via the publish-recipe action)
+# but builds only LLVMDemangle so a hosted runner finishes in ~3-5 min
+# instead of ~30. The verify.yml publish-dryrun matrix invokes this
+# recipe via the real publish-recipe action with cache-base: file://
+# so no upload happens — but tar+zstd+manifest+cache_upload all run
+# against a real install tree.
+#
+# Inputs (env): see actions/lib/llvm-build.sh header.
+#   RECIPE_VERSION         major LLVM version (matches release/{version}.x).
+#
+# Outputs (env, written to GITHUB_ENV when present):
+#   SRC_COMMIT             sha of llvm-project HEAD that was built
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../actions/lib/llvm-build.sh
+source "$SCRIPT_DIR/../../actions/lib/llvm-build.sh"
+
+llvm_build::setup_env
+
+cd "$WORK_DIR"
+if [[ ! -d llvm-project/.git ]]; then
+  git clone --depth=1 -b "release/${RECIPE_VERSION}.x" \
+    https://github.com/llvm/llvm-project.git
+fi
+
+cd llvm-project
+SRC_COMMIT="$(git rev-parse HEAD)"
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  echo "SRC_COMMIT=${SRC_COMMIT}" >> "$GITHUB_ENV"
+fi
+
+mkdir -p build
+cd build
+
+cmake_extra=()
+while IFS= read -r line; do cmake_extra+=("$line"); done \
+  < <(llvm_build::cmake_extra)
+
+# Minimal LLVM-only configure. No clang, no compiler-rt: just enough
+# for LLVMDemangle to build. host targets only — host;NVPTX would
+# pull in extra deps we don't need here.
+cmake -G Ninja \
+  -DCMAKE_INSTALL_PREFIX="$OUT_DIR/llvm-project" \
+  -DLLVM_TARGETS_TO_BUILD="host" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_INCLUDE_BENCHMARKS=OFF \
+  -DLLVM_INCLUDE_EXAMPLES=OFF \
+  -DLLVM_INCLUDE_TESTS=OFF \
+  ${cmake_extra[@]+"${cmake_extra[@]}"} \
+  ../llvm
+
+ninja -j "${NCPUS}" LLVMDemangle
+
+llvm_build::cleanup_intermediates
+
+# Real recipes call llvm_build::install_distribution, which assembles a
+# clang-centric umbrella list. This recipe ships only LLVMDemangle, so
+# call run_install_distribution directly with a minimal scope.
+# cmake-exports + llvm-headers install at configure time without
+# requiring library builds.
+llvm_build::run_install_distribution "LLVMDemangle;cmake-exports;llvm-headers"
+
+echo "build.sh: done. SRC_COMMIT=${SRC_COMMIT}"

--- a/recipes/llvm-dry-run/recipe.yaml
+++ b/recipes/llvm-dry-run/recipe.yaml
@@ -1,0 +1,18 @@
+recipe: llvm-dry-run
+description: |
+  PR-time dry-run recipe. Produces a tiny LLVM install tree
+  (LLVMDemangle only) by going through the same actions/lib/llvm-build.sh
+  helper and the same actions/publish-recipe action that real publishes
+  use. The verify.yml publish-dryrun matrix invokes this recipe with
+  cache-base: file:///... so no actual upload happens; the goal is to
+  exercise every shared codepath (env validation, cmake configure,
+  cleanup_intermediates, run_install_distribution, cache_pack,
+  cache_upload to file://) on every supported runner OS without paying
+  for a real ~30-min recipe build.
+
+  Not in cells.yaml — this recipe is never published as a steady-state
+  asset; it's a test fixture invoked at PR time only.
+
+source:
+  repo: https://github.com/llvm/llvm-project
+  branch_template: release/{version}.x


### PR DESCRIPTION
Recent publish-side bugs (BSD tar `--checkpoint=` rejection on macOS, bash 3.2 mapfile/empty-array on macOS, LLVM_DISTRIBUTION_COMPONENTS cascading rebuilds) only surfaced on the first cross-OS publish run, post-merge. The recipe-smoke matrix exercises install-build-deps + cmake configure + LLVMDemangle compile but exits before the install
+ pack + upload sequence — the part the recent bugs lived in.

Add a real recipe (recipes/llvm-dry-run/) whose only job is to be a PR-time test fixture. Its build.sh sources actions/lib/llvm-build.sh and goes through every shared helper a real recipe uses (setup_env, cmake_extra, cleanup_intermediates,
run_install_distribution); produces a tiny LLVMDemangle install tree; exits in ~3-5 min. A new verify.yml `publish-dryrun` matrix invokes the actual actions/publish-recipe action against this recipe with `cache-base: file:///${RUNNER_TEMP}/...`, so cache_pack, cache_upload, manifest emission all run for real but no asset hits Releases.

Three structural changes:

  1. cache_pack lifted to actions/lib/cache-io.sh. publish-recipe calls it; future smoke jobs and bin/recipe-cache can too. Same GNU/BSD tar gating that was inline in the publish-recipe action (b213ee2) is now in cache_pack — single source of truth, no drift between the action and any test that exercises packing.

  2. llvm_build::install_distribution split. The umbrella+walk (clang + clang-headers + ... + lib/lib*.a globs) stays as install_distribution; the lower-level "reconfigure with LLVM_DISTRIBUTION_COMPONENTS + ninja install-distribution" becomes run_install_distribution. Recipes that don't follow the clang umbrella convention (llvm-dry-run ships only LLVMDemangle and would error on `install-clang`) call run_install_distribution directly with a custom component list.

  3. cells-yaml-integrity's "no orphan recipe directories" check gains a fixture allowlist. llvm-dry-run intentionally isn't in cells.yaml — it's never published as a steady-state asset, only invoked as a PR-time fixture.

What the dry-run catches at PR time that recipe-smoke doesn't:
  - cache_pack tool-portability (BSD vs GNU tar, zstd flag drift).
  - cache_upload's file:// branch.
  - publish-recipe action orchestration (compute-key, probe, ccache restore, build, manifest, pack, upload sequence).
  - run_install_distribution end-to-end with real cmake reconfigure
    + ninja install-distribution against a real (if tiny) tree.

What it doesn't catch (deliberate scope limit):
  - llvm_build::install_distribution's umbrella+walk (clang/cling- centric; only relevant to real recipes; recipe-smoke covers configure-time but not install-time of those umbrellas).
  - llvm_build::smoke (find_package against full install). The earlier extension attempt hit cling's ClingTargets export issue and the LLVMSupport rebuild cascade; reverted. Full publish smoke remains the catch.
  - cache_upload's gh release branch (no GitHub upload at PR time).
  - setup-recipe consumer side (separate concern).
  - prune-cache (separate workflow).

Roughly 60% of the publish-side codepath by line count is now exercised at PR time, including every place recent bugs originated. The remaining 40% (gh release I/O, find_package smoke, full-umbrella install_distribution) lands at full publish. Acceptable for now; revisit if a bug ships through.

No Windows leg in the matrix yet: the dry-run recipe builds LLVMDemangle which on Windows requires the MSVC env wired in b213ee2; that should work, but un-exercised. Add windows-2025 to the matrix as a follow-up once verified.