### PR TITLE
[ci] Fix mask step exit status when broadcast is empty.

### DIFF
--- a/actions/wake-on-lan/action.yml
+++ b/actions/wake-on-lan/action.yml
@@ -59,10 +59,12 @@ runs:
       run: |
         # Reduces the post-incident log-leak surface; MAC/IP are
         # internal-network identifiers and downstream consumers
-        # may share workflow logs publicly.
-        [ -n "$MAC" ]   && echo "::add-mask::$MAC"
-        [ -n "$HOST" ]  && echo "::add-mask::$HOST"
-        [ -n "$BCAST" ] && echo "::add-mask::$BCAST"
+        # may share workflow logs publicly. `if`-blocks (not
+        # `[ ] && echo` chains) so a trailing empty input doesn't
+        # leave the script's last command with a non-zero exit.
+        if [ -n "$MAC" ];   then echo "::add-mask::$MAC";   fi
+        if [ -n "$HOST" ];  then echo "::add-mask::$HOST";  fi
+        if [ -n "$BCAST" ]; then echo "::add-mask::$BCAST"; fi
 
     - name: Skip if target already responsive
       if: ${{ inputs.target-host != '' }}


### PR DESCRIPTION
`[ -n "$VAR" ] && echo ...` is exempt from `set -e` (commands in a && list don't trigger it), but the script's exit code is still the last command's. With `BCAST=''` -- the default when consumers don't pass `broadcast:` -- the trailing `[ -n "$BCAST" ] && ...` short-circuits, the script exits 1, and GHA marks the step failed. Switch the masking lines to `if`-blocks so each line's exit status is benign.