### PR TITLE
[ci] Install llvm-tblgen and clang-tblgen with the distribution.

### DIFF
--- a/actions/lib/llvm_build.py
+++ b/actions/lib/llvm_build.py
@@ -164,6 +164,12 @@ def install_distribution(extras: Optional[Sequence[str]] = None) -> None:
         "clang", "clang-headers", "clang-cmake-exports",
         "clang-resource-headers", "clangInterpreter",
         "cmake-exports", "llvm-headers", "llvm-config",
+        # tablegen binaries: LLVMConfig.cmake's TableGen.cmake exports
+        # LLVM_TABLEGEN_EXE pointing at bin/llvm-tblgen, and downstream
+        # consumers that re-invoke `tablegen()` (ROOT's bundled cling,
+        # any project that ships .td files and wants to find the host
+        # tool through the installed LLVM) need the binaries on disk.
+        "llvm-tblgen", "clang-tblgen",
     ]
     lib = Path("lib")
     if lib.is_dir():


### PR DESCRIPTION
`LLVMConfig.cmake`'s TableGen.cmake exports `LLVM_TABLEGEN_EXE` pointing at `<prefix>/bin/llvm-tblgen`. Consumers that re-invoke the `tablegen()` macro against the installed LLVM (ROOT's bundled cling does, in `interpreter/cling/include/cling/Interpreter/ CMakeLists.txt`) fail at configure with `LLVM_TABLEGEN_EXE not set` because the binary is absent from the install tree -- the recipe's distribution list didn't include the tablegen tools.

Add `llvm-tblgen` and `clang-tblgen` to the umbrella dist list so every recipe consuming `install_distribution()` ships them. Tests (`test_walks_lib_directory`, `test_extras_appended`) only assert membership of specific umbrellas, not the full list, so they pass unchanged.