### PR TITLE
[ci] Add actions/wake-on-lan: shared self-hosted-runner wake action.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ recipes/<name>/
 actions/
   setup-recipe/        consumer-side: probe → download or build-on-miss
   publish-recipe/      producer-side: build under ccache + tar/zstd + upload
+  wake-on-lan/         send a magic packet to wake a self-hosted runner; no-op under act
   lib/cache-io.sh      scheme-aware probe/download/upload helpers; sourced by both actions and the CLI
   install-build-deps/  thin composite action installing host packages
 

--- a/actions/wake-on-lan/action.yml
+++ b/actions/wake-on-lan/action.yml
@@ -1,0 +1,178 @@
+name: 'Wake-on-LAN'
+description: |
+  Send a magic packet to wake a self-hosted runner, then wait for it
+  to come online (TCP connect probe).
+
+  Every step is gated on `!env.ACT`, so under act (env.ACT=true) the
+  whole action is a no-op success. Consuming workflows do NOT need
+  their own env.ACT guard on the wake job; the dependent build
+  job's normal `needs:` chain is satisfied either way:
+
+      jobs:
+        wake-runner:
+          # The job's runs-on must still resolve under act; conditional
+          # on env.ACT to fall back to a hosted runner image act knows
+          # how to map.
+          runs-on: ${{ env.ACT && 'ubuntu-latest' || fromJSON('["self-hosted", "spotter"]') }}
+          steps:
+            - uses: compiler-research/ci-workflows/actions/wake-on-lan@<sha>
+              with:
+                mac: ${{ secrets.DELL_MAC }}
+                target-host: ${{ vars.DELL_HOST }}
+
+        build:
+          needs: wake-runner
+          runs-on: [self-hosted, dell]
+          ...
+
+inputs:
+  mac:
+    required: true
+    description: |
+      MAC address (colons or dashes; case-insensitive). Typically a
+      repo secret -- a leaked MAC is mildly annoying via DDoS.
+  target-host:
+    required: false
+    default: ''
+    description: |
+      Host to TCP-probe before sending the packet (skip if already
+      reachable) and after sending (wait until reachable). When the
+      runner has no `ping` in its environment (common in stripped-
+      down GHA spotter images), TCP connect is the portable
+      readiness check.
+  target-port:
+    required: false
+    default: '22'
+    description: |
+      TCP port on target-host to probe. Default 22 -- SSH on; runner
+      ready to register itself with GitHub. Override for non-SSH
+      runners.
+  broadcast:
+    required: false
+    default: ''
+    description: |
+      Broadcast address for the magic packet. When empty, derived
+      from target-host by replacing the last octet with 255 (e.g.
+      192.168.100.30 -> 192.168.100.255). Override when the LAN
+      topology needs something else.
+  port:
+    required: false
+    default: '9'
+    description: |
+      UDP port for the magic packet. WoL spec is 9; some old
+      consumer routers default to 7.
+  timeout-seconds:
+    required: false
+    default: '240'
+    description: |
+      How long to wait for target-host to start accepting TCP
+      connections after the magic packet. Default 4 minutes,
+      checking every 10 s.
+
+runs:
+  using: composite
+  steps:
+    - name: Mask sensitive values in logs
+      if: ${{ !env.ACT }}
+      shell: bash
+      env:
+        MAC: ${{ inputs.mac }}
+        HOST: ${{ inputs.target-host }}
+        BCAST: ${{ inputs.broadcast }}
+      run: |
+        # Reduces the post-incident log-leak surface; MAC/IP are
+        # internal-network identifiers and downstream consumers
+        # may share workflow logs publicly.
+        [ -n "$MAC" ]   && echo "::add-mask::$MAC"
+        [ -n "$HOST" ]  && echo "::add-mask::$HOST"
+        [ -n "$BCAST" ] && echo "::add-mask::$BCAST"
+
+    - name: Skip if target already responsive
+      if: ${{ !env.ACT && inputs.target-host != '' }}
+      id: precheck
+      shell: bash
+      env:
+        HOST: ${{ inputs.target-host }}
+        PORT: ${{ inputs.target-port }}
+      run: |
+        # `bash /dev/tcp` is portable across GHA images that lack
+        # `nc` or `ping`. Wrapped in `timeout 1` so a black-holed
+        # IP doesn't stall the precheck for the full kernel SYN
+        # retransmit window.
+        if timeout 1 bash -c "cat < /dev/null > /dev/tcp/$HOST/$PORT" 2>/dev/null; then
+          echo "::notice title=Wake-on-LAN::target already responsive on port $PORT; skipping magic packet"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Send magic packet
+      if: ${{ !env.ACT && steps.precheck.outputs.skip != 'true' }}
+      shell: bash
+      env:
+        MAC: ${{ inputs.mac }}
+        HOST: ${{ inputs.target-host }}
+        BCAST_INPUT: ${{ inputs.broadcast }}
+        WOL_PORT: ${{ inputs.port }}
+      run: |
+        # Pure-stdlib python: every GHA hosted runner has python3 and
+        # we don't want to apt-install wakeonlan/etherwake just for
+        # six bytes of header + sixteen mac repeats. Same wire format
+        # as RFC-defined magic packets (0xff x6 + MAC x16 = 102 bytes).
+        # No sudo needed -- UDP sendto on an arbitrary destination
+        # port doesn't require privileges (only binding to a privileged
+        # local port would, and we don't bind).
+        python3 - <<'PYEOF'
+        import os
+        import socket
+        import sys
+
+        raw = os.environ["MAC"].replace(":", "").replace("-", "").lower()
+        if len(raw) != 12 or not all(c in "0123456789abcdef" for c in raw):
+            sys.exit(f"wake-on-lan: invalid MAC: {os.environ['MAC']!r}")
+        mac_bytes = bytes.fromhex(raw)
+        packet = b"\xff" * 6 + mac_bytes * 16
+
+        broadcast = os.environ.get("BCAST_INPUT", "").strip()
+        if not broadcast:
+            host = os.environ.get("HOST", "").strip()
+            if host and "." in host and host.replace(".", "").isdigit():
+                # Derive default broadcast from IPv4 (a.b.c.d -> a.b.c.255).
+                octets = host.split(".")
+                if len(octets) == 4:
+                    broadcast = ".".join(octets[:3] + ["255"])
+            if not broadcast:
+                broadcast = "255.255.255.255"
+
+        port = int(os.environ["WOL_PORT"])
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            s.sendto(packet, (broadcast, port))
+        print(f"wake-on-lan: sent magic packet "
+              f"via {broadcast}:{port}")
+        PYEOF
+
+    - name: Wait for target online
+      if: ${{ !env.ACT && steps.precheck.outputs.skip != 'true' && inputs.target-host != '' }}
+      shell: bash
+      env:
+        HOST: ${{ inputs.target-host }}
+        PORT: ${{ inputs.target-port }}
+        TIMEOUT: ${{ inputs.timeout-seconds }}
+      run: |
+        set -uo pipefail
+        deadline=$((SECONDS + TIMEOUT))
+        echo "wake-on-lan: waiting up to ${TIMEOUT}s for TCP/$PORT on target ..."
+        while [ "$SECONDS" -lt "$deadline" ]; do
+          if timeout 1 bash -c "cat < /dev/null > /dev/tcp/$HOST/$PORT" 2>/dev/null; then
+            echo "::notice title=Wake-on-LAN::target accepting TCP/$PORT after $((SECONDS))s"
+            exit 0
+          fi
+          sleep 10
+        done
+        echo "::error title=Wake-on-LAN::target did not accept TCP/$PORT within ${TIMEOUT}s"
+        exit 1
+
+    - name: Note skipped under act
+      if: ${{ env.ACT }}
+      shell: bash
+      run: |
+        echo "::notice title=Wake-on-LAN::skipped under act (\$ACT=true)"

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -240,6 +240,58 @@ cell gets warmed. The previous version's cell stays cached until
 either it ages past `caps.grace_days` or you remove it from
 `cells.yaml`, at which point `prune-cache` drops it.
 
+## Waking a self-hosted runner before a job
+
+If your matrix targets a `[self-hosted, ...]` runner that isn't
+always on (a Dell box on someone's desk, a workstation that
+sleeps), `actions/wake-on-lan` sends the magic packet from a
+spotter runner and waits for SSH (TCP port 22) on the target:
+
+```yaml
+jobs:
+  wake-runner:
+    name: Activate self-host infrastructure
+    # The spotter runner shares a LAN with the dell so the magic
+    # packet reaches it via subnet broadcast. Conditional runs-on
+    # falls back to ubuntu-latest under act so the job has a runner
+    # act knows how to map.
+    runs-on: ${{ env.ACT && 'ubuntu-latest' || fromJSON('["self-hosted", "spotter"]') }}
+    steps:
+      - uses: compiler-research/ci-workflows/actions/wake-on-lan@<sha>
+        with:
+          mac: ${{ secrets.DELL_MAC }}
+          target-host: ${{ vars.DELL_IP }}
+          # target-port: 22             # default; SSH = "ready"
+          # broadcast: 192.168.100.255  # default derived from IPv4 target
+          # port: 9                     # UDP WoL port; some old routers use 7
+          # timeout-seconds: 240        # 4 minutes, checking every 10 s
+
+  build:
+    needs: wake-runner
+    runs-on: [self-hosted, dell]
+    ...
+```
+
+The action's steps are gated on `!env.ACT`, so under act
+(`bin/repro` or plain `act`) the action runs to no-op success and
+`build`'s `needs:` chain is satisfied without any extra
+`if: success() || env.ACT` boilerplate in the consuming workflow.
+
+What the action does:
+- Masks MAC/IP/broadcast in the run log (`::add-mask::`).
+- Pre-checks the target via `bash /dev/tcp/$host/$port` -- skips
+  the magic packet if the host is already responsive on the
+  readiness port.
+- Sends the magic packet via pure-stdlib Python UDP broadcast
+  (no `apt-get install wakeonlan`, no `sudo` -- UDP sendto
+  doesn't require privileges).
+- Waits for the readiness port to start accepting TCP connects.
+
+`bash /dev/tcp` is the portable readiness probe across GHA images
+that lack `nc` or `ping`. Default port 22 corresponds to SSH being
+up, which is the strongest signal that the runner is ready to
+register itself with GitHub.
+
 ## Inspecting a published asset
 
 The manifest sibling tells you what produced any given tarball:


### PR DESCRIPTION
Multiple downstream repos (CppInterOp's main.yml today, others likely later) start a self-hosted runner via wake-on-LAN before the build job dispatches. Each one re-implements the magic-packet send + ping-wait + env.ACT skip locally. Hoist it into a single composite action.

actions/wake-on-lan/action.yml. Inputs:

  mac (required)            MAC address (colons or dashes)
  broadcast (default ...255) broadcast address; subnet broadcasts
                            for routers that don't forward .255.255
  port (default 9)          UDP port; some old routers want 7
  ping-host (optional)      wait for ping <host> after the magic
                            packet, signalling the runner is up
  timeout-seconds (300)     ping-wait deadline

Implementation:

- Magic packet generator is pure-stdlib Python. Wire format per the WoL spec (0xff x6 + MAC x16 = 102 bytes), sent via UDP broadcast. No `apt-get install wakeonlan` -- works on any GHA hosted runner that has python3 (all of them).
- Ping-wait is a bash loop calling `ping -c1 -W2 <host>` every 5 seconds until the deadline.

Every step is gated on `!env.ACT`. Under act (act sets env.ACT=true automatically) the action runs to no-op success. That's the load-bearing piece: consuming workflows don't need their own `if: !env.ACT` on the wake job AND `if: success() || env.ACT` on the dependent build job. The build's normal `needs:` chain stays satisfied either way:

    jobs:
      wake-runner:
        runs-on: ubuntu-latest
        steps:
          - uses: compiler-research/ci-workflows/actions/wake-on-lan@<sha>
            with:
              mac: ${{ secrets.DELL_RUNNER_MAC }}
              ping-host: ${{ vars.DELL_RUNNER_HOST }}

      build:
        needs: wake-runner
        runs-on: [self-hosted, dell]
        ...

Production GHA: wake-runner sends the packet, waits for the host, then build dispatches on the woken self-hosted runner. Under act: wake-runner is a no-op success; build runs on whatever act maps [self-hosted, dell] to (typically the user passes
-P self-hosted=-self-hosted to skip it for purely-local repro).

Documentation:
  README.md             actions/ index gains a wake-on-lan line.
  docs/developer-guide.md
                        new "Waking a self-hosted runner before a
                        job" section between "Bumping the LLVM
                        version" and "Inspecting a published asset",
                        with a copy-pasteable workflow snippet and
                        a note on the env.ACT gating.