### PR TITLE
[ci] Share the cmake configure prelude across recipes. NFC

### DIFF
--- a/actions/lib/llvm_build.py
+++ b/actions/lib/llvm_build.py
@@ -49,6 +49,60 @@ def setup_env() -> None:
     Path(os.environ["OUT_DIR"]).mkdir(parents=True, exist_ok=True)
 
 
+def base_cmake_args(install_prefix: str,
+                    targets: str = "host;NVPTX") -> List[str]:
+    """Cmake flags every LLVM-family recipe shares.
+
+    Recipes append their flavor-specific flags (LLVM_USE_SANITIZER for
+    asan, LLVM_EXTERNAL_PROJECTS=cling for root, etc.) and feed the
+    combined list to cmake. Centralising the shared subset means a flag
+    bump happens in one place, not three.
+    """
+    return [
+        "cmake", "-G", "Ninja",
+        f"-DCMAKE_INSTALL_PREFIX={install_prefix}",
+        f"-DLLVM_TARGETS_TO_BUILD={targets}",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DLLVM_ENABLE_ASSERTIONS=ON",
+        "-DCLANG_ENABLE_STATIC_ANALYZER=OFF",
+        "-DCLANG_ENABLE_ARCMT=OFF",
+        "-DCLANG_ENABLE_FORMAT=OFF",
+        "-DCLANG_ENABLE_BOOTSTRAP=OFF",
+        "-DLLVM_INCLUDE_BENCHMARKS=OFF",
+        "-DLLVM_INCLUDE_EXAMPLES=OFF",
+        "-DLLVM_INCLUDE_TESTS=OFF",
+    ]
+
+
+def clone_shallow(repo: str, branch: str, dest: Path) -> None:
+    """Shallow git clone to `dest` if missing. No-op on a re-run with
+    a populated working tree (ccache + actions/cache reuse the workspace).
+    """
+    if (dest / ".git").is_dir():
+        return
+    subprocess.run(
+        ["git", "clone", "--depth=1", "-b", branch, repo, str(dest)],
+        check=True,
+    )
+
+
+def record_src_commit(repo_path: Path) -> str:
+    """Return the HEAD sha of `repo_path` and append it to $GITHUB_ENV.
+
+    The action.yml uses `SRC_COMMIT` as a recipe-output env so
+    publish-recipe can stamp it into the manifest's source.commit.
+    """
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_path, check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    github_env = os.environ.get("GITHUB_ENV", "")
+    if github_env:
+        with open(github_env, "a") as f:
+            f.write(f"SRC_COMMIT={sha}\n")
+    return sha
+
+
 def cmake_extra() -> List[str]:
     """Return cmake -D flags derived from CC/CXX/launcher env vars."""
     flags: List[str] = []

--- a/actions/lib/test_llvm_build.py
+++ b/actions/lib/test_llvm_build.py
@@ -52,6 +52,98 @@ class SetupEnvTests(unittest.TestCase):
                 self.assertEqual(os.environ["NCPUS"], "7")
 
 
+class BaseCmakeArgsTests(unittest.TestCase):
+    """base_cmake_args is the single source of truth for the flag set
+    every LLVM-family recipe shares — drift here means a recipe goes red
+    silently in a way only a real CI run would catch. Pin the contract."""
+
+    def test_required_flags_present(self):
+        args = llvm_build.base_cmake_args("/opt/install")
+        self.assertEqual(args[:3], ["cmake", "-G", "Ninja"])
+        self.assertIn("-DCMAKE_INSTALL_PREFIX=/opt/install", args)
+        self.assertIn("-DLLVM_TARGETS_TO_BUILD=host;NVPTX", args)
+        self.assertIn("-DCMAKE_BUILD_TYPE=Release", args)
+        self.assertIn("-DLLVM_ENABLE_ASSERTIONS=ON", args)
+        # CLANG_ENABLE_* off-flags reduce build time in clang-using
+        # recipes; harmless when LLVM_ENABLE_PROJECTS doesn't include clang.
+        for flag in ("-DCLANG_ENABLE_STATIC_ANALYZER=OFF",
+                     "-DCLANG_ENABLE_ARCMT=OFF",
+                     "-DCLANG_ENABLE_FORMAT=OFF",
+                     "-DCLANG_ENABLE_BOOTSTRAP=OFF",
+                     "-DLLVM_INCLUDE_BENCHMARKS=OFF",
+                     "-DLLVM_INCLUDE_EXAMPLES=OFF",
+                     "-DLLVM_INCLUDE_TESTS=OFF"):
+            self.assertIn(flag, args)
+
+    def test_targets_override(self):
+        args = llvm_build.base_cmake_args("/p", targets="host")
+        self.assertIn("-DLLVM_TARGETS_TO_BUILD=host", args)
+        self.assertNotIn("-DLLVM_TARGETS_TO_BUILD=host;NVPTX", args)
+
+
+class CloneShallowTests(unittest.TestCase):
+    def test_skips_when_already_cloned(self):
+        with tempfile.TemporaryDirectory() as d:
+            dest = Path(d) / "repo"
+            (dest / ".git").mkdir(parents=True)
+            with mock.patch.object(llvm_build.subprocess, "run") as run:
+                llvm_build.clone_shallow("https://example/r", "main", dest)
+            run.assert_not_called()
+
+    def test_invokes_git_clone_when_missing(self):
+        with tempfile.TemporaryDirectory() as d:
+            dest = Path(d) / "repo"
+            with mock.patch.object(llvm_build.subprocess, "run") as run:
+                run.return_value = subprocess.CompletedProcess([], 0)
+                llvm_build.clone_shallow("https://example/r.git",
+                                         "release/22.x", dest)
+            run.assert_called_once()
+            cmd = run.call_args[0][0]
+            self.assertEqual(cmd[:5],
+                             ["git", "clone", "--depth=1", "-b", "release/22.x"])
+            self.assertEqual(cmd[5], "https://example/r.git")
+            self.assertEqual(cmd[6], str(dest))
+
+
+class RecordSrcCommitTests(unittest.TestCase):
+    def test_returns_sha_and_appends_when_github_env_set(self):
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d) / "repo"
+            repo.mkdir()
+            ge = Path(d) / "github_env"
+            ge.write_text("PRIOR=1\n")
+
+            def fake_run(cmd, **_):
+                self.assertEqual(cmd, ["git", "rev-parse", "HEAD"])
+                return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n")
+
+            with mock.patch.object(llvm_build.subprocess, "run",
+                                   side_effect=fake_run), \
+                 mock.patch.dict(os.environ, {"GITHUB_ENV": str(ge)},
+                                 clear=False):
+                sha = llvm_build.record_src_commit(repo)
+
+            self.assertEqual(sha, "abc123")
+            self.assertEqual(ge.read_text(),
+                             "PRIOR=1\nSRC_COMMIT=abc123\n")
+
+    def test_no_github_env_still_returns_sha(self):
+        with tempfile.TemporaryDirectory() as d:
+            repo = Path(d) / "repo"
+            repo.mkdir()
+
+            def fake_run(cmd, **_):
+                return subprocess.CompletedProcess(cmd, 0, stdout="deadbeef\n")
+
+            env = {k: v for k, v in os.environ.items() if k != "GITHUB_ENV"}
+            with mock.patch.object(llvm_build.subprocess, "run",
+                                   side_effect=fake_run), \
+                 mock.patch.dict(os.environ, env, clear=True):
+                sha = llvm_build.record_src_commit(repo)
+
+            self.assertEqual(sha, "deadbeef")
+
+
 class CmakeExtraTests(unittest.TestCase):
     def test_empty_when_no_env(self):
         with mock.patch.dict(os.environ, {}, clear=True):

--- a/recipes/llvm-asan/build.py
+++ b/recipes/llvm-asan/build.py
@@ -59,51 +59,39 @@ def main() -> int:
     ncpus = os.environ["NCPUS"]
 
     os.chdir(work_dir)
-    if not (work_dir / "llvm-project" / ".git").is_dir():
-        subprocess.run(
-            ["git", "clone", "--depth=1", "-b", f"release/{version}.x",
-             "https://github.com/llvm/llvm-project.git"],
-            check=True,
-        )
-
-    os.chdir(work_dir / "llvm-project")
-    src_commit = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        check=True, capture_output=True, text=True,
-    ).stdout.strip()
-    github_env = os.environ.get("GITHUB_ENV", "")
-    if github_env:
-        with open(github_env, "a") as f:
-            f.write(f"SRC_COMMIT={src_commit}\n")
+    llvm_build.clone_shallow(
+        "https://github.com/llvm/llvm-project.git",
+        f"release/{version}.x",
+        work_dir / "llvm-project",
+    )
+    src_commit = llvm_build.record_src_commit(work_dir / "llvm-project")
 
     build_dir = work_dir / "llvm-project" / "build"
     build_dir.mkdir(exist_ok=True)
     os.chdir(build_dir)
 
-    cmake_args = [
-        "cmake", "-G", "Ninja",
-        f"-DCMAKE_INSTALL_PREFIX={out_dir / 'llvm-project'}",
-        '-DLLVM_ENABLE_PROJECTS=clang;compiler-rt',
-        '-DLLVM_TARGETS_TO_BUILD=host;NVPTX',
-        '-DCMAKE_BUILD_TYPE=Release',
-        '-DLLVM_ENABLE_ASSERTIONS=ON',
-        '-DLLVM_USE_SANITIZER=Address;Undefined',
-        '-DCLANG_ENABLE_STATIC_ANALYZER=OFF',
-        '-DCLANG_ENABLE_ARCMT=OFF',
-        '-DCLANG_ENABLE_FORMAT=OFF',
-        '-DCLANG_ENABLE_BOOTSTRAP=OFF',
-        '-DLLVM_INCLUDE_BENCHMARKS=OFF',
-        '-DLLVM_INCLUDE_EXAMPLES=OFF',
-        '-DLLVM_INCLUDE_TESTS=OFF',
-        '-DCOMPILER_RT_BUILD_BUILTINS=OFF',
-        '-DCOMPILER_RT_BUILD_LIBFUZZER=OFF',
-        '-DCOMPILER_RT_BUILD_PROFILE=OFF',
-        '-DCOMPILER_RT_BUILD_MEMPROF=OFF',
-        '-DCOMPILER_RT_BUILD_SANITIZERS=OFF',
-        '-DCOMPILER_RT_BUILD_XRAY=OFF',
-        '-DCOMPILER_RT_BUILD_GWP_ASAN=OFF',
-        '-DCOMPILER_RT_BUILD_CTX_PROFILE=OFF',
-    ] + llvm_build.cmake_extra() + ["../llvm"]
+    # asan-specific flags layered on top of base_cmake_args:
+    # - LLVM_USE_SANITIZER propagates to every C/C++ target so the
+    #   resident clang and the compiler-rt OOP runtime ship instrumented.
+    # - compiler-rt is enabled solely for orc_rt_<platform>, which the
+    #   OOP-JIT path needs; everything else under compiler-rt is OFF.
+    cmake_args = (
+        llvm_build.base_cmake_args(str(out_dir / "llvm-project"))
+        + [
+            '-DLLVM_ENABLE_PROJECTS=clang;compiler-rt',
+            '-DLLVM_USE_SANITIZER=Address;Undefined',
+            '-DCOMPILER_RT_BUILD_BUILTINS=OFF',
+            '-DCOMPILER_RT_BUILD_LIBFUZZER=OFF',
+            '-DCOMPILER_RT_BUILD_PROFILE=OFF',
+            '-DCOMPILER_RT_BUILD_MEMPROF=OFF',
+            '-DCOMPILER_RT_BUILD_SANITIZERS=OFF',
+            '-DCOMPILER_RT_BUILD_XRAY=OFF',
+            '-DCOMPILER_RT_BUILD_GWP_ASAN=OFF',
+            '-DCOMPILER_RT_BUILD_CTX_PROFILE=OFF',
+        ]
+        + llvm_build.cmake_extra()
+        + ["../llvm"]
+    )
     subprocess.run(cmake_args, check=True)
 
     llvm_build.quick_check_or_continue()

--- a/recipes/llvm-dry-run/build.py
+++ b/recipes/llvm-dry-run/build.py
@@ -40,22 +40,12 @@ def main() -> int:
     ncpus = os.environ["NCPUS"]
 
     os.chdir(work_dir)
-    if not (work_dir / "llvm-project" / ".git").is_dir():
-        subprocess.run(
-            ["git", "clone", "--depth=1", "-b", f"release/{version}.x",
-             "https://github.com/llvm/llvm-project.git"],
-            check=True,
-        )
-
-    os.chdir(work_dir / "llvm-project")
-    src_commit = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        check=True, capture_output=True, text=True,
-    ).stdout.strip()
-    github_env = os.environ.get("GITHUB_ENV", "")
-    if github_env:
-        with open(github_env, "a") as f:
-            f.write(f"SRC_COMMIT={src_commit}\n")
+    llvm_build.clone_shallow(
+        "https://github.com/llvm/llvm-project.git",
+        f"release/{version}.x",
+        work_dir / "llvm-project",
+    )
+    src_commit = llvm_build.record_src_commit(work_dir / "llvm-project")
 
     build_dir = work_dir / "llvm-project" / "build"
     build_dir.mkdir(exist_ok=True)
@@ -63,7 +53,10 @@ def main() -> int:
 
     # Minimal LLVM-only configure: no clang, no compiler-rt, just enough
     # for LLVMDemangle to build. host targets only — host;NVPTX would
-    # pull in extra deps we don't need here.
+    # pull in extra deps we don't need here. Deliberately not routed
+    # through base_cmake_args: the dry-run is intentionally narrower
+    # than real recipes (no LLVM_ENABLE_ASSERTIONS, no CLANG_*=OFF)
+    # since it never builds clang.
     cmake_args = [
         "cmake", "-G", "Ninja",
         f"-DCMAKE_INSTALL_PREFIX={out_dir / 'llvm-project'}",

--- a/recipes/llvm-root/build.py
+++ b/recipes/llvm-root/build.py
@@ -111,28 +111,9 @@ def main() -> int:
           flush=True)
 
     os.chdir(work_dir)
-    if not (work_dir / "cling" / ".git").is_dir():
-        subprocess.run(
-            ["git", "clone", "--depth=1", "-b", cling_branch,
-             cling_repo, "cling"],
-            check=True,
-        )
-    if not (work_dir / "llvm-project" / ".git").is_dir():
-        subprocess.run(
-            ["git", "clone", "--depth=1", "-b", llvm_branch,
-             llvm_repo, "llvm-project"],
-            check=True,
-        )
-
-    os.chdir(work_dir / "llvm-project")
-    src_commit = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        check=True, capture_output=True, text=True,
-    ).stdout.strip()
-    github_env = os.environ.get("GITHUB_ENV", "")
-    if github_env:
-        with open(github_env, "a") as f:
-            f.write(f"SRC_COMMIT={src_commit}\n")
+    llvm_build.clone_shallow(cling_repo, cling_branch, work_dir / "cling")
+    llvm_build.clone_shallow(llvm_repo, llvm_branch, work_dir / "llvm-project")
+    src_commit = llvm_build.record_src_commit(work_dir / "llvm-project")
 
     build_dir = work_dir / "llvm-project" / "build"
     build_dir.mkdir(exist_ok=True)
@@ -143,23 +124,16 @@ def main() -> int:
     # raw install(TARGETS) rather than LLVM's add_llvm_install_targets,
     # so its components have no install-X umbrellas — they're installed
     # separately below via cmake --install --component.
-    cmake_args = [
-        "cmake", "-G", "Ninja",
-        f"-DCMAKE_INSTALL_PREFIX={out_dir / 'llvm-project'}",
-        '-DLLVM_ENABLE_PROJECTS=clang',
-        '-DLLVM_EXTERNAL_PROJECTS=cling',
-        f'-DLLVM_EXTERNAL_CLING_SOURCE_DIR={work_dir / "cling"}',
-        '-DLLVM_TARGETS_TO_BUILD=host;NVPTX',
-        '-DCMAKE_BUILD_TYPE=Release',
-        '-DLLVM_ENABLE_ASSERTIONS=ON',
-        '-DCLANG_ENABLE_STATIC_ANALYZER=OFF',
-        '-DCLANG_ENABLE_ARCMT=OFF',
-        '-DCLANG_ENABLE_FORMAT=OFF',
-        '-DCLANG_ENABLE_BOOTSTRAP=OFF',
-        '-DLLVM_INCLUDE_BENCHMARKS=OFF',
-        '-DLLVM_INCLUDE_EXAMPLES=OFF',
-        '-DLLVM_INCLUDE_TESTS=OFF',
-    ] + llvm_build.cmake_extra() + ["../llvm"]
+    cmake_args = (
+        llvm_build.base_cmake_args(str(out_dir / "llvm-project"))
+        + [
+            '-DLLVM_ENABLE_PROJECTS=clang',
+            '-DLLVM_EXTERNAL_PROJECTS=cling',
+            f'-DLLVM_EXTERNAL_CLING_SOURCE_DIR={work_dir / "cling"}',
+        ]
+        + llvm_build.cmake_extra()
+        + ["../llvm"]
+    )
     subprocess.run(cmake_args, check=True)
 
     llvm_build.quick_check_or_continue()


### PR DESCRIPTION
Three near-identical blocks were duplicated across every recipe build.py:

  1. The 13-flag cmake configure prelude (CMAKE_BUILD_TYPE, LLVM_TARGETS_TO_BUILD, LLVM_ENABLE_ASSERTIONS, four CLANG_ENABLE_*=OFF, three LLVM_INCLUDE_*=OFF) — verbatim in llvm-asan and llvm-root.

  2. The depth-1 git clone with `if (path / ".git").is_dir(): skip` guard.

  3. The HEAD-sha capture + GITHUB_ENV append, with subtle differences (some recipes used capture_output, some redirected stdout).

A flag bump in any one place required edits in three; a regression caused by recipe drift would surface only at a real CI run.

Helpers added in actions/lib/llvm_build.py:

  base_cmake_args(install_prefix, targets="host;NVPTX")
    Returns the shared prelude. Recipes append flavor-specific flags
    (LLVM_USE_SANITIZER for asan, LLVM_EXTERNAL_PROJECTS=cling for
    root) plus cmake_extra() plus the source dir.

  clone_shallow(repo, branch, dest)
    Idempotent shallow clone — no-op when dest/.git already exists,
    so re-runs over a populated workspace (ccache + actions/cache)
    don't redundantly clone.

  record_src_commit(repo_path) -> str
    Returns the HEAD sha and appends SRC_COMMIT=<sha> to GITHUB_ENV
    when set. Centralizes the publish-recipe action contract.

llvm-asan and llvm-root rewired to call all three helpers; their final cmake flag sets are byte-identical to the pre-refactor lists (verified by set comparison). llvm-dry-run keeps its inline minimal config — it is intentionally narrower than real recipes (no assertions, no clang flags, no NVPTX target) and routing it through base_cmake_args would change behavior. clone_shallow and record_src_commit are NFC for dry-run too.

Tests in actions/lib/test_llvm_build.py:

  BaseCmakeArgsTests       Pin the contract: required flags present;
                           targets="host" override removes NVPTX.
  CloneShallowTests        Both branches: skip-when-cloned and
                           invoke-git-clone-when-missing.
  RecordSrcCommitTests     Both branches: GITHUB_ENV-set (file
                           appended) and GITHUB_ENV-unset (sha still
                           returned).

32 actions/lib tests pass; 31 across setup-recipe / publish-recipe / bin / unchanged. publish-dryrun's macOS legs continue to exercise the helpers end-to-end against a real LLVM tree.