### PR TITLE
[ci] prune-cache: add force input to evict orphans inside grace.

### DIFF
--- a/.github/workflows/prune-cache.yml
+++ b/.github/workflows/prune-cache.yml
@@ -10,7 +10,9 @@ name: prune-cache
 #   2. List existing assets on the rolling Release.
 #   3. orphans = existing − expected.
 #   4. Drop orphans whose age > caps.grace_days (so in-flight PRs that
-#      reference an old key aren't broken mid-run by the prune).
+#      reference an old key aren't broken mid-run by the prune). On a
+#      manual run with force=true, grace is treated as zero and every
+#      orphan drops immediately.
 #   5. Tally remaining storage; warn over caps.soft_gb, fail over
 #      caps.hard_gb.
 #
@@ -19,7 +21,9 @@ name: prune-cache
 # keys; the old assets become orphans. A PR opened a day before the
 # edit and tested a day after still references the old key and pulls
 # the old asset. Holding orphans for `grace_days` (default 7) lets
-# those in-flight PRs finish before the asset disappears.
+# those in-flight PRs finish before the asset disappears. The `force`
+# input bypasses this — only use it when intentionally evicting keys
+# even at the cost of breaking in-flight builds.
 on:
   workflow_run:
     workflows: [publish-recipe]
@@ -28,6 +32,11 @@ on:
     # Weekly watchdog. UTC; pick a low-traffic time.
     - cron: '17 4 * * 1'
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force-drop every orphan now (bypass caps.grace_days). Use only when intentionally evicting in-flight keys.'
+        type: boolean
+        default: false
 
 permissions:
   contents: write   # delete release assets
@@ -39,6 +48,11 @@ jobs:
     # always run.
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
+    env:
+      # Only the manual workflow_dispatch path can set force=true. The
+      # grace check is bypassed for that single run; the schedule and
+      # workflow_run triggers always honour caps.grace_days.
+      FORCE: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
     steps:
       - uses: actions/checkout@v4
 
@@ -92,6 +106,10 @@ jobs:
             exit 0
           fi
           grace_days=$(yq '.caps.grace_days' cells.yaml)
+          if [ "$FORCE" = 'true' ]; then
+            echo "::notice::force=true: bypassing grace period (was ${grace_days} days)"
+            grace_days=0
+          fi
           now=$(date -u +%s)
           # For every .tar.zst whose key (filename minus .tar.zst)
           # isn't in /tmp/expected_keys.txt and whose age exceeds

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -238,7 +238,13 @@ the bump, the recipe builds inline (`build-on-miss: true` does
 the right thing); on the next push to ci-workflows main the new
 cell gets warmed. The previous version's cell stays cached until
 either it ages past `caps.grace_days` or you remove it from
-`cells.yaml`, at which point `prune-cache` drops it.
+`cells.yaml`, at which point `prune-cache` drops it. To evict
+orphans before they age out — e.g. when storage is over `hard_gb`
+and the grace window is holding too much back — dispatch
+`prune-cache` manually with the `force` input enabled; this
+bypasses `grace_days` for that one run and may break in-flight PRs
+that referenced the dropped keys (they fall back to building from
+source).
 
 ## Waking a self-hosted runner before a job
 


### PR DESCRIPTION
The scheduled prune holds orphans for caps.grace_days so in-flight PRs don't break mid-run. When storage approaches caps.hard_gb and a recent batch of orphans is stuck inside the grace window, the weekly run can't claw enough back, and there was no manual escape.

Add a workflow_dispatch boolean input that, when set, treats the grace window as zero for that one run. Only the manual path can flip it; schedule and workflow_run triggers always honour caps.grace_days. In-flight PRs that referenced the dropped keys fall back to building from source on miss, the same behaviour setup-recipe already documents.