### PR TITLE
[ci] llvm-root: ship LLVMLineEditor in the recipe install

### DIFF
--- a/.github/actions/install-build-deps/action.yml
+++ b/.github/actions/install-build-deps/action.yml
@@ -30,7 +30,10 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y ninja-build zstd ccache rsync clang
+        # libedit-dev so LLVM's HAVE_LIBEDIT is on; LLVMLineEditor is a
+        # link dependency of cling's UserInterface (root-project/cling
+        # 9cdffe0c44 LineEditor migration).
+        sudo apt-get install -y ninja-build zstd ccache rsync clang libedit-dev
         # Pin the host compiler for every subsequent step in this job.
         echo "CC=clang" >> "$GITHUB_ENV"
         echo "CXX=clang++" >> "$GITHUB_ENV"
@@ -39,6 +42,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
+        # libedit ships with macOS's libc; no brew package needed for it.
         brew install ninja zstd ccache rsync
         echo "CC=clang" >> "$GITHUB_ENV"
         echo "CXX=clang++" >> "$GITHUB_ENV"

--- a/recipes/llvm-root/build.py
+++ b/recipes/llvm-root/build.py
@@ -93,11 +93,12 @@ def main() -> int:
     # ROOT consumes libclangInterpreter.a even though the clang driver
     # doesn't depend on it transitively) + StaticAnalyzerCore (cling's
     # bundled clang pulled it into CppInterOp's link in the past) +
-    # LLVMOrcDebugging (cling pulls it via LIBS).
+    # LLVMOrcDebugging (cling pulls it via LIBS) + LLVMLineEditor
+    # (cling's UserInterface declares it via LLVM_LINK_COMPONENTS).
     subprocess.run(
         ["ninja", "-j", ncpus,
          "clang", "clangInterpreter", "clangStaticAnalyzerCore",
-         "LLVMOrcDebugging"],
+         "LLVMOrcDebugging", "LLVMLineEditor"],
         check=True,
     )
 


### PR DESCRIPTION
cling's UserInterface library declares
`LLVM_LINK_COMPONENTS LineEditor support`, so anything that links clingUserInterface (driver, libclingJupyter, ...) needs libLLVMLineEditor.a from the recipe install. The llvm-root build target list at recipes/llvm-root/build.py omitted LLVMLineEditor, so ninja never built it, install_distribution's lib/lib*.a walk skipped it, and standalone cling builds on top of the recipe install fail at the cling driver link with `cannot find -lLLVMLineEditor`.

Add LLVMLineEditor to the explicit ninja target list and install libedit-dev in install-build-deps on Linux so HAVE_LIBEDIT is on at LLVM configure time and LLVMLineEditor compiles with real functionality (rather than as an empty archive). macOS already ships libedit with libc; no extra package is needed there.