### PR TITLE
[ci] Strip act handling from wake-on-lan action.

### DIFF
--- a/actions/wake-on-lan/action.yml
+++ b/actions/wake-on-lan/action.yml
@@ -1,29 +1,7 @@
 name: 'Wake-on-LAN'
-description: |
-  Send a magic packet to wake a self-hosted runner, then wait for it
-  to come online (TCP connect probe).
-
-  Every step is gated on `!env.ACT`, so under act (env.ACT=true) the
-  whole action is a no-op success. Consuming workflows do NOT need
-  their own env.ACT guard on the wake job; the dependent build
-  job's normal `needs:` chain is satisfied either way:
-
-      jobs:
-        wake-runner:
-          # The job's runs-on must still resolve under act; conditional
-          # on env.ACT to fall back to a hosted runner image act knows
-          # how to map.
-          runs-on: ${{ env.ACT && 'ubuntu-latest' || fromJSON('["self-hosted", "spotter"]') }}
-          steps:
-            - uses: compiler-research/ci-workflows/actions/wake-on-lan@<sha>
-              with:
-                mac: ${{ secrets.DELL_MAC }}
-                target-host: ${{ vars.DELL_HOST }}
-
-        build:
-          needs: wake-runner
-          runs-on: [self-hosted, dell]
-          ...
+description: >-
+  Send a magic packet to wake a self-hosted runner, then wait for
+  it to come online (TCP connect probe).
 
 inputs:
   mac:
@@ -73,7 +51,6 @@ runs:
   using: composite
   steps:
     - name: Mask sensitive values in logs
-      if: ${{ !env.ACT }}
       shell: bash
       env:
         MAC: ${{ inputs.mac }}
@@ -88,7 +65,7 @@ runs:
         [ -n "$BCAST" ] && echo "::add-mask::$BCAST"
 
     - name: Skip if target already responsive
-      if: ${{ !env.ACT && inputs.target-host != '' }}
+      if: ${{ inputs.target-host != '' }}
       id: precheck
       shell: bash
       env:
@@ -105,7 +82,7 @@ runs:
         fi
 
     - name: Send magic packet
-      if: ${{ !env.ACT && steps.precheck.outputs.skip != 'true' }}
+      if: ${{ steps.precheck.outputs.skip != 'true' }}
       shell: bash
       env:
         MAC: ${{ inputs.mac }}
@@ -151,7 +128,7 @@ runs:
         PYEOF
 
     - name: Wait for target online
-      if: ${{ !env.ACT && steps.precheck.outputs.skip != 'true' && inputs.target-host != '' }}
+      if: ${{ steps.precheck.outputs.skip != 'true' && inputs.target-host != '' }}
       shell: bash
       env:
         HOST: ${{ inputs.target-host }}
@@ -170,9 +147,3 @@ runs:
         done
         echo "::error title=Wake-on-LAN::target did not accept TCP/$PORT within ${TIMEOUT}s"
         exit 1
-
-    - name: Note skipped under act
-      if: ${{ env.ACT }}
-      shell: bash
-      run: |
-        echo "::notice title=Wake-on-LAN::skipped under act (\$ACT=true)"

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -250,17 +250,14 @@ spotter runner and waits for SSH (TCP port 22) on the target:
 ```yaml
 jobs:
   wake-runner:
-    name: Activate self-host infrastructure
-    # The spotter runner shares a LAN with the dell so the magic
-    # packet reaches it via subnet broadcast. Conditional runs-on
-    # falls back to ubuntu-latest under act so the job has a runner
-    # act knows how to map.
-    runs-on: ${{ env.ACT && 'ubuntu-latest' || fromJSON('["self-hosted", "spotter"]') }}
+    # Spotter runner shares a LAN with the dell so the magic packet
+    # reaches it via subnet broadcast.
+    runs-on: [self-hosted, spotter]
     steps:
       - uses: compiler-research/ci-workflows/actions/wake-on-lan@<sha>
         with:
-          mac: ${{ secrets.DELL_MAC }}
-          target-host: ${{ vars.DELL_IP }}
+          mac: <hardware address>
+          target-host: <ip address>
           # target-port: 22             # default; SSH = "ready"
           # broadcast: 192.168.100.255  # default derived from IPv4 target
           # port: 9                     # UDP WoL port; some old routers use 7
@@ -272,10 +269,10 @@ jobs:
     ...
 ```
 
-The action's steps are gated on `!env.ACT`, so under act
-(`bin/repro` or plain `act`) the action runs to no-op success and
-`build`'s `needs:` chain is satisfied without any extra
-`if: success() || env.ACT` boilerplate in the consuming workflow.
+The action makes no assumptions about act -- it just sends the
+packet. Consumers whose self-hosted runner is unreachable from act
+(the typical case) don't need any guarding; act-only repro paths
+target hosted-runner jobs that don't need the wake at all.
 
 What the action does:
 - Masks MAC/IP/broadcast in the run log (`::add-mask::`).


### PR DESCRIPTION
GHA evaluates `${{ ... }}` inside an action's `description:`, which broke composite-action loading on the consumer end:

  Unrecognized named-value: 'env'. Located at position 1 within
  expression: env.ACT && 'ubuntu-latest' || fromJSON(...)

That expression was a yaml example in the docstring -- but the deeper issue is that the action had no business knowing about act at all. Drop the `${{ ... }}` from the description, the `if: !env.ACT` gate from each composite step, and the terminal "Note skipped under act" step. Consumers handle act-skipping at the workflow level when needed.