### PR TITLE
[ci] publish-recipe: drop templated name from event-gated jobs.

### DIFF
--- a/.github/workflows/publish-recipe.yml
+++ b/.github/workflows/publish-recipe.yml
@@ -67,7 +67,11 @@ permissions:
 jobs:
   publish-dispatch:
     if: github.event_name == 'workflow_dispatch'
-    name: dispatch ${{ inputs.recipe }} v${{ inputs.version }} (${{ inputs.os }}/${{ inputs.arch }})
+    # No templated `name:`. When the gate is false (push / pull_request),
+    # GitHub still enumerates the job and renders any `${{ inputs.* }}`
+    # in `name:` literally, producing a phantom Skipped row that reads
+    # like a real failure. Letting GHA fall back to the job id keeps the
+    # Skipped row clean.
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v4
@@ -128,7 +132,9 @@ jobs:
   publish-on-push:
     needs: read-cells
     if: github.event_name == 'push' && needs.read-cells.outputs.empty != 'true'
-    name: ${{ matrix.recipe }} v${{ matrix.version }} (${{ matrix.os }}/${{ matrix.arch }})
+    # No templated `name:`. Same reason as publish-dispatch: on the
+    # pull_request trigger this job is skipped, and a `${{ matrix.* }}`
+    # template in `name:` would render unresolved on the Skipped row.
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -185,7 +191,9 @@ jobs:
   validate-on-pr:
     needs: validate-pr-cells
     if: github.event_name == 'pull_request' && needs.validate-pr-cells.outputs.empty != 'true'
-    name: validate ${{ matrix.recipe }} v${{ matrix.version }} (${{ matrix.os }}/${{ matrix.arch }})
+    # No templated `name:`. Same reason as publish-on-push: on the push
+    # trigger this job is skipped, and a `${{ matrix.* }}` template in
+    # `name:` would render unresolved on the Skipped row.
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
publish-recipe.yml has three jobs gated by trigger: publish-dispatch (workflow_dispatch), publish-on-push (push), and validate-on-pr (pull_request). Each had a `name:` field templated on `${{ inputs.* }}` or `${{ matrix.* }}`.

GitHub Actions enumerates every job in the workflow on every trigger, evaluates each `if:`, and lists the falsy ones in the run UI as Skipped. When the gate is false the templated `name:` renders verbatim, so a push run shows phantom Skipped rows like

    dispatch ${{ inputs.recipe }} v${{ inputs.version }} ...
    validate ${{ matrix.recipe }} v${{ matrix.version }} ...

— easy to misread as a real failure. Verified on a recent push run (compiler-research/ci-workflows actions run 25211664908): two phantom rows, both with unresolved templates.

Drop the `name:` field from each gated job so GHA falls back to the job id for the display name. On the active trigger, matrix jobs auto-expand to `<job-id> (<matrix values>)` per cell, which is at least as informative as the old templated form. On the inactive trigger, the Skipped row is just the job id — no template to render unresolved.