### PR TITLE
[ci] Split workflow_dispatch out of publish-recipe.yml.

### DIFF
--- a/.github/actions/install-build-deps/action.yml
+++ b/.github/actions/install-build-deps/action.yml
@@ -1,9 +1,9 @@
 name: 'Install build dependencies'
 description: |
   Installs the host-side packages a recipe build needs (ninja, zstd,
-  ccache, rsync) and a Clang host toolchain. Pulled out of
-  publish-recipe.yml so the dispatch and push jobs share the same
-  install logic.
+  ccache, rsync) and a Clang host toolchain. Pulled out of the
+  publish-recipe / publish-recipe-dispatch / verify workflows so the
+  push, dispatch, and PR-time jobs share the same install logic.
 
   Why Clang: recipes that set LLVM_USE_SANITIZER (e.g. llvm-asan)
   rely on Clang-specific UBSan flags such as `-fno-sanitize=function`

--- a/.github/workflows/publish-recipe-dispatch.yml
+++ b/.github/workflows/publish-recipe-dispatch.yml
@@ -1,0 +1,48 @@
+name: publish-recipe-dispatch
+
+# Operator-driven publish of a single cell. Lives in its own workflow
+# file so it doesn't enumerate (and render as Skipped) on every push
+# to publish-recipe.yml's siblings; previous shape combined dispatch
+# + push triggers in one file, which made GitHub Actions list a
+# Skipped row with an unresolved `${{ inputs.* }}` name on every push.
+on:
+  workflow_dispatch:
+    inputs:
+      recipe:
+        type: choice
+        required: true
+        options:
+          - llvm-asan
+      version:
+        type: string
+        required: true
+        default: '22'
+      os:
+        type: choice
+        required: true
+        options:
+          - ubuntu-24.04
+        default: ubuntu-24.04
+      arch:
+        type: choice
+        required: true
+        options:
+          - x86_64
+        default: x86_64
+
+permissions:
+  contents: write   # release upload
+
+jobs:
+  publish-dispatch:
+    name: dispatch ${{ inputs.recipe }} v${{ inputs.version }} (${{ inputs.os }}/${{ inputs.arch }})
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-build-deps
+      - uses: ./actions/publish-recipe
+        with:
+          recipe: ${{ inputs.recipe }}
+          version: ${{ inputs.version }}
+          os: ${{ inputs.os }}
+          arch: ${{ inputs.arch }}

--- a/.github/workflows/publish-recipe.yml
+++ b/.github/workflows/publish-recipe.yml
@@ -1,40 +1,17 @@
 name: publish-recipe
 
-# Two trigger paths:
-#   workflow_dispatch — operator-driven, single cell from inputs.
-#   push to main      — auto-warm the recipe cache after a merge that
-#                       touched the recipe directory or actions. The
-#                       push matrix is derived from cells.yaml; a
-#                       preflight job reads cells.yaml, probes the
-#                       Releases cache for each cell, and emits *only*
-#                       the cells whose key is missing. So the
-#                       steady-state cost on a no-op push is one
-#                       preflight runner (~30 s) and zero per-cell
-#                       runners.
+# Auto-warm the recipe cache after a merge that touched the recipe
+# directory or actions. The matrix is derived from cells.yaml; a
+# preflight job reads cells.yaml, probes the Releases cache for each
+# cell, and emits *only* the cells whose key is missing. Steady-state
+# cost on a no-op push is one preflight runner (~30 s) and zero
+# per-cell runners.
+#
+# Operator-driven single-cell publishes live in publish-recipe-
+# dispatch.yml. Splitting the dispatch path out of this file removes
+# the Skipped phantom row that GHA would otherwise list on every push
+# (cross-event jobs gated by `if:` still enumerate in the run UI).
 on:
-  workflow_dispatch:
-    inputs:
-      recipe:
-        type: choice
-        required: true
-        options:
-          - llvm-asan
-      version:
-        type: string
-        required: true
-        default: '22'
-      os:
-        type: choice
-        required: true
-        options:
-          - ubuntu-24.04
-        default: ubuntu-24.04
-      arch:
-        type: choice
-        required: true
-        options:
-          - x86_64
-        default: x86_64
   push:
     branches: [main]
     paths:
@@ -48,22 +25,7 @@ permissions:
   contents: write   # release upload
 
 jobs:
-  publish-dispatch:
-    if: github.event_name == 'workflow_dispatch'
-    name: dispatch ${{ inputs.recipe }} v${{ inputs.version }} (${{ inputs.os }}/${{ inputs.arch }})
-    runs-on: ${{ inputs.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/install-build-deps
-      - uses: ./actions/publish-recipe
-        with:
-          recipe: ${{ inputs.recipe }}
-          version: ${{ inputs.version }}
-          os: ${{ inputs.os }}
-          arch: ${{ inputs.arch }}
-
   read-cells:
-    if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     outputs:
       # Matrix `include:` JSON. Empty when every cell is already
@@ -110,7 +72,7 @@ jobs:
 
   publish-on-push:
     needs: read-cells
-    if: github.event_name == 'push' && needs.read-cells.outputs.empty != 'true'
+    if: needs.read-cells.outputs.empty != 'true'
     name: ${{ matrix.recipe }} v${{ matrix.version }} (${{ matrix.os }}/${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     strategy:

--- a/README.md
+++ b/README.md
@@ -30,14 +30,18 @@ CI doesn't break before the cache is warmed.
 
 ## Producer side: `publish-recipe`
 
-The `publish-recipe.yml` workflow runs on:
+Two workflow files publish to the Releases cache, one per trigger:
 
-- **Push to `main`** that touches `recipes/`, `actions/setup-recipe/`,
-  `actions/publish-recipe/`, or the workflow file itself. Iterates a
-  matrix of cells and uploads any whose key isn't yet in the Releases
-  cache. `skip-if-exists` keeps the steady-state cost to one HEAD
-  probe per cell.
-- **Manual `workflow_dispatch`** for one-off cell warming.
+- **`publish-recipe.yml`** — fires on push to `main` that touches
+  `cells.yaml`, `recipes/`, `actions/setup-recipe/`,
+  `actions/publish-recipe/`, or the workflow file itself. Reads
+  `cells.yaml`, probes the Releases cache for each cell, and only
+  spawns per-cell runners for the cells whose key is missing. A
+  no-op push costs one preflight runner (~30 s) and zero per-cell
+  runners.
+- **`publish-recipe-dispatch.yml`** — manual `workflow_dispatch` for
+  one-off cell warming. Single cell from inputs (recipe / version /
+  os / arch).
 
 ## Local testing
 
@@ -102,18 +106,22 @@ are supported sinks).
 
 ```
 recipes/<name>/
-  recipe.yaml          metadata fields the manifest reads
-  build.sh             imperative build invoked by setup-recipe and publish-recipe
-  patches/             optional, applied to the source tree
+  recipe.yaml                   metadata fields the manifest reads
+  build.py                      imperative build invoked by setup-recipe and publish-recipe
+  patches/                      optional, applied to the source tree
 
 actions/
-  setup-recipe/        consumer-side: probe → download or build-on-miss
-  publish-recipe/      producer-side: build under ccache + tar/zstd + upload
-  lib/cache-io.sh      scheme-aware probe/download/upload helpers; sourced by both actions and the CLI
-  install-build-deps/  thin composite action installing host packages
+  setup-recipe/                 consumer-side: probe → download or build-on-miss
+  publish-recipe/               producer-side: build under ccache + tar/zstd + upload
+  lib/cache_io.py               scheme-aware probe/download/upload helpers; imported by both actions and the CLI
+  lib/llvm_build.py             shared LLVM-recipe scaffolding (env, cmake flags, install-distribution, smoke)
+  install-build-deps/           thin composite action installing host packages
 
-bin/recipe-cache       CLI wrapping the same scripts the actions use
+bin/recipe-cache                Python CLI wrapping the same modules the actions use
 
 .github/workflows/
-  publish-recipe.yml   workflow_dispatch + push-on-main publisher
+  publish-recipe.yml            push-on-main publisher (cells.yaml-driven)
+  publish-recipe-dispatch.yml   workflow_dispatch single-cell publisher
+  verify.yml                    PR-time sanity checks
+  prune-cache.yml               garbage-collect cells past caps.grace_days
 ```

--- a/actions/setup-recipe/action.yml
+++ b/actions/setup-recipe/action.yml
@@ -197,7 +197,7 @@ runs:
         {
           echo "::error::no prebuilt for key=${KEY}"
           echo "::error::populate by running:"
-          echo "::error::  gh workflow run publish-recipe.yml \\"
+          echo "::error::  gh workflow run publish-recipe-dispatch.yml \\"
           echo "::error::    -R compiler-research/ci-workflows \\"
           echo "::error::    -f recipe=${RECIPE} -f version=${VERSION} \\"
           echo "::error::    -f os=${OS} -f arch=${ARCH}"

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -19,7 +19,7 @@ upstream. So we end up rebuilding them.
 
 This repository caches those variants. The contract is small: a
 recipe is a directory under `recipes/` with two files
-(`recipe.yaml` for metadata, `build.sh` for the build), and the
+(`recipe.yaml` for metadata, `build.py` for the build), and the
 cache is a content-addressed store of tarballs keyed by a hash of
 that directory plus `(version, os, arch)`. Same inputs → same key
 → same artifact, regardless of which CI run produced it.
@@ -28,13 +28,13 @@ Nothing about the cache is magical. A cached recipe is a
 `<key>.tar.zst` plus a `<key>.manifest.json`, attached to a GitHub
 Release on this repository. `setup-recipe` is a thin Action that
 knows how to compute the key and HEAD-probe the asset.
-`publish-recipe` is its inverse — runs the recipe's `build.sh`,
+`publish-recipe` is its inverse — runs the recipe's `build.py`,
 tar/zstd's the result, uploads it.
 
 ## When the cache moves, and when it doesn't
 
 The recipe directory's content is the only knob. Edit
-`recipes/llvm-asan/build.sh` — the key changes for every cell that
+`recipes/llvm-asan/build.py` — the key changes for every cell that
 recipe produces, the next push to `main` rebuilds them, the cache
 repopulates. Bump the LLVM version in your client repo's matrix
 from `'22'` to `'23'` — the key changes (different `version`
@@ -89,17 +89,21 @@ HTTP cache. The same key works against all of them.
 
 ### Producing from this repository
 
-Two triggers feed `publish-recipe.yml`:
+Two workflow files publish to the Releases cache, one per trigger:
 
-- **Push to `main`** that touches `recipes/`,
-  `actions/setup-recipe/`, `actions/publish-recipe/`, or the
-  workflow file. Iterates the cell matrix automatically;
-  `skip-if-exists` keeps it idempotent so a no-op push costs one
-  HEAD probe per cell.
-- **Manual `workflow_dispatch`** for one-off cell warming —
-  retrying a flaky build, populating a cell that just got added.
+- **`publish-recipe.yml`** — push to `main` that touches
+  `cells.yaml`, `recipes/`, `actions/setup-recipe/`,
+  `actions/publish-recipe/`, or the workflow file itself. Reads
+  `cells.yaml`, probes the Releases cache for each cell, and only
+  spawns per-cell runners for the cells whose key is missing. A
+  no-op push costs one preflight runner (~30 s) and zero per-cell
+  runners.
+- **`publish-recipe-dispatch.yml`** — manual `workflow_dispatch`
+  for one-off cell warming: retrying a flaky build, populating a
+  cell that just got added. Single cell from inputs (recipe /
+  version / os / arch).
 
-You almost never invoke `publish-recipe` directly. Most of the
+You almost never invoke either workflow directly. Most of the
 time, when you change a recipe, the next push to `main` does the
 right thing.
 
@@ -107,7 +111,8 @@ right thing.
 
 This is the part worth knowing about even if you never push to
 ci-workflows. The `bin/recipe-cache` CLI is a self-contained
-shell script that wraps the same code paths as the actions.
+Python script that imports the same modules as the actions
+(`actions/lib/cache_io.py`, `actions/setup-recipe/compute_key.py`).
 Defaults the backend to `file://` in `~/.cache/recipe-cache`, and
 exposes the same operations:
 
@@ -170,7 +175,7 @@ machine, also invisible. Cross-machine cache sharing is the case
 that doesn't work today; we'll revisit if it actually matters.
 
 **The first miss after a flag bump pays the build cost.** When
-you edit `build.sh`, the key changes for every cell that uses
+you edit `build.py`, the key changes for every cell that uses
 that recipe. The push-to-main triggers `publish-recipe` to refill
 them all in parallel — typically `~30 min` end-to-end, ccache
 makes most of it cheap. Until that finishes, downstream PRs that
@@ -191,44 +196,53 @@ publish for — cmake flag differences, ninja target name
 differences, available libraries. `cells.yaml` enumerates which
 combinations are first-class; every cell expansion is a manual
 integration step done by adding a row to `cells.yaml` and either
-dispatching `publish-recipe` once for that cell or letting the
-push trigger pick it up.
+dispatching `publish-recipe-dispatch.yml` once for that cell or
+letting the push trigger pick it up.
 
 ## Adding a new recipe
 
 A recipe is a directory under `recipes/`. Two files:
 
-- `recipe.yaml` — metadata read by `build-manifest.sh`. Keep it
+- `recipe.yaml` — metadata read by `build_manifest.py`. Keep it
   minimal. Today only `recipe`, `description`, and `source.{repo,
   branch_template}` are read; the verify workflow's
   `recipe-yaml-no-dead-fields` check enforces this.
-- `build.sh` — the imperative build. Receives `RECIPE_VERSION`,
+- `build.py` — the imperative build. Receives `RECIPE_VERSION`,
   `WORK_DIR`, `OUT_DIR` env vars; writes its result to
   `$OUT_DIR/llvm-project/` (or whatever subdirectory tree your
   recipe wants — `setup-recipe` and the CLI both surface the
-  tarball root verbatim).
+  tarball root verbatim). Build scripts typically import
+  `actions/lib/llvm_build.py` for shared scaffolding (env
+  validation, cmake flags, install-distribution, smoke).
 
 Verify locally with `bin/recipe-cache build` before pushing.
 The verify workflow will catch the rest at PR time:
 
 - `actionlint` over your edits to action / workflow files.
-- `compute-key-parity` — your new key is stable across invocation
-  contexts.
-- `manifest-schema` — emitting valid JSON.
-- `tar-zstd-round-trip` — the publish/consume pipelines round-trip
-  bytewise.
-- `end-to-end-fixture` — the CLI builds + caches + extracts a
-  synthetic recipe.
+- `python-unit-tests` — cross-OS unit tests for every Python
+  module in `actions/lib/`, `actions/setup-recipe/`,
+  `actions/publish-recipe/`, and `bin/`.
+- `recipe-yaml-no-dead-fields` — every top-level key in
+  `recipe.yaml` is read by something.
+- `cells-yaml-integrity` — schema + duplicate-cell + recipe-
+  existence checks on `cells.yaml`.
+- `recipe-smoke` — `RECIPE_QUICK_CHECK=1 build.py` for every
+  cells.yaml entry on its native OS (cmake configure +
+  LLVMDemangle compile).
+- `publish-dryrun` — end-to-end dry run of the
+  `actions/publish-recipe` action against the `llvm-dry-run`
+  fixture with `cache-base: file://`, exercising every shared
+  codepath a real publish runs.
 
-When the recipe lands, add a row to `publish-recipe.yml`'s
-push-trigger matrix so `main` warms it on every relevant push.
+When the recipe lands, add a row to `cells.yaml` so `main` warms
+it on every relevant push.
 
 ## Adding a new cell to an existing recipe
 
-For now, edit the matrix in `publish-recipe.yml`. Add a row
-matching the new (version, os, arch) tuple. The push trigger
-takes care of the build on the next merge that touches the
-recipe directory or the workflow file.
+Edit `cells.yaml`. Add a row matching the new (version, os, arch)
+tuple. `publish-recipe.yml`'s preflight job reads `cells.yaml`
+directly, so the next push to `main` that touches the recipe
+directory or the workflow file picks up the new cell automatically.
 
 ## Bumping the LLVM version
 


### PR DESCRIPTION
publish-recipe.yml combined two trigger paths in one file: workflow_dispatch (operator-driven single-cell publish) and push to main (auto-warm cache from cells.yaml). Each job was gated with `if: github.event_name == ...` so only the matching trigger's jobs ran.

GitHub Actions still enumerates every job in a workflow on every trigger, evaluates each `if:`, and lists the falsy ones in the run UI as Skipped. The workflow_dispatch job's `name:` template uses `${{ inputs.recipe }}` etc., which are unset on push events, so the unresolved template renders verbatim:

    publish-recipe / dispatch ${{ inputs.recipe }} v${{ inputs.version }}
    (${{ inputs.os }}/${{ inputs.arch }})  Skipped

A phantom row on every push, easy to misread as a real failure.

Move the workflow_dispatch path into its own
.github/workflows/publish-recipe-dispatch.yml. The new file has only the workflow_dispatch trigger and only the publish-dispatch job; no cross-event gating remains. publish-recipe.yml is now strictly push-only, with the per-job `if: github.event_name == 'push'` gates dropped (the workflow itself is the gate).

Both paths invoke the same actions/publish-recipe composite action with identical inputs, so behaviour is unchanged for callers of the action. PR-time test coverage is unchanged: `verify.yml`'s `pull_request: paths: ['.github/workflows/**']` filter matches both workflow files; `lint-actions` runs actionlint on each; the `publish-dryrun` matrix exercises the composite action, not the workflow file.

Consumer references updated to match:

  actions/setup-recipe/action.yml
    The cache-miss error message printed to operators told them to
    run `gh workflow run publish-recipe.yml ...`. Post-split that
    command fails (no workflow_dispatch on publish-recipe.yml).
    Point at publish-recipe-dispatch.yml.

  .github/actions/install-build-deps/action.yml
    Header comment updated: the install action is now shared by the
    push, dispatch, and verify workflows, not just publish-recipe's
    dispatch + push jobs.

  README.md
    "Producer side" section split into two bullets, one per workflow
    file. Layout section updated for both the split and the Python
    migration (#24): build.sh -> build.py, cache-io.sh -> cache_io.py,
    new entry for llvm_build.py, new entries for publish-recipe-
    dispatch.yml / verify.yml / prune-cache.yml.

  docs/developer-guide.md
    "Producing from this repository" section split. "Adding a new
    recipe" section's verify-workflow checklist replaced with the
    actual current jobs (python-unit-tests, recipe-yaml-no-dead-
    fields, cells-yaml-integrity, recipe-smoke, publish-dryrun) --
    the previous list cited four jobs (compute-key-parity,
    manifest-schema, tar-zstd-round-trip, end-to-end-fixture) that
    all dropped during the Python migration. "Adding a new cell"
    section pointed at editing publish-recipe.yml's matrix; the
    matrix moved to cells.yaml in a prior commit, doc updated.
    Stale build.sh / build-manifest.sh / shell-script references
    swept across the file.