### PR TITLE
[ci] Add bin/repro: act wrapper for local CI reproduction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,39 @@ A team-internal HTTP cache works the same way — point `cache-base` at
 URL are read-only at the moment (only `file://` and `gh release upload`
 are supported sinks).
 
+## Reproducing a CI failure locally
+
+When a matrix row fails on a downstream PR, `bin/repro` runs that
+exact row inside docker via [nektos/act](https://github.com/nektos/act)
+— no branch push, no waiting for CI:
+
+```bash
+cd ~/sources/CppInterOp                     # the failing-PR repo
+bin/repro --list                            # jobs + cell-cache hits
+                                            # + red [failed] tags
+bin/repro <row-name>                        # reproduce one row
+```
+
+The row-name shortcut resolves to `-W <workflow> -j <job> -m
+name:<row>` via fnmatch against `act -n --json`. `bin/repro` picks
+the right `--container-architecture` from the row's `os:` slug,
+refuses to launch when stale `build/` or `llvm-project/` in cwd
+would collide with the workflow's `mkdir`, and drops you into a
+shell inside the post-run container. On shell exit you're prompted
+to dump any in-container edits as a patch on the host.
+
+Iterate on a `ci-workflows` action without pushing:
+
+```bash
+~/sources/ci-workflows/bin/repro \
+    --ci-workflows ~/sources/ci-workflows \
+    <row-name>
+```
+
+Stage / temp-workflow files are cleaned at exit; disk after the
+run is zero (image cache aside). See `bin/repro --help` and
+[docs/developer-guide.md](docs/developer-guide.md) for the rest.
+
 ## Layout
 
 ```

--- a/bin/repro
+++ b/bin/repro
@@ -1,0 +1,1315 @@
+#!/usr/bin/env python3
+"""bin/repro -- nektos/act wrapper for local CI-failure reproduction.
+
+Modes:
+  --list / -l            List jobs in the workflow (calls `act -l`).
+                         Each matrix row is annotated with a
+                         copy-pastable `bin/repro <name>` invocation.
+                         Rows whose Linux cell is already published
+                         in compiler-research/ci-workflows' cache are
+                         tagged so you know which ones download the
+                         LLVM tree (~seconds) vs. build inline
+                         (~30 min). Failed rows on the current
+                         branch's upstream tip are tagged red.
+  bin/repro <NAME>       Positional row-name glob (fnmatch). Resolves
+                         to `-W <workflow> -j <job> -m name:<NAME>`
+                         when the glob matches a unique matrix row;
+                         ambiguous matches print the candidates and
+                         exit. No flags needed for the common case.
+  -j NAME                Run the job. Default: drop into a bash shell
+                         inside the container after act exits, then
+                         remove the container.
+  -m KEY:VALUE           Filter to a specific matrix row. Repeatable.
+                         e.g. -m name:osx26-arm-clang-cling-llvm20-cppyy
+                         (passed to `act --matrix KEY:VALUE`).
+                         Auto-arch: when the cell targets an arch
+                         different from the host, bin/repro sets
+                         `act --container-architecture linux/<X>` so
+                         docker pulls the right platform variant of
+                         the runner image. The arch is resolved (in
+                         order) from `-m arch:X`, then `-m os:X`
+                         (ubuntu-24.04 -> x86_64, ubuntu-24.04-arm
+                         -> arm64), then by looking the row up in
+                         act's matrix expansion via `-m name:X`. The
+                         common `bin/repro <name>` form picks up the
+                         right arch with no further flags.
+
+Default behavior: shell drops in after act exits. When the shell
+exits, you're asked whether to remove the container (default: yes,
+so bare Enter cleans up; --save-temps short-circuits to keep). Two
+opt-outs:
+
+  --no-shell             Skip the post-run shell. Container is still
+                         removed unless --save-temps is given.
+                         (No interactive prompt -- there's no shell
+                         session in which to ask.)
+  --save-temps           Keep the container after the script exits
+                         (disk NOT cleaned up). Skip the prompt.
+                         bin/repro prints the `docker exec` command
+                         to re-enter it.
+
+When stdin is not a TTY (piped / scripted invocations), the prompt
+is bypassed and the documented default (remove) applies, so
+unattended runs stay clean.
+
+Pre-flight workspace clash check: bin/repro mounts the consumer's
+working tree into the act container. If a top-level dir matching a
+known offender (`build/`, `llvm-project/`) already exists, the
+workflow's `mkdir build` / setup-recipe's `mv ../llvm-project` will
+trip under `set -e` before any actionable error appears. The
+pre-flight lists the colliding paths and refuses to proceed by
+default. Move them aside (`mv build build.local`) or pass
+`--skip-clash-check` to bypass.
+
+Patch export on shell exit: when the in-container git tree differs
+from HEAD at the time the shell session ends (you edited / built /
+poked something inside the container), bin/repro offers to dump
+`git diff HEAD` to /tmp/repro-<row>.patch on the host before the
+container is removed. Default Y -- losing in-container edits is the
+worse failure mode. Apply on the host with `git apply /tmp/repro-
+<row>.patch`. Untracked files aren't included; `git add` them
+inside the container first if you need them in the patch.
+
+Network: only what act + setup-recipe naturally fetch (catthehacker
+image one-time pull, then setup-recipe's tarball download inside the
+container). Nothing pre-fetched by this script.
+
+Disk: container is removed at exit (unless --save-temps). The
+consumer working tree, however, accumulates whatever the workflow
+writes into $GITHUB_WORKSPACE -- act bind-mounts the working tree
+into the container, so `mkdir build`, setup-recipe's `mv ../llvm-
+project`, etc. land directly on the host. The workspace-clash
+pre-flight (above) catches the resulting `build/` / `llvm-project/`
+on the next run; clean them up by hand if you want a pristine tree.
+
+Anything after `--` is passed verbatim to act.
+
+Examples
+========
+
+    cd ~/sources/CppInterOp
+    bin/repro --list                              # see jobs + cells
+    bin/repro ubu24-x86-gcc14-cling-llvm20-cppyy  # row-name shortcut
+    bin/repro -j build -m name:osx26-arm-...      # explicit -j / -m
+    bin/repro -j test --no-shell                  # scripted: act, then rm
+    bin/repro -j test --save-temps                # keep container around
+    bin/repro -j test -- --verbose                # passthrough to act
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import re
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CELLS_YAML = REPO_ROOT / "cells.yaml"
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="bin/repro",
+        description=__doc__.split("\n\n", 1)[0],
+        epilog=__doc__.split("\n\n", 1)[1],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("-l", "--list", action="store_true",
+                   help="list jobs in the workflow and exit")
+    p.add_argument("-j", "--job",
+                   help="job name (passed to act -j)")
+    p.add_argument("-m", "--matrix", action="append", default=[],
+                   metavar="KEY:VALUE",
+                   help="filter to a specific matrix row, e.g. "
+                        "`-m os:ubuntu-24.04`. Repeatable; each "
+                        "becomes a separate `act --matrix KEY:VALUE`.")
+    p.add_argument("-W", "--workflow",
+                   help="workflow file (passed to act -W). act "
+                        "defaults to scanning ./.github/workflows/ "
+                        "when omitted; pass -W only to disambiguate "
+                        "when the same job NAME exists in more than "
+                        "one workflow.")
+    p.add_argument("-n", "--dry-run", action="store_true",
+                   help="pass -n to act: validate the workflow "
+                        "without spinning up containers. Useful for "
+                        "quick disambiguation checks (does -j + -m "
+                        "identify a unique row?).")
+    p.add_argument("--no-shell", dest="shell", action="store_false",
+                   default=True,
+                   help="exit when act finishes; do NOT drop into a "
+                        "shell. Container is still removed unless "
+                        "--save-temps is given.")
+    p.add_argument("--save-temps", action="store_true",
+                   help="preserve the act container after the script "
+                        "exits (disk NOT cleaned up). bin/repro prints "
+                        "the docker exec command to re-enter it later.")
+
+    advanced = p.add_argument_group(
+        "advanced",
+        "rarely needed; opt-in flags for testing local changes "
+        "and overriding act's defaults.")
+    advanced.add_argument(
+        "--ci-workflows", type=Path, metavar="PATH",
+        help="run against a local checkout of "
+             "compiler-research/ci-workflows. Symlinks every "
+             "actions/<name> from PATH under "
+             ".github/.act-ci-workflows-stage/<name> in the "
+             "consumer repo, writes a temp workflow next to the "
+             "original with each "
+             "`uses: compiler-research/ci-workflows/actions/<name>@<ref>` "
+             "rewritten to `uses: ./.github/.act-ci-workflows-stage/"
+             "<name>` (act's local-action form), and runs that. "
+             "Stage and temp file are removed at exit. Requires "
+             "-W <workflow>.")
+    advanced.add_argument(
+        "--skip-clash-check", action="store_true",
+        help="skip the pre-flight scan for workspace dirs (e.g. "
+             "stale `build/` from local development) that the "
+             "workflow will mkdir into. Default is to warn and "
+             "prompt; pass this to proceed unconditionally.")
+
+    p.add_argument("passthrough", nargs=argparse.REMAINDER,
+                   help="anything after `--` is passed to act verbatim")
+    return p.parse_args(argv)
+
+
+def _log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def host_arch() -> str:
+    """Hardware arch slug, robust to Rosetta on Darwin.
+
+    `platform.machine()` reflects the *current process's* arch. On
+    Apple Silicon under Rosetta an x86_64 Python reports x86_64, so
+    a host-vs-cell-arch comparison without sysctl correction would
+    silently treat the host as Intel and miss the chance to suggest
+    a native-arch cell when one is published.
+    """
+    if platform.system() == "Darwin":
+        try:
+            r = subprocess.run(["sysctl", "-n", "hw.optional.arm64"],
+                               capture_output=True, text=True, check=True)
+            if r.stdout.strip() == "1":
+                return "arm64"
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            pass
+    m = platform.machine().lower()
+    return {
+        "arm64":   "arm64",
+        "aarch64": "arm64",
+        "x86_64":  "x86_64",
+        "amd64":   "x86_64",
+    }.get(m, m)
+
+
+def _require(tool: str) -> str:
+    if shutil.which(tool):
+        return tool
+    sys.exit(f"error: `{tool}` is not on PATH.")
+
+
+def _run_interactive(cmd: List[str]) -> int:
+    """Run cmd interactively; ignore SIGINT in this Python parent.
+
+    act and `docker exec -it` share the controlling TTY's foreground
+    process group with this Python process. Without SIG_IGN, Python's
+    default reaction to Ctrl+C (raise KeyboardInterrupt out of
+    subprocess.run, which then SIGTERMs the docker child) tears the
+    container down even when the user just wanted to interrupt cmake/
+    ninja running INSIDE it. Restoring the handler on exit, even if
+    Popen.wait raises, keeps the parent's signal disposition clean.
+    """
+    old = signal.signal(signal.SIGINT, signal.SIG_IGN)
+    try:
+        return subprocess.Popen(cmd).wait()
+    finally:
+        signal.signal(signal.SIGINT, old)
+
+
+def list_jobs(args: argparse.Namespace) -> int:
+    cmd = [_require("act"), "-l"]
+    if args.workflow:
+        cmd += ["-W", args.workflow]
+    rc = _run_interactive(cmd)
+    _print_fast_cells_hint()
+    return rc
+
+
+def published_cells(path: Optional[Path] = None) -> List[Dict[str, str]]:
+    """Parse cells.yaml's `cells:` array into a list of dicts.
+
+    cells.yaml lists each cell as one inline-flow YAML row:
+        - { recipe: llvm-asan, version: '22', os: ubuntu-24.04, arch: x86_64 }
+    Hand-rolled parser instead of pulling in PyYAML to keep the
+    script stdlib-only. Returns [] on missing file or parse failure
+    -- the caller treats this purely as a hint, never a hard error.
+    `path` defaults to the in-tree cells.yaml; tests inject a
+    different path.
+    """
+    if path is None:
+        path = CELLS_YAML
+    if not path.is_file():
+        return []
+    out: List[Dict[str, str]] = []
+    in_cells = False
+    for line in path.read_text().splitlines():
+        if line.startswith("cells:"):
+            in_cells = True
+            continue
+        if not in_cells:
+            continue
+        # Any new top-level key ends the cells: section.
+        if line and not line[0].isspace() and not line.startswith("#"):
+            break
+        s = line.strip()
+        if not s.startswith("- {") or not s.endswith("}"):
+            continue
+        body = s[3:-1].strip()  # strip leading "- {" and trailing "}"
+        cell: Dict[str, str] = {}
+        for kv in body.split(","):
+            if ":" not in kv:
+                continue
+            k, _, v = kv.partition(":")
+            cell[k.strip()] = v.strip().strip("'").strip('"')
+        if all(k in cell for k in ("recipe", "version", "os", "arch")):
+            out.append(cell)
+    return out
+
+
+def _act_listing() -> List[Dict[str, str]]:
+    """Parse `act -l` into one dict per row with keys: job_id,
+    job_name, workflow_name, workflow_file. The columns are
+    whitespace-aligned; we split on 2+ spaces to keep multi-word
+    `Job name` values intact.
+    """
+    act = shutil.which("act")
+    if not act:
+        return []
+    try:
+        proc = subprocess.run(
+            [act, "-l"], capture_output=True, text=True, check=False,
+        )
+    except Exception:
+        return []
+    rows: List[Dict[str, str]] = []
+    headers: Optional[List[str]] = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("Stage"):
+            headers = [h.strip().lower().replace(" ", "_")
+                       for h in re.split(r"\s{2,}", line.strip())]
+            continue
+        if headers is None or not line.strip():
+            continue
+        parts = re.split(r"\s{2,}", line.strip())
+        if len(parts) != len(headers):
+            continue
+        rows.append(dict(zip(headers, parts)))
+    return rows
+
+
+def discover_matrix_rows() -> List[Tuple[str, str, str]]:
+    """Enumerate every (workflow_file, job_id, row_name) the user
+    can target. Drives off `act -n --json`: act has already done
+    the matrix expansion and emits one dryrun line per row with
+    the resolved matrix dict, so we just read it.
+    """
+    listing = _act_listing()
+    wf_name_to_file = {r["workflow_name"]: r["workflow_file"]
+                       for r in listing}
+    out: List[Tuple[str, str, str]] = []
+    out_set: set = set()
+    for r in _act_dryrun_rows():
+        wf_file = wf_name_to_file.get(r["workflow_name"])
+        if not wf_file:
+            continue
+        key = (wf_file, r["jobID"], r["row_name"])
+        if key not in out_set:
+            out.append(key)
+            out_set.add(key)
+    return out
+
+
+def _origin_repo_slug() -> Optional[str]:
+    """Return `owner/repo` parsed from the `origin` remote URL,
+    or None when not in a git repo or origin isn't a github URL.
+    """
+    try:
+        url = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True, text=True, check=False,
+        ).stdout.strip()
+    except Exception:
+        return None
+    # SSH form: git@github.com:owner/repo(.git)?
+    # HTTPS form: https://github.com/owner/repo(.git)?
+    m = re.search(r"github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?/?$", url)
+    if not m:
+        return None
+    return f"{m.group(1)}/{m.group(2)}"
+
+
+def _failed_rows_for_branch() -> set:
+    """Return the set of matrix-row names that failed in the latest
+    CI run for this branch's upstream tip. Uses GitHub's anonymous
+    Checks API -- public repos serve it without authentication, so
+    we don't need `gh` (and the broad token scopes that come with
+    `gh auth login`). Trade-offs:
+      - 60 requests/hour anonymous rate limit; one request per
+        `bin/repro --list` is fine for interactive use.
+      - Private repos return 404; the result is just an empty set
+        (no annotations), no error message.
+    """
+    import json
+    import urllib.error
+    import urllib.request
+    slug = _origin_repo_slug()
+    if not slug:
+        return set()
+    try:
+        branch = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, check=False,
+        ).stdout.strip()
+        if not branch or branch == "HEAD":
+            return set()
+        # Prefer the upstream tip's sha (what CI actually ran on);
+        # fall back to local HEAD when the branch isn't tracked.
+        sha = subprocess.run(
+            ["git", "rev-parse", f"origin/{branch}"],
+            capture_output=True, text=True, check=False,
+        ).stdout.strip()
+        if not sha:
+            sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                capture_output=True, text=True, check=False,
+            ).stdout.strip()
+        if not sha:
+            return set()
+        url = (f"https://api.github.com/repos/{slug}/commits/{sha}"
+               f"/check-runs?per_page=100")
+        req = urllib.request.Request(
+            url, headers={
+                "User-Agent": "ci-workflows-bin-repro",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                data = json.load(resp)
+        except urllib.error.HTTPError as e:
+            if e.code == 403:
+                _log("repro: github anonymous API rate-limited; "
+                     "[failed] annotations skipped.")
+            return set()
+        except Exception:
+            return set()
+        failed: set = set()
+        for cr in data.get("check_runs", []):
+            if cr.get("conclusion") not in (
+                    "failure", "cancelled", "timed_out"):
+                continue
+            # GitHub renders matrix-row check names as
+            # "<workflow> / <row_name>"; strip the prefix.
+            name = cr.get("name", "")
+            if " / " in name:
+                name = name.split(" / ", 1)[-1]
+            failed.add(name.strip())
+        return failed
+    except Exception:
+        return set()
+
+
+def _act_dryrun_rows() -> List[Dict[str, object]]:
+    """Run `act -n --json` for both push and pull_request events
+    and return one dict per matrix-expanded job (jobID, matrix,
+    workflow_name, row_name). Two events because workflows like
+    CppInterOp's root.yml only trigger on pull_request and would
+    otherwise be invisible to the default (push) dispatch.
+    """
+    act = shutil.which("act")
+    if not act:
+        return []
+    import json
+    out: List[Dict[str, object]] = []
+    seen_keys: set = set()
+    for event in ("push", "pull_request"):
+        cmd = [act, "-n", "--json"]
+        if event != "push":
+            cmd.append(event)
+        try:
+            proc = subprocess.run(
+                cmd, capture_output=True, text=True, check=False,
+            )
+        except Exception:
+            continue
+        for line in proc.stdout.splitlines():
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                obj = json.loads(line)
+            except Exception:
+                continue
+            if not obj.get("dryrun"):
+                continue
+            job_id = obj.get("jobID")
+            matrix = obj.get("matrix") or {}
+            # `job`: "CI/prepare-dell                         " --
+            # workflow display name lives before the slash.
+            job_field = (obj.get("job") or "").strip()
+            wf_name = (job_field.split("/", 1)[0].strip()
+                       if "/" in job_field else "")
+            row_name = matrix.get("name") or job_id
+            key = (wf_name, job_id, row_name)
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            out.append({"jobID": job_id, "matrix": matrix,
+                        "workflow_name": wf_name, "row_name": row_name})
+    return out
+
+
+def _print_fast_cells_hint() -> None:
+    """After `act -l`, print copy-pastable `bin/repro` invocations
+    for each matrix row, annotating rows that hit a published Linux
+    cell (download instead of inline build).
+    """
+    cells = published_cells()
+    rows = discover_matrix_rows()
+    if not rows:
+        return
+    # Index act-resolved matrices by row_name so cell tagging uses
+    # the same data act has already computed.
+    matrix_by_row: Dict[str, Dict[str, str]] = {
+        r["row_name"]: r["matrix"] for r in _act_dryrun_rows()
+    }
+
+    def _cell_for(row_name: str) -> Optional[Dict[str, str]]:
+        m = matrix_by_row.get(row_name) or {}
+        # Standard mapping convention used by main.yml's setup-recipe
+        # step: recipe = matrix.use-recipe, version = recipe-version
+        # || clang-runtime, arch = recipe-arch || x86_64.
+        coord = {
+            "recipe":  m.get("use-recipe"),
+            "version": (m.get("recipe-version")
+                        or m.get("clang-runtime")),
+            "os":      m.get("os"),
+            "arch":    m.get("recipe-arch") or "x86_64",
+        }
+        if not all(coord.values()):
+            return None
+        for c in cells:
+            if all(coord[k] == c[k]
+                   for k in ("recipe", "version", "os", "arch")):
+                return c
+        return None
+
+    # Count name occurrences so we know whether the user needs `-W`
+    # / `-j` to disambiguate. Unique row names get the minimal
+    # `bin/repro -m name:<row>` -- main() auto-detects the rest.
+    name_count: Dict[str, int] = {}
+    for _wf, _job, name in rows:
+        name_count[name] = name_count.get(name, 0) + 1
+
+    failed = _failed_rows_for_branch()
+    # Color the [failed] tag red on a TTY; plain text everywhere
+    # else (pipes, redirects, CI logs) so copy-paste stays clean.
+    red = "\033[31m" if sys.stderr.isatty() else ""
+    reset = "\033[0m" if sys.stderr.isatty() else ""
+
+    _log("")
+    _log("Matrix rows -- copy-paste any line. Rows tagged [cell: ...]")
+    _log("download a prebuilt LLVM tree instead of inline build;")
+    _log("[failed] marks rows whose latest run on this branch failed.")
+    _log("")
+    for wf_file, job_id, row_name in rows:
+        cell = _cell_for(row_name) if cells else None
+        tags = []
+        if cell:
+            tags.append(f"[cell: {cell['recipe']}/{cell['version']}/"
+                        f"{cell['os']}/{cell['arch']}]")
+        if row_name in failed or job_id in failed:
+            tags.append(f"{red}[failed]{reset}")
+        suffix = "  # " + " ".join(tags) if tags else ""
+        is_matrix = job_id != row_name
+        if is_matrix and name_count[row_name] == 1:
+            inv = f"bin/repro {row_name}"
+        elif is_matrix:
+            inv = f"bin/repro -W {wf_file} -j {job_id} -m name:{row_name}"
+        else:
+            inv = f"bin/repro -W {wf_file} -j {job_id}"
+        _log(f"  {inv}{suffix}")
+
+
+_ARCH_TO_DOCKER = {
+    "x86_64":  "amd64",
+    "amd64":   "amd64",
+    "arm64":   "arm64",
+    "aarch64": "arm64",
+}
+
+
+def _matrix_get(matrix_args: List[str], key: str) -> Optional[str]:
+    """Return the value of `-m <key>:<value>` if present, else None."""
+    prefix = f"{key}:"
+    for m in matrix_args:
+        if m.startswith(prefix):
+            return m[len(prefix):]
+    return None
+
+
+# Map ubuntu runner-image slugs to their target arch. Linux rows on
+# GitHub-hosted runners are x86_64 unless the slug ends in `-arm`. We
+# only need ubuntu-* here: act doesn't run macOS / Windows containers,
+# so non-Linux rows never reach the auto-arch logic.
+_OS_TO_ARCH = {
+    "ubuntu-24.04":     "x86_64",
+    "ubuntu-22.04":     "x86_64",
+    "ubuntu-20.04":     "x86_64",
+    "ubuntu-24.04-arm": "arm64",
+    "ubuntu-22.04-arm": "arm64",
+}
+
+
+def _resolve_cell_arch(matrix_args: List[str]) -> Optional[str]:
+    """Best-effort target arch for this matrix row.
+
+    Tried in order:
+      1. `-m arch:X`   — caller stated it directly.
+      2. `-m os:X`     — Linux slug uniquely implies arch.
+      3. `-m name:X`   — look up the row's matrix dict via the same
+                         act -n --json data `--list` already uses, and
+                         derive from `arch` / `recipe-arch` / `os`.
+    None when nothing matches; caller falls back to host arch.
+    """
+    explicit = _matrix_get(matrix_args, "arch")
+    if explicit:
+        return explicit
+    derived = _OS_TO_ARCH.get(_matrix_get(matrix_args, "os") or "")
+    if derived:
+        return derived
+    name = _matrix_get(matrix_args, "name")
+    if not name:
+        return None
+    for r in _act_dryrun_rows():
+        mat = r.get("matrix") or {}
+        if mat.get("name") != name:
+            continue
+        # Row's own matrix may carry arch directly (recipe-arch on
+        # mac arm rows); prefer it over deriving from os.
+        row_arch = mat.get("arch") or mat.get("recipe-arch")
+        if row_arch:
+            return str(row_arch)
+        return _OS_TO_ARCH.get(str(mat.get("os") or ""))
+    return None
+
+
+_CELL_TO_MATRIX_KEY = {
+    "recipe":  "use-recipe",
+    "version": "recipe-version",
+    "os":      "os",
+    "arch":    "recipe-arch",
+}
+
+
+_DEFAULT_PLATFORMS = [
+    # act has no built-in mapping for these slugs; without -P it
+    # emits "Skipping unsupported platform" and dispatches no work.
+    # Image choice (`act-XX.04`, the lean ~1.5 GiB variant) is a
+    # default -- override per-slug via `~/.actrc` (which we honour
+    # below) or `-- -P <slug>=<image>` on the command line.
+    "ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04",
+    "ubuntu-24.04-arm=ghcr.io/catthehacker/ubuntu:act-24.04",
+    "ubuntu-22.04=ghcr.io/catthehacker/ubuntu:act-22.04",
+]
+
+
+def _actrc_platforms() -> set:
+    """Return the set of platform slugs the user has already mapped
+    in `~/.actrc`. We skip our defaults for those so the user's
+    image choice wins instead of being silently overridden by ours.
+    """
+    rc = Path.home() / ".actrc"
+    if not rc.is_file():
+        return set()
+    slugs: set = set()
+    try:
+        for line in rc.read_text().splitlines():
+            # Match `-P slug=image` (with or without the space).
+            m = re.match(r"\s*-P\s+([^=\s]+)=", line)
+            if m:
+                slugs.add(m.group(1))
+    except Exception:
+        return set()
+    return slugs
+
+
+def _translate_matrix(raw: List[str]) -> List[str]:
+    """Map cell-coord aliases (recipe/version/arch) to real matrix
+    keys (use-recipe/recipe-version/recipe-arch). Real matrix keys
+    pass through unchanged so users can still target rows directly.
+    """
+    out = []
+    for m in raw:
+        if ":" in m:
+            k, v = m.split(":", 1)
+            k = _CELL_TO_MATRIX_KEY.get(k, k)
+            out.append(f"{k}:{v}")
+        else:
+            out.append(m)
+    return out
+
+
+def build_act_command(args: argparse.Namespace) -> List[str]:
+    cmd = [_require("act"), "-j", args.job]
+    if args.workflow:
+        cmd += ["-W", args.workflow]
+    # Default -P fallbacks for slugs act doesn't ship a mapping
+    # for. Skip the slug if `~/.actrc` already maps it -- that's
+    # the user's preferred image and command-line -P would silently
+    # override it.
+    rc_slugs = _actrc_platforms()
+    for plat in _DEFAULT_PLATFORMS:
+        slug = plat.split("=", 1)[0]
+        if slug in rc_slugs:
+            continue
+        cmd += ["-P", plat]
+    for m in _translate_matrix(args.matrix or []):
+        cmd += ["--matrix", m]
+
+    # Auto-set --container-architecture when the matrix row targets
+    # an arch different from the host. `act --help`: "If not specified,
+    # will use host default architecture." On Apple Silicon, a row
+    # whose `os: ubuntu-24.04` (x86_64) would otherwise land in an
+    # arm64 container, and an x86_64 LLVM cache asset extracted there
+    # crashes at exec time. Resolution order is `arch:` → `os:` →
+    # row-name lookup, so the common `bin/repro -m name:<row>` form
+    # picks up the right arch without the user spelling it out.
+    cell_arch = _resolve_cell_arch(args.matrix or [])
+    if cell_arch and cell_arch != host_arch():
+        docker_arch = _ARCH_TO_DOCKER.get(cell_arch, cell_arch)
+        cmd += ["--container-architecture", f"linux/{docker_arch}"]
+
+    if args.dry_run:
+        cmd += ["-n"]
+
+    # The container must outlive `act` for either of two reasons:
+    #   - --shell: bin/repro execs bash into it, then rm's.
+    #   - --save-temps: container is kept past script exit.
+    # Without --reuse, act sets autoremove=true and the container
+    # is gone before bin/repro can do anything with it.
+    if args.shell or args.save_temps:
+        cmd += ["--reuse"]
+    extra = args.passthrough or []
+    if extra and extra[0] == "--":
+        extra = extra[1:]
+    cmd += extra
+    return cmd
+
+
+def _find_setup_recipe_job(text: str) -> Optional[str]:
+    """Hand-rolled scan: in a workflow YAML, return the first
+    jobs.<id> whose body references a setup-recipe action.
+    Tolerates 2- or 4-space indentation. Used by the matrix-driven
+    workflow auto-detection below; never raises -- worst case
+    returns None and the caller falls back to requiring -W."""
+    in_jobs = False
+    current_job = None
+    has_setup_recipe = False
+    for line in text.splitlines():
+        if line.rstrip() == "jobs:":
+            in_jobs = True
+            continue
+        if not in_jobs:
+            continue
+        if line and not line[0].isspace() and not line.startswith("#"):
+            break
+        m = re.match(r"^( {2}|\t)([\w-]+):\s*$", line)
+        if m:
+            if current_job and has_setup_recipe:
+                return current_job
+            current_job = m.group(2)
+            has_setup_recipe = False
+            continue
+        if "setup-recipe" in line and current_job:
+            has_setup_recipe = True
+    if current_job and has_setup_recipe:
+        return current_job
+    return None
+
+
+def find_workflow_for_cell_matrix(matrix: List[str],
+                                  cwd: Optional[Path] = None
+                                  ) -> Optional[Tuple[str, str]]:
+    """Auto-detect (workflow_file, job_id) when the user's -m flags
+    pin a recipe.
+
+    Goal: most downstream repos have multiple workflows but only one
+    of them consumes a given cells.yaml recipe. The recipe name in
+    -m recipe:<X> is enough to identify that workflow uniquely. The
+    user shouldn't also have to type -W.
+
+    Strategy: text-grep .github/workflows/*.yml for files that
+    mention BOTH `setup-recipe` AND the recipe name (literal or in a
+    matrix definition). Return only when exactly one matches; on
+    ambiguity, return None and let check_job_ambiguous error with
+    the per-workflow list.
+    """
+    recipe = _matrix_get(matrix or [], "recipe")
+    if not recipe:
+        return None
+    base = cwd or Path.cwd()
+    workflows = base / ".github" / "workflows"
+    if not workflows.is_dir():
+        return None
+    candidates: List[Tuple[str, str]] = []
+    for wf in sorted(list(workflows.glob("*.yml"))
+                     + list(workflows.glob("*.yaml"))):
+        try:
+            text = wf.read_text(errors="replace")
+        except OSError:
+            continue
+        if "setup-recipe" not in text or recipe not in text:
+            continue
+        job = _find_setup_recipe_job(text)
+        if not job:
+            continue
+        try:
+            rel = wf.relative_to(base)
+        except ValueError:
+            rel = wf
+        candidates.append((str(rel), job))
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
+
+
+def find_workflow_via_dry_run(args: argparse.Namespace
+                              ) -> Optional[Tuple[str, str]]:
+    """Disambiguation fallback: when text-grep can't pick a unique
+    workflow but act -l shows multiple candidates, run `act -n -W
+    <wf> -j <job> -m <flags>` against each and keep only those
+    whose dry-run accepts the filter (act prints the ⭐ Run-Set-up-
+    job marker for each row that would actually run; a workflow
+    whose matrix doesn't admit the filter or whose job has a
+    different shape gets zero rows).
+
+    Slower than text-grep (one act invocation per candidate) but
+    precise: act itself decides whether the matrix flags pin
+    something runnable in each workflow.
+
+    Returns (workflow_path, args.job) on unique match, else None.
+    """
+    listing = _act_listing()
+    if not listing:
+        return None
+    candidates = sorted({r["workflow_file"] for r in listing
+                         if r["job_id"] == args.job})
+    if len(candidates) <= 1:
+        return None
+    matches: List[Tuple[str, str]] = []
+    for wf_basename in candidates:
+        wf_path = resolve_workflow(wf_basename)
+        if not Path(wf_path).is_file():
+            continue
+        cmd = [_require("act"), "-W", wf_path, "-j", args.job, "-n"]
+        for m in args.matrix or []:
+            cmd += ["--matrix", m]
+        try:
+            r = subprocess.run(cmd, capture_output=True, text=True,
+                               timeout=60, check=False)
+        except subprocess.TimeoutExpired:
+            continue
+        # act -n exits 0 on a valid workflow. The "⭐" marker
+        # (Run Set up job) appears once per matrix row that would
+        # actually run -- absent if our filter excluded everything.
+        if r.returncode == 0 and "⭐" in r.stdout:
+            matches.append((wf_path, args.job))
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def resolve_workflow(w: Optional[str]) -> Optional[str]:
+    """If `-W foo.yml` is a bare basename and the literal path doesn't
+    exist, expand it to `.github/workflows/foo.yml`. The literal-path
+    case (-W full/path/to/file.yml) passes through unchanged. Falls
+    through to the original value if neither resolves -- act will
+    emit its own error.
+    """
+    if not w:
+        return w
+    if Path(w).is_file():
+        return w
+    candidate = Path(".github") / "workflows" / w
+    if candidate.is_file():
+        return str(candidate)
+    return w
+
+
+def check_job_ambiguous(args: argparse.Namespace) -> None:
+    """If `-j NAME` matches the same job ID across multiple workflow
+    files and -W wasn't given, refuse to proceed with a clear error
+    listing the workflows. Otherwise act would silently run ALL of
+    them in parallel; the "Detected multiple jobs" line act prints
+    is informational, not blocking."""
+    if not args.job or args.workflow:
+        return
+    rows = _act_listing()
+    if not rows:
+        return  # listing failed; let act handle
+    matching = [r for r in rows if r["job_id"] == args.job]
+    workflows = sorted({r["workflow_file"] for r in matching})
+    if len(workflows) <= 1:
+        return
+    lines = [f"error: job ID '{args.job}' is defined in multiple workflows:"]
+    for r in matching:
+        lines.append(f"  {r['workflow_file']}  ({r['workflow_name']})")
+    lines.append("")
+    lines.append("Pass -W <path> to pick one, e.g.:")
+    lines.append(f"  bin/repro -W {workflows[0]} -j {args.job}")
+    lines.append("(bare basenames work too; -W <foo>.yml resolves to "
+                 ".github/workflows/<foo>.yml)")
+    sys.exit("\n".join(lines))
+
+
+def find_recent_act_container() -> Optional[str]:
+    """Most recent act-* container ID (running or stopped), or None."""
+    r = subprocess.run(
+        ["docker", "ps", "-aq", "--filter", "name=act-", "--latest"],
+        capture_output=True, text=True, check=False)
+    cid = r.stdout.strip()
+    return cid if cid else None
+
+
+def shell_into(cid: str) -> int:
+    subprocess.run(["docker", "start", cid], check=False,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return _run_interactive(["docker", "exec", "-it", cid, "bash"])
+
+
+def remove_container(cid: str) -> None:
+    subprocess.run(["docker", "rm", "-f", cid], check=False,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _container_tree_dirty(cid: str, workspace: str) -> bool:
+    """True when `git -C <workspace> diff HEAD` reports changes.
+
+    Uses --quiet and rc-based detection: 0 = clean, 1 = changes,
+    128 = not a git repo / no HEAD / git missing. Treat anything but
+    1 as "no patch to export" -- a missing-git diagnostic isn't
+    actionable here, and the user can always docker exec themselves.
+    """
+    r = subprocess.run(
+        ["docker", "exec", cid, "git", "-C", workspace,
+         "diff", "--quiet", "HEAD"],
+        capture_output=True, text=True, check=False,
+    )
+    return r.returncode == 1
+
+
+def _export_container_patch(cid: str, workspace: str, dest: Path) -> bool:
+    """Capture `git diff HEAD` from inside the container; write to dest.
+    Returns True on success, False on diagnostic-worthy failure.
+    """
+    r = subprocess.run(
+        ["docker", "exec", cid, "git", "-C", workspace, "diff", "HEAD"],
+        capture_output=True, text=True, check=False,
+    )
+    if r.returncode != 0:
+        _log(f"repro: docker exec git diff failed (rc={r.returncode}): "
+             f"{r.stderr.strip()}")
+        return False
+    dest.write_text(r.stdout)
+    return True
+
+
+def maybe_export_in_container_patch(cid: str,
+                                    row: Optional[str]) -> None:
+    """Pre-cleanup hook: if the container's git tree has unstaged or
+    staged changes vs HEAD, prompt to save a patch on the host.
+
+    Why: `--shell` lets the user edit / recompile / retest inside the
+    container. Without an export step, those changes evaporate when
+    the container is removed. Default-Y on the prompt -- losing edits
+    is the worse failure mode; the user can always `n` if they don't
+    want a file.
+
+    Untracked files aren't included (`git diff HEAD` doesn't see them).
+    Users wanting those in the patch should `git add` first inside
+    the container before exiting the shell.
+    """
+    workspace = os.getcwd()
+    if not _container_tree_dirty(cid, workspace):
+        return
+    name = (row or "session").replace("/", "_")
+    dest = Path(f"/tmp/repro-{name}.patch")
+    if not _confirm(
+            f"repro: in-container changes detected. "
+            f"Export `git diff HEAD` to {dest}?",
+            default=True):
+        return
+    if _export_container_patch(cid, workspace, dest):
+        _log(f"repro: patch saved -- apply on host with:")
+        _log(f"  git apply {dest}")
+
+
+def _confirm(prompt: str, default: bool = True) -> bool:
+    """y/n prompt with `default` selected on bare Enter. Falls back to
+    `default` when stdin isn't a TTY -- scripted / piped invocations
+    can't answer interactively, so we honor the documented default
+    (rm the container) instead of hanging the script."""
+    if not sys.stdin.isatty():
+        return default
+    suffix = " [Y/n]: " if default else " [y/N]: "
+    print(prompt + suffix, file=sys.stderr, end="", flush=True)
+    try:
+        response = sys.stdin.readline().strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print("", file=sys.stderr)
+        return default
+    if not response:
+        return default
+    return response in ("y", "yes")
+
+
+# Top-level dir names that compiler-research workflows we drive
+# typically `mkdir` (CppInterOp build) or `mv` into (setup-recipe
+# extracts here). Hand-rolled list -- a YAML scan would be more
+# general but also catches ephemeral working dirs like `_recipe_work`
+# we don't care about. Add names here when a new clash bites someone.
+_LIKELY_CLASH_DIRS = (
+    "build",
+    "llvm-project",
+)
+
+
+def detect_workspace_clashes() -> List[Path]:
+    """Top-level dirs in cwd that match `_LIKELY_CLASH_DIRS`.
+
+    Returns absolute paths. Empty list when nothing matches.
+    """
+    cwd = Path.cwd()
+    return [cwd / name for name in _LIKELY_CLASH_DIRS
+            if (cwd / name).is_dir()]
+
+
+def warn_workspace_clashes(args: argparse.Namespace) -> None:
+    """Pre-flight: refuse to proceed when the consumer workspace has
+    dirs that the workflow will collide with.
+
+    Why: bin/repro mounts the consumer's working tree into the act
+    container. CppInterOp's Build_and_Test_CppInterOp action does
+    `mkdir build && cd build && cmake ...` -- a stale `build/` from
+    local development trips `mkdir` under `set -e`, and the job
+    aborts before any cmake output appears. The act log shows
+    "Job failed" with no actionable cause; the actual diagnosis is
+    that this directory existed at start.
+
+    Bypass with `--skip-clash-check` when you've already cleaned up
+    or know the workflow is defensive (`rm -rf build` before mkdir).
+    """
+    if args.dry_run or args.skip_clash_check:
+        return
+    paths = detect_workspace_clashes()
+    if not paths:
+        return
+    _log("repro: workspace clash -- the following dirs already exist and")
+    _log("repro:   the workflow will try to (re)create them. Under")
+    _log("repro:   `set -e`, `mkdir <dir>` fails with 'File exists' and")
+    _log("repro:   the act job aborts before reaching cmake.")
+    for p in paths:
+        _log(f"repro:     {p}")
+    _log("repro: choose one before re-running:")
+    _log("repro:     - `rm -rf <dir>`  (loses local build state)")
+    _log("repro:     - `mv <dir> <dir>.local`  (preserves it)")
+    _log("repro:     - re-run with `--skip-clash-check` to proceed anyway")
+    if not _confirm("repro: proceed without removing them?", default=False):
+        sys.exit(1)
+
+
+_STAGE_DIR_NAME = "act-ci-workflows-stage"
+
+
+def _localize_workflow_for_ci_workflows(
+        workflow_path: Path, ci_workflows: Path) -> Path:
+    """Stage the local ci-workflows actions under
+    `.github/.act-ci-workflows-stage/<name>` as symlinks, rewrite
+    every `uses: compiler-research/ci-workflows/actions/<name>@<ref>`
+    in `workflow_path` to `uses: ./.github/.act-ci-workflows-stage/
+    <name>` (act's local-action form), and return the path to a
+    temp workflow file beside the original.
+
+    Why this shape:
+      - `uses: ./<path>` makes act treat the action as a local
+        action and read `<path>/action.yml` directly -- no fetch,
+        no `~/.cache/act/` involvement.
+      - `<path>` must be inside the consumer's repo (act resolves
+        relative to cwd / the workflow's repo root), so we stage
+        symlinks under `.github/`.
+      - Each ci-workflows action becomes its own symlink target
+        rather than the whole repo, so consumers reading the temp
+        workflow see a clean stage layout.
+    """
+    consumer = Path.cwd()
+    stage = consumer / ".github" / _STAGE_DIR_NAME
+    if stage.exists() or stage.is_symlink():
+        shutil.rmtree(stage, ignore_errors=True)
+        if stage.is_symlink():
+            stage.unlink()
+    stage.mkdir(parents=True)
+    actions_dir = ci_workflows / "actions"
+    if not actions_dir.is_dir():
+        sys.exit(f"error: {actions_dir} not found")
+    for action_dir in sorted(actions_dir.iterdir()):
+        if not action_dir.is_dir() or action_dir.name == "lib":
+            continue
+        if not (action_dir / "action.yml").is_file():
+            continue
+        # act doesn't follow directory symlinks for local actions
+        # (`uses: ./<path>`), so copy the action's contents instead
+        # of symlinking. Each action is a few small files; fast.
+        shutil.copytree(action_dir, stage / action_dir.name)
+
+    text = workflow_path.read_text()
+    rel = f"./.github/{_STAGE_DIR_NAME}"
+    text = re.sub(
+        r"uses:\s*compiler-research/ci-workflows/actions/(\w[\w-]*)@\S+",
+        lambda m: f"uses: {rel}/{m.group(1)}",
+        text,
+    )
+    fd, tmp = tempfile.mkstemp(
+        prefix=f"act-{workflow_path.stem}-localized-",
+        suffix=".yml", dir=str(workflow_path.parent),
+    )
+    os.close(fd)
+    Path(tmp).write_text(text)
+    _log(f"repro: --ci-workflows: staged {ci_workflows} under "
+         f"{stage.relative_to(consumer)}; running act on {Path(tmp).name}")
+    return Path(tmp)
+
+
+def _cleanup_ci_workflows_overlay() -> None:
+    """Remove the .github/.act-ci-workflows-stage/ symlink tree and
+    any act-*-localized-*.yml temp workflow we wrote. Idempotent;
+    best-effort."""
+    consumer = Path.cwd()
+    stage = consumer / ".github" / _STAGE_DIR_NAME
+    if stage.exists() or stage.is_symlink():
+        shutil.rmtree(stage, ignore_errors=True)
+    workflows = consumer / ".github" / "workflows"
+    if workflows.is_dir():
+        for p in workflows.glob("act-*-localized-*.yml"):
+            try:
+                p.unlink()
+            except OSError:
+                pass
+
+
+def _resolve_pattern(pattern: str, args: argparse.Namespace) -> None:
+    """Glob `pattern` against matrix-row names; on unique match,
+    populate args.workflow, args.job, and args.matrix; on ambiguous
+    or empty match, print the candidates and exit. `fnmatch` so the
+    user can write `asan*`, `*cling*`, or a literal name.
+    """
+    import fnmatch
+    rows = discover_matrix_rows()
+    matches = [(wf, j, n) for wf, j, n in rows
+               if fnmatch.fnmatch(n, pattern)]
+    if not matches:
+        # Literal matches that aren't actual rows are a common typo;
+        # fall through to printing the row list so the user can pick.
+        candidates = sorted({n for _wf, _j, n in rows})
+        msg = [f"error: no matrix row matches pattern '{pattern}'."]
+        if candidates:
+            msg.append("Available rows:")
+            msg += [f"  {n}" for n in candidates]
+        sys.exit("\n".join(msg))
+    if len(matches) > 1:
+        _log(f"repro: pattern '{pattern}' matches {len(matches)} rows; "
+             f"narrow it:")
+        for wf, j, n in matches:
+            _log(f"repro:   {n}  (in {wf}, job {j})")
+        sys.exit(1)
+    wf, job, name = matches[0]
+    if not args.workflow:
+        args.workflow = wf
+    args.job = job
+    args.matrix = (args.matrix or []) + [f"name:{name}"]
+
+
+def main() -> int:
+    args = parse_args()
+    if args.list:
+        return list_jobs(args)
+
+    # First non-flag passthrough argument is treated as a row-name
+    # glob -- `bin/repro asan-ubsan` or `bin/repro *cling*` resolves
+    # to a unique matrix row and auto-fills -W/-j/-m. Anything after
+    # an explicit `--` continues to flow into act verbatim.
+    if (args.passthrough and args.passthrough[0] != "--"
+            and not args.passthrough[0].startswith("-")
+            and not args.job):
+        pattern = args.passthrough[0]
+        args.passthrough = args.passthrough[1:]
+        _resolve_pattern(pattern, args)
+
+    # Auto-fill -W / -j from `-m name:<row>` when both are omitted.
+    # discover_matrix_rows already cross-references act -l + act -n,
+    # so a unique row name resolves to (workflow_file, job_id) with
+    # no extra plumbing; ambiguous names print which workflows they
+    # match and bail.
+    if not args.job:
+        wanted = _matrix_get(args.matrix or [], "name")
+        if wanted:
+            matches = [(wf, j) for wf, j, n in discover_matrix_rows()
+                       if n == wanted]
+            if len(matches) == 1:
+                wf, job = matches[0]
+                if not args.workflow:
+                    args.workflow = wf
+                args.job = job
+                _log(f"repro: auto-detected -W {wf} -j {job} "
+                     f"from -m name:{wanted}")
+            elif len(matches) > 1:
+                conflicts = "\n  ".join(f"{wf} (job {j})"
+                                        for wf, j in matches)
+                sys.exit(f"error: row name '{wanted}' matches multiple "
+                         f"workflows; pass -W to disambiguate:\n  "
+                         f"{conflicts}")
+    if not args.job:
+        sys.exit("error: -j NAME, --list, or -m name:<row> required")
+
+    # `-W foo.yml` (bare basename) -> `.github/workflows/foo.yml`.
+    args.workflow = resolve_workflow(args.workflow)
+
+    # Auto-detect -W from the matrix flags when the user didn't
+    # pin one explicitly. Two-step:
+    #
+    #   Fast (text-grep): if -m recipe:<X> appears, find the unique
+    #   workflow that uses setup-recipe AND mentions <X>.
+    #
+    #   Slow (act dry-run): if text-grep is ambiguous, run `act -n`
+    #   against each candidate workflow with the matrix flags
+    #   applied. Only the workflow whose matrix actually admits the
+    #   filter emits the ⭐ Run-Set-up-job marker. act decides for
+    #   us; bin/repro doesn't have to YAML-parse matrix definitions.
+    if not args.workflow and args.matrix:
+        detected = find_workflow_for_cell_matrix(args.matrix)
+        if not detected:
+            _log("repro: text-grep auto-detect ambiguous; iterating "
+                 "candidates via act dry-run ...")
+            detected = find_workflow_via_dry_run(args)
+        if detected:
+            wf_path, _ = detected
+            _log(f"repro: auto-detected -W {wf_path}")
+            args.workflow = wf_path
+
+    # Pre-flight: refuse to proceed if -j still matches multiple
+    # workflows and -W wasn't given. Without this, act silently
+    # runs ALL matching jobs across all workflows in parallel.
+    check_job_ambiguous(args)
+
+    # Pre-flight: warn (and prompt) when stale workspace dirs would
+    # collide with `mkdir build` etc. -- bin/repro mounts the
+    # consumer tree as-is, so leftover local builds break `set -e`
+    # under act before any actionable error appears.
+    warn_workspace_clashes(args)
+
+    # `--ci-workflows`: stage local actions under .github/<dir>/ and
+    # rewrite the workflow's `uses: compiler-research/ci-workflows/...`
+    # to `uses: ./<dir>/<name>` so act reads them as local actions.
+    # Cleanup on exit (success or failure).
+    if args.ci_workflows:
+        if not args.workflow:
+            sys.exit("error: --ci-workflows requires -W <workflow>")
+        args.workflow = str(_localize_workflow_for_ci_workflows(
+            Path(args.workflow).resolve(),
+            Path(args.ci_workflows).resolve(),
+        ))
+
+    cmd = build_act_command(args)
+    _log("+ " + " ".join(shlex.quote(c) for c in cmd))
+    try:
+        rc = _run_interactive(cmd)
+    finally:
+        if args.ci_workflows:
+            _cleanup_ci_workflows_overlay()
+
+    # --dry-run: act validated only; no container exists. Skip the
+    # shell + cleanup dance entirely -- there's nothing to drop into
+    # and nothing to remove. Returning early also avoids the
+    # misleading "no act-* container found" message.
+    if args.dry_run:
+        return rc
+
+    # Container cleanup matrix (orthogonal flags, four combinations):
+    #
+    #   --shell  --save-temps  | post-act behaviour
+    #   ------   -----------   | ------------------------------
+    #   yes      no  (default) | shell, then rm
+    #   yes      yes           | shell, keep container
+    #   no       no            | nothing (act --rm'd already)
+    #   no       yes           | keep, log how to re-enter
+    #
+    # build_act_command passed --reuse to act when shell or save_temps
+    # was set, so the container is around to interact with here.
+
+    cid = find_recent_act_container() if (args.shell or args.save_temps) else None
+
+    if args.shell:
+        if not cid:
+            _log("repro: no act-* container found; nothing to shell into")
+            return rc
+        if args.save_temps:
+            _log(f"repro: dropping into shell of container {cid[:12]} "
+                 f"(--save-temps: kept on exit)")
+        else:
+            _log(f"repro: dropping into shell of container {cid[:12]}")
+        try:
+            return shell_into(cid)
+        finally:
+            # In-container edits made during the shell session would
+            # evaporate when the container is removed. Offer to dump
+            # `git diff HEAD` to /tmp/repro-<row>.patch first; the user
+            # then `git apply`s on the host. No-ops silently when the
+            # tree is clean.
+            maybe_export_in_container_patch(
+                cid, _matrix_get(args.matrix or [], "name"))
+            # --save-temps short-circuits the prompt (user already
+            # said keep). Otherwise ask, defaulting to remove (TTY
+            # absent => default applies, so scripted runs stay
+            # unattended and clean up).
+            if args.save_temps:
+                _log_keep_hint(cid)
+            elif _confirm(f"repro: remove container {cid[:12]}?",
+                          default=True):
+                _log(f"repro: removing container {cid[:12]}")
+                remove_container(cid)
+            else:
+                _log_keep_hint(cid)
+
+    if args.save_temps and cid:
+        _log_keep_hint(cid, prefix="repro: --save-temps: ")
+
+    return rc
+
+
+def _log_keep_hint(cid: str, prefix: str = "repro: ") -> None:
+    _log(f"{prefix}container {cid[:12]} preserved. Re-enter with:")
+    _log(f"repro:   docker start {cid[:12]} && "
+         f"docker exec -it {cid[:12]} bash")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/test_repro.py
+++ b/bin/test_repro.py
@@ -1,0 +1,1377 @@
+"""Unit tests for bin/repro (nektos/act wrapper for local CI-failure reproduction).
+
+Pin the contract: act invocation shape per flag combination, the
+post-run shell + cleanup path, the SIG_IGN-around-Popen behavior
+that keeps Ctrl+C interrupting cmake-inside-container instead of
+killing the docker child.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.machinery
+import importlib.util
+import io
+import os
+import signal as _signal
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import mock
+
+REPRO_PATH = Path(__file__).resolve().parent / "repro"
+
+
+def _load_repro():
+    loader = importlib.machinery.SourceFileLoader("repro", str(REPRO_PATH))
+    spec = importlib.util.spec_from_loader("repro", loader)
+    m = importlib.util.module_from_spec(spec)
+    loader.exec_module(m)
+    return m
+
+
+repro = _load_repro()
+
+
+def _ns(**kw) -> argparse.Namespace:
+    defaults = dict(list=False, job=None, workflow=None, matrix=[],
+                    shell=True, save_temps=False, dry_run=False,
+                    passthrough=[])
+    defaults.update(kw)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# build_act_command
+# ---------------------------------------------------------------------------
+
+class BuildActCommandTests(unittest.TestCase):
+    def setUp(self):
+        # Mock _require so we don't need act on PATH for these tests.
+        self._require_patch = mock.patch.object(
+            repro, "_require", side_effect=lambda x: x)
+        self._require_patch.start()
+
+    def tearDown(self):
+        self._require_patch.stop()
+
+    def test_minimal_job_invocation_includes_reuse(self):
+        cmd = repro.build_act_command(_ns(job="test"))
+        self.assertEqual(cmd[:3], ["act", "-j", "test"])
+        self.assertIn("--reuse", cmd)
+
+    def test_no_shell_drops_reuse(self):
+        cmd = repro.build_act_command(_ns(job="test", shell=False))
+        self.assertEqual(cmd[:3], ["act", "-j", "test"])
+        self.assertNotIn("--reuse", cmd)
+
+    def test_workflow_passes_dash_W(self):
+        cmd = repro.build_act_command(
+            _ns(job="test", workflow="ci.yml", shell=False))
+        self.assertEqual(cmd[:5], ["act", "-j", "test", "-W", "ci.yml"])
+
+    def test_passthrough_after_dashdash(self):
+        cmd = repro.build_act_command(
+            _ns(job="test", shell=False,
+                passthrough=["--", "--verbose", "--dryrun"]))
+        # Trailing `--` separator is consumed; rest is appended.
+        self.assertEqual(cmd[-2:], ["--verbose", "--dryrun"])
+
+    def test_matrix_passes_through_each_filter(self):
+        cmd = repro.build_act_command(
+            _ns(job="build", shell=False,
+                matrix=["name:osx26-arm-clang", "python:3.12"]))
+        # Each --matrix becomes its own act flag pair (positions are
+        # interleaved with the default -P platform maps).
+        pairs = list(zip(cmd, cmd[1:]))
+        self.assertIn(("--matrix", "name:osx26-arm-clang"), pairs)
+        self.assertIn(("--matrix", "python:3.12"), pairs)
+
+    def test_matrix_translates_cell_aliases(self):
+        # `recipe`/`version`/`arch` are cell-coordinate aliases for
+        # the real matrix keys (use-recipe / recipe-version /
+        # recipe-arch). The suggestion output uses the aliases; the
+        # translation here keeps `act --matrix` matching real keys.
+        cmd = repro.build_act_command(
+            _ns(job="build", shell=False,
+                matrix=["recipe:llvm-root", "version:ROOT-llvm20",
+                        "os:ubuntu-24.04", "arch:x86_64"]))
+        pairs = list(zip(cmd, cmd[1:]))
+        self.assertIn(("--matrix", "use-recipe:llvm-root"), pairs)
+        self.assertIn(("--matrix", "recipe-version:ROOT-llvm20"), pairs)
+        self.assertIn(("--matrix", "os:ubuntu-24.04"), pairs)
+        self.assertIn(("--matrix", "recipe-arch:x86_64"), pairs)
+
+    def test_default_platforms_present_when_no_actrc(self):
+        with mock.patch.object(repro, "_actrc_platforms",
+                               return_value=set()):
+            cmd = repro.build_act_command(_ns(job="test", shell=False))
+        pairs = list(zip(cmd, cmd[1:]))
+        self.assertIn(("-P",
+                       "ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04"),
+                      pairs)
+
+    def test_actrc_slug_skipped(self):
+        # User has -P ubuntu-24.04=... in ~/.actrc; bin/repro must
+        # NOT inject its own default for that slug, or the user's
+        # mapping gets silently overridden.
+        with mock.patch.object(repro, "_actrc_platforms",
+                               return_value={"ubuntu-24.04"}):
+            cmd = repro.build_act_command(_ns(job="test", shell=False))
+        # Other defaults still present.
+        pairs = list(zip(cmd, cmd[1:]))
+        self.assertIn(("-P",
+                       "ubuntu-22.04=ghcr.io/catthehacker/ubuntu:act-22.04"),
+                      pairs)
+        # ubuntu-24.04 NOT injected.
+        self.assertFalse(
+            any(p[0] == "-P" and p[1].startswith("ubuntu-24.04=")
+                for p in pairs)
+        )
+
+    def test_save_temps_implies_act_reuse_even_without_shell(self):
+        """--save-temps needs the container to outlive act, same as
+        --shell. Without --reuse act would set autoremove=true and the
+        container would be gone before save-temps could preserve it."""
+        cmd = repro.build_act_command(_ns(job="test", shell=False,
+                                          save_temps=True))
+        self.assertIn("--reuse", cmd)
+
+    def test_no_shell_no_save_temps_omits_act_reuse(self):
+        """Default (act --rm) cleanup -- nothing for bin/repro to do
+        afterwards."""
+        cmd = repro.build_act_command(_ns(job="test", shell=False))
+        self.assertNotIn("--reuse", cmd)
+
+    def test_dry_run_passes_act_dash_n(self):
+        cmd = repro.build_act_command(_ns(job="test", shell=False,
+                                          dry_run=True))
+        self.assertIn("-n", cmd)
+
+    def test_dry_run_omits_act_reuse_even_with_shell(self):
+        """Dry-run never creates a container, so --reuse is moot.
+        We still pass --reuse here (build_act_command honors --shell
+        regardless), but main() short-circuits before any docker
+        interaction. The shape stays consistent."""
+        cmd = repro.build_act_command(_ns(job="test", shell=True,
+                                          dry_run=True))
+        # --reuse stays since --shell is True; main() handles the
+        # actual short-circuit. Just pin -n is present.
+        self.assertIn("-n", cmd)
+
+    def test_arch_matrix_differing_from_host_passes_container_architecture(self):
+        """Apple Silicon host (arm64), x86_64 cell: bin/repro must
+        force docker to run the runner image as linux/amd64,
+        otherwise docker pulls the arm64 variant by default and
+        x86_64 LLVM binaries fail inside."""
+        with mock.patch.object(repro, "host_arch", return_value="arm64"):
+            cmd = repro.build_act_command(_ns(
+                job="test", shell=False, matrix=["arch:x86_64"]))
+        self.assertIn("--container-architecture", cmd)
+        i = cmd.index("--container-architecture")
+        self.assertEqual(cmd[i + 1], "linux/amd64")
+
+    def test_arch_matrix_matching_host_omits_container_architecture(self):
+        """Host arch matches cell: act's default (host arch) is
+        already correct; passing --container-architecture would be
+        redundant."""
+        with mock.patch.object(repro, "host_arch", return_value="x86_64"):
+            cmd = repro.build_act_command(_ns(
+                job="test", shell=False, matrix=["arch:x86_64"]))
+        self.assertNotIn("--container-architecture", cmd)
+
+    def test_no_arch_matrix_omits_container_architecture(self):
+        """No -m arch:<X>, no -m os:<X>, no -m name:<X> -> we don't
+        know the cell's arch -> let act use its default. Don't
+        second-guess."""
+        with mock.patch.object(repro, "host_arch", return_value="arm64"):
+            cmd = repro.build_act_command(_ns(
+                job="test", shell=False, matrix=["recipe:llvm-asan"]))
+        self.assertNotIn("--container-architecture", cmd)
+
+    def test_os_matrix_derives_container_architecture(self):
+        """`-m os:ubuntu-24.04` on an arm64 host: the slug uniquely
+        implies x86_64, so bin/repro should set linux/amd64 even
+        though the user didn't say `arch:`."""
+        with mock.patch.object(repro, "host_arch", return_value="arm64"):
+            cmd = repro.build_act_command(_ns(
+                job="test", shell=False, matrix=["os:ubuntu-24.04"]))
+        self.assertIn("--container-architecture", cmd)
+        i = cmd.index("--container-architecture")
+        self.assertEqual(cmd[i + 1], "linux/amd64")
+
+    def test_name_matrix_resolves_arch_via_dryrun_lookup(self):
+        """`-m name:<row>`: bin/repro looks the row up in the
+        act -n --json data and reads `os` from the matrix dict."""
+        rows = [{"jobID": "build",
+                 "matrix": {"name": "row-x86", "os": "ubuntu-24.04"},
+                 "workflow_name": "CI", "row_name": "row-x86"}]
+        with mock.patch.object(repro, "host_arch", return_value="arm64"), \
+             mock.patch.object(repro, "_act_dryrun_rows", return_value=rows):
+            cmd = repro.build_act_command(_ns(
+                job="test", shell=False, matrix=["name:row-x86"]))
+        i = cmd.index("--container-architecture")
+        self.assertEqual(cmd[i + 1], "linux/amd64")
+
+
+# ---------------------------------------------------------------------------
+# Container discovery + cleanup
+# ---------------------------------------------------------------------------
+
+class FindRecentActContainerTests(unittest.TestCase):
+    def test_returns_id_when_present(self):
+        with mock.patch.object(repro.subprocess, "run") as run:
+            run.return_value = mock.Mock(stdout="abc123def\n", returncode=0)
+            self.assertEqual(repro.find_recent_act_container(), "abc123def")
+
+    def test_returns_none_when_empty(self):
+        with mock.patch.object(repro.subprocess, "run") as run:
+            run.return_value = mock.Mock(stdout="\n", returncode=0)
+            self.assertIsNone(repro.find_recent_act_container())
+
+    def test_filter_args_target_act_containers(self):
+        with mock.patch.object(repro.subprocess, "run") as run:
+            run.return_value = mock.Mock(stdout="", returncode=0)
+            repro.find_recent_act_container()
+            argv = run.call_args[0][0]
+            self.assertIn("--filter", argv)
+            self.assertIn("name=act-", argv)
+            self.assertIn("--latest", argv)
+
+
+class RemoveContainerTests(unittest.TestCase):
+    def test_invokes_docker_rm_dash_f(self):
+        with mock.patch.object(repro.subprocess, "run") as run:
+            repro.remove_container("abc123")
+            run.assert_called_once()
+            argv = run.call_args[0][0]
+            self.assertEqual(argv, ["docker", "rm", "-f", "abc123"])
+
+
+# ---------------------------------------------------------------------------
+# _confirm: y/n prompt with TTY fallback
+# ---------------------------------------------------------------------------
+
+class PublishedCellsTests(unittest.TestCase):
+    """published_cells parses cells.yaml into a list of dicts. Inputs
+    are well-defined (one inline-flow YAML row per cell), so a
+    hand-rolled parser is enough."""
+
+    def test_parses_repo_cells_yaml_to_nonempty_list(self):
+        # Sanity check against the real cells.yaml at repo root.
+        cells = repro.published_cells()
+        self.assertGreater(len(cells), 0)
+        for c in cells:
+            for k in ("recipe", "version", "os", "arch"):
+                self.assertIn(k, c)
+
+    def test_missing_file_returns_empty_list(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as d:
+            self.assertEqual(
+                repro.published_cells(Path(d) / "nope.yaml"), [])
+
+    def test_strips_quotes_around_values(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from textwrap import dedent
+        cells_text = dedent("""\
+            cells:
+              - { recipe: llvm-asan, version: '22', os: ubuntu-24.04, arch: x86_64 }
+              - { recipe: llvm-root, version: "ROOT-llvm20", os: macos-26, arch: arm64 }
+            """)
+        with TemporaryDirectory() as d:
+            p = Path(d) / "cells.yaml"
+            p.write_text(cells_text)
+            cells = repro.published_cells(p)
+        self.assertEqual(len(cells), 2)
+        self.assertEqual(cells[0]["version"], "22")        # single-quotes stripped
+        self.assertEqual(cells[1]["version"], "ROOT-llvm20")  # double-quotes stripped
+
+    def test_stops_at_next_top_level_key(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from textwrap import dedent
+        cells_text = dedent("""\
+            cells:
+              - { recipe: llvm-asan, version: '22', os: ubuntu-24.04, arch: x86_64 }
+            other_key:
+              foo: bar
+            """)
+        with TemporaryDirectory() as d:
+            p = Path(d) / "cells.yaml"
+            p.write_text(cells_text)
+            cells = repro.published_cells(p)
+        self.assertEqual(len(cells), 1)
+
+
+class ResolveWorkflowTests(unittest.TestCase):
+    """`-W foo.yml` from the user's checkout typically means "the
+    foo.yml in this repo's .github/workflows/", not a literal
+    cwd-relative path. Pin the resolution behaviour."""
+
+    def test_passthrough_when_path_exists_as_given(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as d:
+            literal = Path(d) / "explicit.yml"
+            literal.write_text("name: t\n")
+            self.assertEqual(repro.resolve_workflow(str(literal)),
+                             str(literal))
+
+    def test_bare_basename_expands_to_github_workflows(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as d:
+            wfdir = Path(d) / ".github" / "workflows"
+            wfdir.mkdir(parents=True)
+            (wfdir / "main.yml").write_text("name: t\n")
+            old = os.getcwd()
+            try:
+                os.chdir(d)
+                # Compare via Path.as_posix() so the test passes on
+                # Windows (where str(Path('a/b')) yields 'a\\b').
+                self.assertEqual(
+                    Path(repro.resolve_workflow("main.yml")).as_posix(),
+                    ".github/workflows/main.yml")
+            finally:
+                os.chdir(old)
+
+    def test_neither_path_passes_through_for_act_to_complain(self):
+        # If both forms miss, return the original; act will emit
+        # the clearer "no such file" message itself.
+        self.assertEqual(repro.resolve_workflow("nope.yml"), "nope.yml")
+
+    def test_none_passes_through(self):
+        self.assertIsNone(repro.resolve_workflow(None))
+
+
+class CheckJobAmbiguousTests(unittest.TestCase):
+    """Pin the load-bearing pre-flight: bin/repro must refuse to
+    proceed when -j matches multiple workflow files and -W wasn't
+    given. Without this, the user's actual `bin/repro -j build`
+    invocation ran build jobs from five different workflows in
+    parallel."""
+
+    DUP_LISTING = [
+        {"stage": "0", "job_id": "build", "job_name": "build",
+         "workflow_name": "Markdown-Linter",
+         "workflow_file": "markdown-linter.yml"},
+        {"stage": "1", "job_id": "build", "job_name": "${{ matrix.name }}",
+         "workflow_name": "Native Builds",
+         "workflow_file": "main.yml"},
+    ]
+
+    def test_ambiguous_without_workflow_exits(self):
+        ns = argparse.Namespace(job="build", workflow=None)
+        with mock.patch.object(repro, "_act_listing",
+                               return_value=self.DUP_LISTING):
+            with self.assertRaises(SystemExit) as cm:
+                repro.check_job_ambiguous(ns)
+        msg = str(cm.exception)
+        self.assertIn("multiple workflows", msg)
+        self.assertIn("markdown-linter.yml", msg)
+        self.assertIn("main.yml", msg)
+        self.assertIn("-W ", msg)  # copy-pasteable hint
+
+    def test_with_workflow_short_circuits(self):
+        ns = argparse.Namespace(job="build", workflow="main.yml")
+        # Even if act_listing would say ambiguous, we trust the user.
+        with mock.patch.object(repro, "_act_listing",
+                               return_value=self.DUP_LISTING):
+            repro.check_job_ambiguous(ns)  # must not raise
+
+    def test_unique_job_id_does_not_exit(self):
+        ns = argparse.Namespace(job="precheckin", workflow=None)
+        with mock.patch.object(repro, "_act_listing",
+                               return_value=[
+                                   {"stage": "0", "job_id": "precheckin",
+                                    "job_name": "precheckin",
+                                    "workflow_name": "clang-format",
+                                    "workflow_file": "clang-format.yml"}]):
+            repro.check_job_ambiguous(ns)  # must not raise
+
+    def test_listing_failure_does_not_exit(self):
+        """If act -l can't be parsed, fall through to act and let act
+        complain naturally rather than blocking."""
+        ns = argparse.Namespace(job="build", workflow=None)
+        with mock.patch.object(repro, "_act_listing", return_value=[]):
+            repro.check_job_ambiguous(ns)  # no-op
+
+
+class HostArchTests(unittest.TestCase):
+    """Pin the Rosetta-aware host detection so the 'most efficient
+    cell' suggestion doesn't silently regress Apple Silicon users to
+    'host is x86_64' on x86_64 Pythons."""
+
+    def test_darwin_arm64_via_sysctl_even_under_rosetta(self):
+        with mock.patch.object(repro.platform, "system", return_value="Darwin"), \
+             mock.patch.object(repro.platform, "machine", return_value="x86_64"), \
+             mock.patch.object(repro.subprocess, "run") as run:
+            run.return_value = mock.Mock(stdout="1\n", returncode=0)
+            self.assertEqual(repro.host_arch(), "arm64")
+
+    def test_darwin_intel_when_sysctl_returns_zero(self):
+        with mock.patch.object(repro.platform, "system", return_value="Darwin"), \
+             mock.patch.object(repro.platform, "machine", return_value="x86_64"), \
+             mock.patch.object(repro.subprocess, "run") as run:
+            run.return_value = mock.Mock(stdout="0\n", returncode=0)
+            self.assertEqual(repro.host_arch(), "x86_64")
+
+    def test_linux_aarch64_normalized_to_arm64(self):
+        with mock.patch.object(repro.platform, "system", return_value="Linux"), \
+             mock.patch.object(repro.platform, "machine", return_value="aarch64"):
+            self.assertEqual(repro.host_arch(), "arm64")
+
+
+class ListJobsCellHintTests(unittest.TestCase):
+    """After `act -l`, list_jobs prints the published cells from
+    cells.yaml so the user can pick a matrix row that hits the
+    download-fast path instead of building inline."""
+
+    def test_hint_emits_minimal_repro_for_unique_row_name(self):
+        # A row whose name is unique across workflows gets the bare
+        # `bin/repro -m name:<row>` -- no -W / -j needed; main()
+        # auto-detects them.
+        fake_cells = [{"recipe": "llvm-asan", "version": "22",
+                       "os": "ubuntu-24.04", "arch": "x86_64"}]
+        fake_rows = [("main.yml", "build",
+                      "ubu24-x86-clang22-llvm22-asan-ubsan")]
+        fake_dryrun = [{
+            "jobID": "build",
+            "matrix": {"name": "ubu24-x86-clang22-llvm22-asan-ubsan",
+                       "use-recipe": "llvm-asan",
+                       "clang-runtime": "22",
+                       "os": "ubuntu-24.04"},
+            "workflow_name": "CI",
+            "row_name": "ubu24-x86-clang22-llvm22-asan-ubsan",
+        }]
+        with mock.patch.object(repro, "_require", side_effect=lambda x: x), \
+             mock.patch.object(repro.subprocess, "Popen") as popen, \
+             mock.patch.object(repro, "published_cells",
+                               return_value=fake_cells), \
+             mock.patch.object(repro, "discover_matrix_rows",
+                               return_value=fake_rows), \
+             mock.patch.object(repro, "_act_dryrun_rows",
+                               return_value=fake_dryrun), \
+             mock.patch.object(repro, "_failed_rows_for_branch",
+                               return_value=set()), \
+             mock.patch.object(repro, "host_arch", return_value="x86_64"):
+            popen.return_value.wait = lambda: 0
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                repro.list_jobs(_ns(list=True))
+        out = buf.getvalue()
+        self.assertIn(
+            "bin/repro ubu24-x86-clang22-llvm22-asan-ubsan",
+            out)
+        self.assertIn(
+            "[cell: llvm-asan/22/ubuntu-24.04/x86_64]", out)
+        self.assertNotIn("-W main.yml", out)
+
+    def test_hint_full_form_when_row_name_collides(self):
+        # Same row name across two workflows: the minimal form is
+        # ambiguous, so emit the full -W / -j form for each.
+        fake_rows = [
+            ("main.yml", "build", "shared-row-name"),
+            ("other.yml", "build", "shared-row-name"),
+        ]
+        with mock.patch.object(repro, "_require", side_effect=lambda x: x), \
+             mock.patch.object(repro.subprocess, "Popen") as popen, \
+             mock.patch.object(repro, "published_cells", return_value=[]), \
+             mock.patch.object(repro, "discover_matrix_rows",
+                               return_value=fake_rows), \
+             mock.patch.object(repro, "_failed_rows_for_branch",
+                               return_value=set()), \
+             mock.patch.object(repro, "host_arch", return_value="x86_64"):
+            popen.return_value.wait = lambda: 0
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                repro.list_jobs(_ns(list=True))
+        out = buf.getvalue()
+        self.assertIn(
+            "bin/repro -W main.yml -j build -m name:shared-row-name",
+            out)
+        self.assertIn(
+            "bin/repro -W other.yml -j build -m name:shared-row-name",
+            out)
+
+
+class FindWorkflowForCellMatrixTests(unittest.TestCase):
+    """When the user's -m flags pin a recipe, only one workflow in
+    .github/workflows/ typically consumes that recipe. bin/repro
+    auto-picks -W so the user doesn't have to type it."""
+
+    def test_unique_workflow_matched_by_recipe(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from textwrap import dedent
+        with TemporaryDirectory() as d:
+            base = Path(d)
+            wfdir = base / ".github" / "workflows"
+            wfdir.mkdir(parents=True)
+            # Workflow A: setup-recipe with llvm-asan -> match.
+            (wfdir / "ci.yml").write_text(dedent("""\
+                jobs:
+                  build:
+                    runs-on: ubuntu-24.04
+                    steps:
+                      - uses: compiler-research/ci-workflows/actions/setup-recipe@main
+                        with:
+                          recipe: llvm-asan
+                """))
+            # Workflow B: setup-recipe but for a different recipe.
+            (wfdir / "root.yml").write_text(dedent("""\
+                jobs:
+                  build:
+                    runs-on: ubuntu-24.04
+                    steps:
+                      - uses: compiler-research/ci-workflows/actions/setup-recipe@main
+                        with:
+                          recipe: llvm-root
+                """))
+            wf, job = repro.find_workflow_for_cell_matrix(
+                ["recipe:llvm-asan", "version:22"], cwd=base)
+        # Path.as_posix() so the test passes on Windows (str(Path('a/b'))
+        # yields 'a\\b').
+        self.assertEqual(Path(wf).as_posix(), ".github/workflows/ci.yml")
+        self.assertEqual(job, "build")
+
+    def test_no_recipe_in_matrix_returns_none(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as d:
+            self.assertIsNone(
+                repro.find_workflow_for_cell_matrix([], cwd=Path(d)))
+            self.assertIsNone(
+                repro.find_workflow_for_cell_matrix(
+                    ["arch:x86_64"], cwd=Path(d)))
+
+    def test_multiple_matches_returns_none(self):
+        """Two workflows both setup-recipe llvm-asan: ambiguous,
+        let check_job_ambiguous report it instead of guessing."""
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from textwrap import dedent
+        with TemporaryDirectory() as d:
+            base = Path(d)
+            wfdir = base / ".github" / "workflows"
+            wfdir.mkdir(parents=True)
+            for name in ("ci.yml", "release.yml"):
+                (wfdir / name).write_text(dedent("""\
+                    jobs:
+                      build:
+                        steps:
+                          - uses: compiler-research/ci-workflows/actions/setup-recipe@main
+                            with:
+                              recipe: llvm-asan
+                    """))
+            self.assertIsNone(repro.find_workflow_for_cell_matrix(
+                ["recipe:llvm-asan"], cwd=base))
+
+    def test_no_workflows_dir_returns_none(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as d:
+            self.assertIsNone(repro.find_workflow_for_cell_matrix(
+                ["recipe:llvm-asan"], cwd=Path(d)))
+
+
+class FindWorkflowViaDryRunTests(unittest.TestCase):
+    """Disambiguation fallback: when text-grep can't pick a unique
+    workflow, run `act -n -W <each>` per candidate and keep only
+    those whose dry-run accepts the matrix filter."""
+
+    LISTING = [
+        {"stage": "0", "job_id": "build", "job_name": "Linter",
+         "workflow_name": "Markdown-Linter",
+         "workflow_file": "markdown-linter.yml"},
+        {"stage": "0", "job_id": "build", "job_name": "${{ matrix.name }}",
+         "workflow_name": "Native Builds",
+         "workflow_file": "main.yml"},
+    ]
+
+    def test_unique_dry_run_match_returned(self):
+        """Two workflows have job=build; only main.yml's dry-run
+        emits a Run-Set-up-job marker (matches our matrix filter).
+        Pick main.yml."""
+        def fake_run(cmd, **kw):
+            wf = cmd[cmd.index("-W") + 1]
+            if "main.yml" in wf:
+                return mock.Mock(returncode=0,
+                                 stdout="[Native Builds/build] ⭐ Run Set up job\n")
+            return mock.Mock(returncode=0, stdout="")  # no rows matched
+
+        with mock.patch.object(repro, "_act_listing",
+                               return_value=self.LISTING), \
+             mock.patch.object(repro.subprocess, "run",
+                               side_effect=fake_run), \
+             mock.patch.object(repro, "_require",
+                               side_effect=lambda x: x), \
+             mock.patch.object(repro, "resolve_workflow",
+                               side_effect=lambda x: x), \
+             mock.patch("pathlib.Path.is_file", return_value=True):
+            r = repro.find_workflow_via_dry_run(
+                _ns(job="build", matrix=["recipe:llvm-root"]))
+        self.assertEqual(r, ("main.yml", "build"))
+
+    def test_multiple_dry_run_matches_returns_none(self):
+        """Both workflows accept the filter -- still ambiguous, defer
+        to check_job_ambiguous's user-facing error."""
+        def fake_run(cmd, **kw):
+            return mock.Mock(returncode=0, stdout="⭐ Run Set up job\n")
+        with mock.patch.object(repro, "_act_listing",
+                               return_value=self.LISTING), \
+             mock.patch.object(repro.subprocess, "run",
+                               side_effect=fake_run), \
+             mock.patch.object(repro, "_require",
+                               side_effect=lambda x: x), \
+             mock.patch.object(repro, "resolve_workflow",
+                               side_effect=lambda x: x), \
+             mock.patch("pathlib.Path.is_file", return_value=True):
+            self.assertIsNone(repro.find_workflow_via_dry_run(
+                _ns(job="build", matrix=["recipe:llvm-root"])))
+
+    def test_empty_listing_returns_none(self):
+        with mock.patch.object(repro, "_act_listing", return_value=[]):
+            self.assertIsNone(repro.find_workflow_via_dry_run(
+                _ns(job="build", matrix=["recipe:llvm-root"])))
+
+
+class ConfirmTests(unittest.TestCase):
+    def test_no_tty_returns_default(self):
+        with mock.patch.object(repro.sys.stdin, "isatty", return_value=False):
+            self.assertTrue(repro._confirm("?", default=True))
+            self.assertFalse(repro._confirm("?", default=False))
+
+    def test_bare_enter_picks_default(self):
+        with mock.patch.object(repro.sys.stdin, "isatty", return_value=True), \
+             mock.patch.object(repro.sys.stdin, "readline", return_value="\n"):
+            self.assertTrue(repro._confirm("?", default=True))
+            self.assertFalse(repro._confirm("?", default=False))
+
+    def test_yes_responses(self):
+        for resp in ("y\n", "Y\n", "yes\n", "YES\n", "Yes\n"):
+            with mock.patch.object(repro.sys.stdin, "isatty", return_value=True), \
+                 mock.patch.object(repro.sys.stdin, "readline", return_value=resp):
+                self.assertTrue(repro._confirm("?", default=False),
+                                msg=f"expected True for {resp!r}")
+
+    def test_no_response_falls_through_to_false_when_default_true(self):
+        with mock.patch.object(repro.sys.stdin, "isatty", return_value=True), \
+             mock.patch.object(repro.sys.stdin, "readline", return_value="n\n"):
+            self.assertFalse(repro._confirm("?", default=True))
+
+    def test_eof_returns_default(self):
+        """Ctrl+D / closed stdin during prompt: don't hang, use default."""
+        with mock.patch.object(repro.sys.stdin, "isatty", return_value=True), \
+             mock.patch.object(repro.sys.stdin, "readline",
+                               side_effect=EOFError):
+            self.assertTrue(repro._confirm("?", default=True))
+
+
+# ---------------------------------------------------------------------------
+# In-container patch export
+# ---------------------------------------------------------------------------
+
+class ContainerTreeDirtyTests(unittest.TestCase):
+    def test_clean_returns_false(self):
+        with mock.patch.object(repro.subprocess, "run") as run:
+            run.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+            self.assertFalse(repro._container_tree_dirty("cid", "/ws"))
+        # Sanity: invocation shape.
+        argv = run.call_args[0][0]
+        self.assertEqual(argv[:3], ["docker", "exec", "cid"])
+        self.assertIn("--quiet", argv)
+        self.assertIn("HEAD", argv)
+
+    def test_diff_present_returns_true(self):
+        with mock.patch.object(repro.subprocess, "run") as run:
+            run.return_value = mock.Mock(returncode=1, stdout="", stderr="")
+            self.assertTrue(repro._container_tree_dirty("cid", "/ws"))
+
+    def test_not_a_git_repo_returns_false(self):
+        """rc=128 (no HEAD, no .git, git missing) is not actionable
+        here -- the user can always docker exec themselves; we'd just
+        be noisy. Behave as 'nothing to export'."""
+        with mock.patch.object(repro.subprocess, "run") as run:
+            run.return_value = mock.Mock(returncode=128, stdout="",
+                                          stderr="not a git repo")
+            self.assertFalse(repro._container_tree_dirty("cid", "/ws"))
+
+
+class MaybeExportInContainerPatchTests(unittest.TestCase):
+    def test_clean_tree_skips_prompt(self):
+        with mock.patch.object(repro, "_container_tree_dirty",
+                               return_value=False), \
+             mock.patch.object(repro, "_confirm") as conf:
+            repro.maybe_export_in_container_patch("cid", "row1")
+        conf.assert_not_called()
+
+    def test_dirty_tree_prompts_default_yes(self):
+        """Default Y -- losing in-container edits is the worse
+        failure mode."""
+        with mock.patch.object(repro, "_container_tree_dirty",
+                               return_value=True), \
+             mock.patch.object(repro, "_confirm",
+                               return_value=False) as conf, \
+             mock.patch.object(repro, "_export_container_patch") as exp:
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                repro.maybe_export_in_container_patch("cid", "row1")
+        conf.assert_called_once()
+        self.assertEqual(conf.call_args.kwargs.get("default"), True)
+        # User declined -> no export.
+        exp.assert_not_called()
+
+    def test_user_confirms_export_writes_patch_and_logs_apply_hint(self):
+        with mock.patch.object(repro, "_container_tree_dirty",
+                               return_value=True), \
+             mock.patch.object(repro, "_confirm", return_value=True), \
+             mock.patch.object(repro, "_export_container_patch",
+                               return_value=True) as exp:
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                repro.maybe_export_in_container_patch("cid", "row1")
+        # Wrote to /tmp/repro-<row>.patch.
+        args = exp.call_args[0]
+        self.assertEqual(args[0], "cid")
+        # Path.as_posix() so the test passes on Windows.
+        self.assertEqual(args[2].as_posix(), "/tmp/repro-row1.patch")
+        self.assertIn("git apply", buf.getvalue())
+
+    def test_no_row_falls_back_to_session_name(self):
+        with mock.patch.object(repro, "_container_tree_dirty",
+                               return_value=True), \
+             mock.patch.object(repro, "_confirm", return_value=True), \
+             mock.patch.object(repro, "_export_container_patch",
+                               return_value=True) as exp:
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                repro.maybe_export_in_container_patch("cid", None)
+        # Path.as_posix() so the test passes on Windows.
+        self.assertEqual(exp.call_args[0][2].as_posix(),
+                         "/tmp/repro-session.patch")
+
+    def test_export_failure_does_not_log_apply_hint(self):
+        """If the patch write fails, don't tell the user to apply
+        a file that doesn't exist."""
+        with mock.patch.object(repro, "_container_tree_dirty",
+                               return_value=True), \
+             mock.patch.object(repro, "_confirm", return_value=True), \
+             mock.patch.object(repro, "_export_container_patch",
+                               return_value=False):
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                repro.maybe_export_in_container_patch("cid", "row1")
+        self.assertNotIn("git apply", buf.getvalue())
+
+
+# ---------------------------------------------------------------------------
+# Workspace-clash pre-flight
+# ---------------------------------------------------------------------------
+
+class WorkspaceClashTests(unittest.TestCase):
+    def _ns_clash(self, **kw):
+        # MainDispatch fields are a superset; warn_workspace_clashes
+        # only reads dry_run and skip_clash_check.
+        defaults = dict(dry_run=False, skip_clash_check=False)
+        defaults.update(kw)
+        return argparse.Namespace(**defaults)
+
+    def test_no_clash_no_warning(self):
+        with mock.patch.object(repro, "detect_workspace_clashes",
+                               return_value=[]), \
+             mock.patch.object(repro, "_confirm") as conf:
+            repro.warn_workspace_clashes(self._ns_clash())
+        conf.assert_not_called()
+
+    def test_clash_prompts_and_exits_on_decline(self):
+        """Default answer is 'no' (don't proceed). Bare-Enter at the
+        prompt -> SystemExit(1). The user lost no data; they get to
+        clean up and re-run."""
+        with mock.patch.object(repro, "detect_workspace_clashes",
+                               return_value=[Path("/tmp/build")]), \
+             mock.patch.object(repro, "_confirm",
+                               return_value=False) as conf:
+            buf = io.StringIO()
+            with redirect_stderr(buf), \
+                 self.assertRaises(SystemExit) as cm:
+                repro.warn_workspace_clashes(self._ns_clash())
+        self.assertEqual(cm.exception.code, 1)
+        # Prompt fired with default=False (the safer choice).
+        conf.assert_called_once()
+        self.assertEqual(conf.call_args.kwargs.get("default"), False)
+        # Listed paths are surfaced in the warning. The code logs
+        # via str(Path), so use the same form here -- str(Path('/tmp/
+        # build')) is '/tmp/build' on POSIX and '\\tmp\\build' on
+        # Windows.
+        self.assertIn(str(Path("/tmp/build")), buf.getvalue())
+
+    def test_clash_proceeds_when_user_confirms(self):
+        with mock.patch.object(repro, "detect_workspace_clashes",
+                               return_value=[Path("/tmp/build")]), \
+             mock.patch.object(repro, "_confirm", return_value=True):
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                # Should not raise.
+                repro.warn_workspace_clashes(self._ns_clash())
+
+    def test_skip_flag_bypasses_check_entirely(self):
+        with mock.patch.object(repro, "detect_workspace_clashes") as det, \
+             mock.patch.object(repro, "_confirm") as conf:
+            repro.warn_workspace_clashes(
+                self._ns_clash(skip_clash_check=True))
+        det.assert_not_called()
+        conf.assert_not_called()
+
+    def test_dry_run_bypasses_check(self):
+        """--dry-run: act doesn't actually mkdir anything; the clash
+        is only relevant for real runs."""
+        with mock.patch.object(repro, "detect_workspace_clashes") as det, \
+             mock.patch.object(repro, "_confirm") as conf:
+            repro.warn_workspace_clashes(self._ns_clash(dry_run=True))
+        det.assert_not_called()
+        conf.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# SIGINT handling
+# ---------------------------------------------------------------------------
+
+class RunInteractiveTests(unittest.TestCase):
+    def test_sigint_ignored_during_run_then_restored(self):
+        observed = []
+
+        def fake_popen(_cmd):
+            class _Proc:
+                def wait(self_):
+                    observed.append(_signal.getsignal(_signal.SIGINT))
+                    return 0
+            return _Proc()
+
+        sentinel = lambda *a: None
+        prev = _signal.signal(_signal.SIGINT, sentinel)
+        try:
+            with mock.patch.object(repro.subprocess, "Popen",
+                                   side_effect=fake_popen):
+                rc = repro._run_interactive(["act"])
+            self.assertEqual(rc, 0)
+            self.assertEqual(observed, [_signal.SIG_IGN])
+            self.assertEqual(_signal.getsignal(_signal.SIGINT), sentinel)
+        finally:
+            _signal.signal(_signal.SIGINT, prev)
+
+    def test_handler_restored_on_subprocess_exception(self):
+        def fake_popen(_cmd):
+            class _Proc:
+                def wait(self_):
+                    raise OSError("simulated")
+            return _Proc()
+
+        sentinel = lambda *a: None
+        prev = _signal.signal(_signal.SIGINT, sentinel)
+        try:
+            with mock.patch.object(repro.subprocess, "Popen",
+                                   side_effect=fake_popen):
+                with self.assertRaises(OSError):
+                    repro._run_interactive(["act"])
+            self.assertEqual(_signal.getsignal(_signal.SIGINT), sentinel)
+        finally:
+            _signal.signal(_signal.SIGINT, prev)
+
+
+# ---------------------------------------------------------------------------
+# main() dispatch
+# ---------------------------------------------------------------------------
+
+class MainDispatchTests(unittest.TestCase):
+    def test_list_short_circuits_to_act_dash_l(self):
+        argv = ["bin/repro", "--list"]
+        with mock.patch.object(sys, "argv", argv), \
+             mock.patch.object(repro, "_require", side_effect=lambda x: x), \
+             mock.patch.object(repro.subprocess, "Popen") as popen, \
+             mock.patch.object(repro, "host_arch", return_value="x86_64"):
+            popen.return_value = mock.Mock()
+            popen.return_value.wait = lambda: 0
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                rc = repro.main()
+        self.assertEqual(rc, 0)
+        # First Popen call is `act -l` (before _print_fast_cells_hint).
+        cmd = popen.call_args_list[0][0][0]
+        self.assertEqual(cmd, ["act", "-l"])
+
+    def test_no_job_no_list_exits(self):
+        argv = ["bin/repro"]
+        with mock.patch.object(sys, "argv", argv), \
+             mock.patch.object(repro, "_require", side_effect=lambda x: x):
+            with self.assertRaises(SystemExit) as cm:
+                repro.main()
+        self.assertIn("-j NAME, --list, or -m name:", str(cm.exception))
+
+    def test_job_default_runs_shell_then_prompts_remove(self):
+        """Default flow: after act exits, drop into shell, then PROMPT
+        whether to remove the container. Bare-Enter (default=Y) -->
+        rm. Pin both that the prompt fires AND that 'yes' triggers
+        removal -- the 0-disk path's load-bearing assertion."""
+        invocations = []
+
+        def fake_popen(cmd):
+            invocations.append(("popen", cmd))
+            return mock.Mock(wait=lambda: 0)
+
+        def fake_subprocess_run(cmd, **kw):
+            invocations.append(("run", cmd[:3]))
+            if cmd[:3] == ["docker", "ps", "-aq"]:
+                return mock.Mock(stdout="abc123def\n", returncode=0)
+            return mock.Mock(stdout="", returncode=0)
+
+        argv = ["bin/repro", "-j", "test"]
+        with mock.patch.object(sys, "argv", argv), \
+             mock.patch.object(repro, "_require", side_effect=lambda x: x), \
+             mock.patch.object(repro.subprocess, "Popen",
+                               side_effect=fake_popen), \
+             mock.patch.object(repro.subprocess, "run",
+                               side_effect=fake_subprocess_run), \
+             mock.patch.object(repro, "_confirm", return_value=True) as conf:
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                rc = repro.main()
+        self.assertEqual(rc, 0)
+        # Prompt was issued.
+        conf.assert_called_once()
+        self.assertIn("remove container", conf.call_args[0][0])
+
+        # 1. act ran with --reuse.
+        act_cmds = [c for kind, c in invocations if kind == "popen"
+                    and c[0] == "act"]
+        self.assertEqual(len(act_cmds), 1)
+        self.assertIn("--reuse", act_cmds[0])
+
+        # 2. docker exec into the discovered container.
+        exec_cmds = [c for kind, c in invocations if kind == "popen"
+                     and c[0] == "docker" and c[1] == "exec"]
+        self.assertEqual(len(exec_cmds), 1)
+        self.assertEqual(exec_cmds[0],
+                         ["docker", "exec", "-it", "abc123def", "bash"])
+
+        # 3. docker rm fired (user said yes at the prompt).
+        rm_calls = [c for kind, c in invocations if kind == "run"
+                    and c[:3] == ["docker", "rm", "-f"]]
+        self.assertEqual(len(rm_calls), 1)
+
+    def test_user_declines_remove_keeps_container_logs_reentry(self):
+        """User answers 'n' at the prompt: container preserved and
+        the re-entry hint is logged."""
+        invocations = []
+        def fake_popen(cmd):
+            invocations.append(("popen", cmd))
+            return mock.Mock(wait=lambda: 0)
+        def fake_subprocess_run(cmd, **kw):
+            invocations.append(("run", cmd[:3]))
+            if cmd[:3] == ["docker", "ps", "-aq"]:
+                return mock.Mock(stdout="abc123def\n", returncode=0)
+            return mock.Mock(stdout="", returncode=0)
+
+        argv = ["bin/repro", "-j", "test"]
+        with mock.patch.object(sys, "argv", argv), \
+             mock.patch.object(repro, "_require", side_effect=lambda x: x), \
+             mock.patch.object(repro.subprocess, "Popen",
+                               side_effect=fake_popen), \
+             mock.patch.object(repro.subprocess, "run",
+                               side_effect=fake_subprocess_run), \
+             mock.patch.object(repro, "_confirm", return_value=False):
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                repro.main()
+        # No `docker rm -f` because user said no.
+        rm_calls = [c for kind, c in invocations if kind == "run"
+                    and c[:3] == ["docker", "rm", "-f"]]
+        self.assertEqual(rm_calls, [])
+        # Re-entry hint logged.
+        out = buf.getvalue()
+        self.assertIn("preserved", out)
+        self.assertIn("docker exec", out)
+        self.assertIn("abc123def", out)
+
+    def test_save_temps_skips_prompt(self):
+        """--save-temps is the user pre-answering 'no' before the
+        shell starts; no prompt should fire."""
+        with mock.patch.object(sys, "argv",
+                               ["bin/repro", "-j", "test", "--save-temps"]), \
+             mock.patch.object(repro, "_require", side_effect=lambda x: x), \
+             mock.patch.object(repro.subprocess, "Popen") as popen, \
+             mock.patch.object(repro.subprocess, "run") as run, \
+             mock.patch.object(repro, "_confirm") as conf:
+            popen.return_value.wait = lambda: 0
+            run.side_effect = lambda cmd, **kw: (
+                mock.Mock(stdout="abc123def\n", returncode=0)
+                if cmd[:3] == ["docker", "ps", "-aq"]
+                else mock.Mock(stdout="", returncode=0))
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                repro.main()
+        conf.assert_not_called()
+
+    def test_no_shell_no_save_temps_does_nothing_post_run(self):
+        """act with autoremove=true cleans up its own container; the
+        script just propagates the exit code."""
+        invocations = []
+        def fake_popen(cmd):
+            invocations.append(("popen", cmd))
+            return mock.Mock(wait=lambda: 7)
+        def fake_subprocess_run(cmd, **kw):
+            invocations.append(("run", cmd[:3]))
+            return mock.Mock(stdout="", returncode=0)
+
+        argv = ["bin/repro", "-j", "test", "--no-shell"]
+        with mock.patch.object(sys, "argv", argv), \
+             mock.patch.object(repro, "_require", side_effect=lambda x: x), \
+             mock.patch.object(repro.subprocess, "Popen",
+                               side_effect=fake_popen), \
+             mock.patch.object(repro.subprocess, "run",
+                               side_effect=fake_subprocess_run):
+            rc = repro.main()
+        self.assertEqual(rc, 7)
+        # No docker exec, no docker rm. act's --reuse omitted.
+        for kind, cmd in invocations:
+            self.assertNotIn("exec", cmd)
+            self.assertNotIn("rm", cmd)
+            if kind == "popen" and cmd[0] == "act":
+                self.assertNotIn("--reuse", cmd)
+
+    def test_dry_run_skips_shell_and_cleanup(self):
+        """--dry-run never creates a container; any post-run docker
+        interaction would emit misleading output. main() must
+        short-circuit before any 'no act-* container found' message."""
+        invocations = []
+        def fake_popen(cmd):
+            invocations.append(("popen", cmd))
+            return mock.Mock(wait=lambda: 0)
+        def fake_subprocess_run(cmd, **kw):
+            invocations.append(("run", cmd[:3]))
+            return mock.Mock(stdout="", returncode=0)
+
+        argv = ["bin/repro", "-j", "test", "--dry-run"]
+        with mock.patch.object(sys, "argv", argv), \
+             mock.patch.object(repro, "_require", side_effect=lambda x: x), \
+             mock.patch.object(repro.subprocess, "Popen",
+                               side_effect=fake_popen), \
+             mock.patch.object(repro.subprocess, "run",
+                               side_effect=fake_subprocess_run):
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                rc = repro.main()
+        self.assertEqual(rc, 0)
+        # Only act ran; no docker ps/exec/rm invocations.
+        for kind, cmd in invocations:
+            self.assertNotEqual(cmd[:2], ["docker", "ps"])
+            self.assertNotIn("exec", cmd)
+            self.assertNotIn("rm", cmd)
+        # The misleading "no act-* container found" message must
+        # NOT have been logged.
+        self.assertNotIn("no act-* container", buf.getvalue())
+
+    def test_save_temps_keeps_container_and_logs_reentry(self):
+        invocations = []
+        def fake_popen(cmd):
+            invocations.append(("popen", cmd))
+            return mock.Mock(wait=lambda: 0)
+        def fake_subprocess_run(cmd, **kw):
+            invocations.append(("run", cmd[:3]))
+            if cmd[:3] == ["docker", "ps", "-aq"]:
+                return mock.Mock(stdout="abc123def\n", returncode=0)
+            return mock.Mock(stdout="", returncode=0)
+
+        argv = ["bin/repro", "-j", "test", "--no-shell", "--save-temps"]
+        with mock.patch.object(sys, "argv", argv), \
+             mock.patch.object(repro, "_require", side_effect=lambda x: x), \
+             mock.patch.object(repro.subprocess, "Popen",
+                               side_effect=fake_popen), \
+             mock.patch.object(repro.subprocess, "run",
+                               side_effect=fake_subprocess_run):
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                rc = repro.main()
+        self.assertEqual(rc, 0)
+        # No `docker rm -f` invocation.
+        rm_calls = [c for kind, c in invocations
+                    if kind == "run" and c[:3] == ["docker", "rm", "-f"]]
+        self.assertEqual(rm_calls, [])
+        # Re-entry hint logged.
+        out = buf.getvalue()
+        self.assertIn("--save-temps", out)
+        self.assertIn("docker exec", out)
+        self.assertIn("abc123def", out)
+
+    def test_shell_plus_save_temps_runs_shell_then_keeps_container(self):
+        """--shell --save-temps: drop into shell, but DON'T rm on
+        shell exit. Useful for `enter, poke, leave, come back later`
+        flows."""
+        invocations = []
+        def fake_popen(cmd):
+            invocations.append(("popen", cmd))
+            return mock.Mock(wait=lambda: 0)
+        def fake_subprocess_run(cmd, **kw):
+            invocations.append(("run", cmd[:3]))
+            if cmd[:3] == ["docker", "ps", "-aq"]:
+                return mock.Mock(stdout="abc123def\n", returncode=0)
+            return mock.Mock(stdout="", returncode=0)
+
+        argv = ["bin/repro", "-j", "test", "--save-temps"]
+        with mock.patch.object(sys, "argv", argv), \
+             mock.patch.object(repro, "_require", side_effect=lambda x: x), \
+             mock.patch.object(repro.subprocess, "Popen",
+                               side_effect=fake_popen), \
+             mock.patch.object(repro.subprocess, "run",
+                               side_effect=fake_subprocess_run):
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                rc = repro.main()
+        self.assertEqual(rc, 0)
+        # Shell ran (docker exec via Popen).
+        exec_calls = [c for kind, c in invocations
+                      if kind == "popen" and c[0] == "docker"
+                      and c[1] == "exec"]
+        self.assertEqual(len(exec_calls), 1)
+        # No `docker rm -f`.
+        rm_calls = [c for kind, c in invocations
+                    if kind == "run" and c[:3] == ["docker", "rm", "-f"]]
+        self.assertEqual(rm_calls, [])
+
+    def test_no_act_container_after_run_skips_shell(self):
+        """If act failed before creating a container, find_recent_act
+        returns None; we log and return act's rc rather than blowing
+        up trying to docker exec into nothing."""
+        def fake_popen(cmd):
+            return mock.Mock(wait=lambda: 1)
+        def fake_subprocess_run(cmd, **kw):
+            return mock.Mock(stdout="\n", returncode=0)
+
+        argv = ["bin/repro", "-j", "test"]
+        with mock.patch.object(sys, "argv", argv), \
+             mock.patch.object(repro, "_require", side_effect=lambda x: x), \
+             mock.patch.object(repro.subprocess, "Popen",
+                               side_effect=fake_popen), \
+             mock.patch.object(repro.subprocess, "run",
+                               side_effect=fake_subprocess_run):
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                rc = repro.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("no act-* container found", buf.getvalue())
+
+
+# ---------------------------------------------------------------------------
+# Row-name pattern resolution
+# ---------------------------------------------------------------------------
+
+class ResolvePatternTests(unittest.TestCase):
+    """`_resolve_pattern` is the row-name glob behind the
+    `bin/repro <name>` shortcut. Verify that unique matches populate
+    args.workflow/job/matrix correctly, ambiguous matches bail with
+    a clear message, and a typo prints the available rows."""
+
+    _ROWS = [
+        ("main.yml", "build", "ubu24-x86-gcc14"),
+        ("main.yml", "build", "ubu24-x86-clang22-asan"),
+        ("main.yml", "build", "osx26-arm-clang"),
+    ]
+
+    def _ns(self, **kw):
+        defaults = dict(workflow=None, job=None, matrix=None)
+        defaults.update(kw)
+        return argparse.Namespace(**defaults)
+
+    def test_unique_match_populates_args(self):
+        args = self._ns()
+        with mock.patch.object(repro, "discover_matrix_rows",
+                               return_value=self._ROWS):
+            repro._resolve_pattern("ubu24-x86-gcc14", args)
+        self.assertEqual(args.workflow, "main.yml")
+        self.assertEqual(args.job, "build")
+        self.assertEqual(args.matrix, ["name:ubu24-x86-gcc14"])
+
+    def test_existing_workflow_not_overwritten(self):
+        """If the user already passed -W, don't second-guess them."""
+        args = self._ns(workflow="explicit.yml")
+        with mock.patch.object(repro, "discover_matrix_rows",
+                               return_value=self._ROWS):
+            repro._resolve_pattern("ubu24-x86-gcc14", args)
+        self.assertEqual(args.workflow, "explicit.yml")
+
+    def test_glob_matching_multiple_rows_lists_and_exits(self):
+        args = self._ns()
+        with mock.patch.object(repro, "discover_matrix_rows",
+                               return_value=self._ROWS):
+            buf = io.StringIO()
+            with redirect_stderr(buf), \
+                 self.assertRaises(SystemExit) as cm:
+                repro._resolve_pattern("ubu24-*", args)
+        self.assertEqual(cm.exception.code, 1)
+        # Both ubu24 rows surfaced.
+        self.assertIn("ubu24-x86-gcc14", buf.getvalue())
+        self.assertIn("ubu24-x86-clang22-asan", buf.getvalue())
+
+    def test_no_match_lists_available_rows(self):
+        """Common typo case: shows the user what's actually there
+        instead of a bare 'no match' error."""
+        args = self._ns()
+        with mock.patch.object(repro, "discover_matrix_rows",
+                               return_value=self._ROWS):
+            with self.assertRaises(SystemExit) as cm:
+                repro._resolve_pattern("nonexistent", args)
+        msg = str(cm.exception)
+        self.assertIn("no matrix row matches pattern 'nonexistent'", msg)
+        self.assertIn("Available rows:", msg)
+        self.assertIn("ubu24-x86-gcc14", msg)
+
+
+# ---------------------------------------------------------------------------
+# --ci-workflows local-action overlay
+# ---------------------------------------------------------------------------
+
+class LocalizeCiWorkflowsTests(unittest.TestCase):
+    """`_localize_workflow_for_ci_workflows` is the file-rewriter
+    behind `--ci-workflows <path>`. Verify the staged action layout,
+    the `uses:` rewrites, and that lib/ + non-action dirs are skipped.
+    Filesystem-heavy; uses tempdirs and chdir."""
+
+    def setUp(self):
+        import tempfile
+        self.tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self.tmp.name)
+        self.consumer = self.tmp_path / "consumer"
+        self.ci = self.tmp_path / "ci-workflows"
+        (self.consumer / ".github" / "workflows").mkdir(parents=True)
+        # Three action dirs in ci-workflows/actions/: two real, one
+        # `lib` (non-action), one missing action.yml (skip).
+        (self.ci / "actions" / "setup-recipe").mkdir(parents=True)
+        (self.ci / "actions" / "setup-recipe" / "action.yml").write_text(
+            "name: 'Setup recipe'\n")
+        (self.ci / "actions" / "publish-recipe").mkdir(parents=True)
+        (self.ci / "actions" / "publish-recipe" / "action.yml").write_text(
+            "name: 'Publish recipe'\n")
+        (self.ci / "actions" / "lib").mkdir(parents=True)
+        (self.ci / "actions" / "lib" / "cache_io.py").write_text("# noop")
+        (self.ci / "actions" / "no-action-yml-here").mkdir(parents=True)
+        # The downstream workflow with a uses: that needs rewriting.
+        self.wf = self.consumer / ".github" / "workflows" / "main.yml"
+        self.wf.write_text(
+            "jobs:\n  build:\n    steps:\n"
+            "    - uses: compiler-research/ci-workflows/actions/setup-recipe@main\n"
+            "      with:\n        recipe: llvm-asan\n"
+            "    - uses: compiler-research/ci-workflows/actions/publish-recipe@v1\n")
+        self._cwd = os.getcwd()
+        os.chdir(self.consumer)
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+        self.tmp.cleanup()
+
+    def test_stages_real_actions_skips_lib_and_action_yml_less_dirs(self):
+        repro._localize_workflow_for_ci_workflows(self.wf, self.ci)
+        stage = self.consumer / ".github" / "act-ci-workflows-stage"
+        self.assertTrue((stage / "setup-recipe" / "action.yml").is_file())
+        self.assertTrue((stage / "publish-recipe" / "action.yml").is_file())
+        # lib/ must be skipped (it's a Python module dir, not an action)
+        self.assertFalse((stage / "lib").exists())
+        # Dirs without action.yml are skipped too.
+        self.assertFalse((stage / "no-action-yml-here").exists())
+
+    def test_uses_rewritten_to_local_form(self):
+        out = repro._localize_workflow_for_ci_workflows(self.wf, self.ci)
+        text = Path(out).read_text()
+        self.assertIn(
+            "uses: ./.github/act-ci-workflows-stage/setup-recipe", text)
+        self.assertIn(
+            "uses: ./.github/act-ci-workflows-stage/publish-recipe", text)
+        # Both at-refs gone.
+        self.assertNotIn("@main", text)
+        self.assertNotIn("@v1", text)
+
+    def test_returns_temp_workflow_beside_original(self):
+        out = repro._localize_workflow_for_ci_workflows(self.wf, self.ci)
+        self.assertEqual(Path(out).parent, self.wf.parent)
+        self.assertTrue(Path(out).name.startswith("act-main-localized-"))
+        self.assertTrue(Path(out).name.endswith(".yml"))
+
+    def test_stage_overwritten_on_re_run(self):
+        """A leftover stage from a prior run shouldn't shadow the
+        actions you're testing now."""
+        repro._localize_workflow_for_ci_workflows(self.wf, self.ci)
+        # Mutate the local action; re-localize.
+        (self.ci / "actions" / "setup-recipe" / "action.yml").write_text(
+            "name: 'Setup recipe (v2)'\n")
+        repro._localize_workflow_for_ci_workflows(self.wf, self.ci)
+        staged = (self.consumer / ".github" / "act-ci-workflows-stage"
+                  / "setup-recipe" / "action.yml").read_text()
+        self.assertIn("v2", staged)
+
+
+class CleanupCiWorkflowsOverlayTests(unittest.TestCase):
+    """Verify `_cleanup_ci_workflows_overlay` removes both the stage
+    dir and any leftover act-*-localized-*.yml temp workflows."""
+
+    def setUp(self):
+        import tempfile
+        self.tmp = tempfile.TemporaryDirectory()
+        self.consumer = Path(self.tmp.name) / "consumer"
+        (self.consumer / ".github" / "workflows").mkdir(parents=True)
+        (self.consumer / ".github" / "act-ci-workflows-stage").mkdir()
+        (self.consumer / ".github" / "act-ci-workflows-stage" / "marker"
+         ).write_text("")
+        (self.consumer / ".github" / "workflows"
+         / "act-main-localized-abcd.yml").write_text("")
+        # Untouched workflow that must NOT be removed.
+        (self.consumer / ".github" / "workflows" / "main.yml").write_text("")
+        self._cwd = os.getcwd()
+        os.chdir(self.consumer)
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+        self.tmp.cleanup()
+
+    def test_removes_stage_and_temp_workflow_keeps_originals(self):
+        repro._cleanup_ci_workflows_overlay()
+        stage = self.consumer / ".github" / "act-ci-workflows-stage"
+        self.assertFalse(stage.exists())
+        wf = self.consumer / ".github" / "workflows"
+        self.assertFalse((wf / "act-main-localized-abcd.yml").exists())
+        self.assertTrue((wf / "main.yml").exists())
+
+    def test_idempotent_on_already_clean_workspace(self):
+        repro._cleanup_ci_workflows_overlay()
+        # Second call: stage gone, no temp workflow left. Should not raise.
+        repro._cleanup_ci_workflows_overlay()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end subprocess (--help, no act on PATH, etc.)
+# ---------------------------------------------------------------------------
+
+class SubprocessTests(unittest.TestCase):
+    def _run(self, *args, **kw):
+        cmd = [sys.executable, str(REPRO_PATH), *args]
+        return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+    def test_help_lists_essentials(self):
+        r = self._run("--help")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("--list", r.stdout)
+        self.assertIn("--no-shell", r.stdout)
+        self.assertIn("act", r.stdout)
+        self.assertIn("Examples", r.stdout)
+
+    def test_no_args_errors_with_useful_message(self):
+        r = self._run()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("-j NAME, --list, or -m name:", r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -312,3 +312,57 @@ file content hashes, the runner image and version, the
 ci-workflows commit that built it, the build timestamp. If a
 cached binary surprises you in the field, the manifest is where
 you start.
+
+## Iterating on actions/ or recipes/ without pushing
+
+End-to-end:
+
+1. CI fails on a downstream PR. You'd rather not push another
+   branch every iteration.
+2. From the failing-PR repo: `bin/repro --list`. Failed rows on
+   the current branch are tagged red; pick the row you care
+   about.
+3. `bin/repro <row-name>` runs that exact row inside docker via
+   nektos/act. The shortcut handles workflow / job / matrix /
+   container-arch / pre-flight collision detection.
+4. The post-run shell drops you inside the container. Edit code,
+   recompile, rerun the tests. On shell exit you're prompted to
+   dump `git diff HEAD` to `/tmp/repro-<row>.patch` on the host;
+   `git apply <patch>` brings the edits back to your working
+   tree.
+5. To test changes to *ci-workflows itself* (this repo) without
+   pushing a branch, pass `--ci-workflows <local-path>` --
+   bin/repro overlays your local `actions/` on the workflow.
+6. Iterate. Push when green.
+
+### What `--ci-workflows <path>` does
+
+1. Copies every `actions/<name>/` from the local checkout to
+   `<downstream>/.github/act-ci-workflows-stage/<name>/` (a copy
+   rather than a symlink, because act doesn't follow directory
+   symlinks for local actions).
+2. Writes a temp workflow beside the original with each
+   `uses: compiler-research/ci-workflows/actions/<name>@<ref>`
+   rewritten to `uses: ./.github/act-ci-workflows-stage/<name>`.
+3. Runs act on the temp workflow; removes the stage and temp file
+   at exit.
+
+`~/.cache/act/` is untouched, so you can keep multiple
+ci-workflows checkouts on different branches and switch which one
+bin/repro consumes via `--ci-workflows <path>`.
+
+### Limits
+
+- The downstream's `runs-on:` slugs need to dispatch under act
+  (Linux containers; macOS / Windows rows skip).
+- `<row-name>` resolves via fnmatch against what `act -n --json`
+  enumerates; ambiguous matches print the candidates instead of
+  running.
+- act bind-mounts the consumer working tree, so workflow side
+  effects (`build/`, `llvm-project/`, `__ci_workflows__/`) persist
+  on the host after the container is removed. The workspace-clash
+  pre-flight catches these on the next run; clean them up by hand
+  for a pristine tree. Stage and temp workflow ARE cleaned at
+  exit; if a run is killed hard, remove
+  `.github/act-ci-workflows-stage/` and
+  `.github/workflows/act-*-localized-*.yml` by hand.


### PR DESCRIPTION
Reproducing a failed CI matrix row today means: push a branch, wait for CI, push again, repeat. For rows whose build is ~30 min that's a multi-hour loop. nektos/act runs GHA workflows locally, but several rough edges trip on workspace state that github-hosted runners never see. bin/repro is the wrapper that handles them.

Capabilities (see `bin/repro --help` for the full menu):

  bin/repro <row-name>    Row-name glob; resolves to -W/-j/-m via
                          fnmatch against act -n --json's matrix
                          expansion.
  --list                  Job listing tagged with cell-cache-hit
                          status and per-row CI failure markers
                          (anonymous Checks API; 60 req/h cap,
                          fine for interactive use).
  Auto-arch               Derives `--container-architecture` from
                          the row's `os:` slug (ubuntu-24.04 ->
                          x86_64, ubuntu-24.04-arm -> arm64). On
                          Apple Silicon, an x86_64-cell row stops
                          silently landing in an arm64 container
                          where x86_64 LLVM binaries crash at
                          exec.
  Workspace clash check   Pre-flight that refuses to launch act
                          when build/ or llvm-project/ already
                          exist in cwd. The workflow's `mkdir
                          build` (CppInterOp) or setup-recipe's
                          `mv ../llvm-project` would otherwise
                          trip under `set -e` with no actionable
                          error in the act log. `--skip-clash-
                          check` bypasses.
  --ci-workflows <path>   Stages a local checkout of ci-workflows
                          under `<consumer>/.github/act-ci-
                          workflows-stage/`, rewrites
                          `uses: compiler-research/ci-workflows/
                          actions/<name>@<ref>` to the staged
                          local-action form, runs act on the
                          rewritten workflow. Lets you iterate on
                          actions/setup-recipe/ etc. without
                          pushing a branch first; stage + temp
                          workflow are cleaned at exit.
  Patch export on exit    When the post-run shell ends with the
                          in-container git tree dirty, prompts to
                          dump `git diff HEAD` to /tmp/repro-
                          <row>.patch on the host. `git apply` on
                          the host brings in-container edits
                          back. Untracked files aren't included
                          (`git diff HEAD` doesn't see them).

Defaults that matter:

  - Container: removed at exit (unless `--save-temps`).
  - Workspace: act bind-mounts the consumer working tree, so workflow side effects (`build/`, `llvm-project/`, `__ci_workflows__/`) DO persist on the host. The workspace-clash pre-flight catches the resulting dirs on the next run; clean by hand for a pristine tree.
  - Network: only what act + setup-recipe naturally fetch (catthehacker image one-time pull, then the recipe tarball inside the container).
  - TTY: shell drops in after act, asks before removing the container; non-TTY (scripted) bypasses prompts and applies the documented defaults.
  - `--save-temps` keeps the container for `docker exec` re-entry; bin/repro prints the command.

Tests: 87 unit tests in bin/test_repro.py covering act invocation shape, post-run cleanup, SIGINT handling, arch derivation, workspace-clash prompts, patch-export, the row-name pattern resolver, and the --ci-workflows local-action overlay (stage layout, uses-rewrite, idempotent re-run). The integration target is "act runs a real consumer's workflow end-to-end", verified empirically (~9 min on Apple Silicon, 16 GB Docker, against CppInterOp's ubu24-x86-gcc14-cling-llvm20-cppyy row).

Documented in docs/developer-guide.md under "Iterating on actions/ or recipes/ without pushing".

This is squashed from 8 commits that built up incrementally (initial wrapper -> --list polish -> --ci-workflows -> auto-arch -> workspace-clash -> patch-export -> docs). Reviewers who'd prefer the patches as a stack can ask -- the unsquashed history naturally splits into three orthogonal concerns: (a) core wrapper
+ listing + arch + clash detection, (b) --ci-workflows overlay, (c) patch-export.