### PR TITLE
[ci] setup-recipe: make recipe checkout idempotent.

### DIFF
--- a/actions/setup-recipe/action.yml
+++ b/actions/setup-recipe/action.yml
@@ -95,6 +95,13 @@ runs:
         # with no GITHUB_TOKEN available, even though the repo is
         # public. Sparse-checkout limits the working tree to the
         # two directories the rest of this action reads.
+        #
+        # `rm -rf` first so the step is idempotent: re-runs in the
+        # same workspace (act with reused containers, or any job
+        # that calls setup-recipe twice) would otherwise trip on
+        # `git remote add origin` ("remote already exists") since
+        # `git init` is the only idempotent half of the pair.
+        rm -rf __ci_workflows__
         git init __ci_workflows__
         cd __ci_workflows__
         git remote add origin https://github.com/compiler-research/ci-workflows.git


### PR DESCRIPTION
The "Checkout ci-workflows recipes" step did `git init __ci_workflows__` followed by `git remote add origin ...`. The first is idempotent; the second is not. Re-runs in the same workspace -- act with reused containers (default), or any future job that calls setup-recipe twice -- trip on:

    Reinitialized existing Git repository in .../__ci_workflows__/.git/
    error: remote origin already exists.

`rm -rf __ci_workflows__` before `git init` to make the whole step idempotent. Cheap (the directory is sparse-checkout-pruned), and covers any other stale state a re-run might inherit (sparse- checkout config, dangling FETCH_HEAD, prior `git checkout` HEAD).