### PR TITLE
[ci] publish-recipe: ship a sibling ccache asset.

### DIFF
--- a/actions/lib/cache_io.py
+++ b/actions/lib/cache_io.py
@@ -116,22 +116,30 @@ def gh_release_url_parse(base: str) -> Optional[Tuple[str, str]]:
     return owner_repo, tag
 
 
-def cache_upload(base: str, key: str, asset: str, manifest: str) -> None:
-    """Store the asset and manifest at the cache backend.
+def cache_upload(base: str, key: str, asset: str,
+                 manifest: Optional[str] = None) -> None:
+    """Store the asset (and optional manifest) at the cache backend.
 
     file://         - cp into the directory (creates if missing).
     https://github.com/.../releases/download/TAG/  - gh release upload.
     anything else   - error (read-only backend).
+
+    Files are stored under their own basename, so callers are
+    responsible for naming the asset correctly (e.g. ``<key>.tar.zst``
+    for the install tree, ``<key>.ccache.tar.zst`` for a sibling
+    ccache snapshot). `manifest` is optional: pass None when uploading
+    a sibling asset that reuses the install tree's manifest.
     """
     base = _strip_trailing_slash(base)
     asset_path = Path(asset)
-    manifest_path = Path(manifest)
+    manifest_path = Path(manifest) if manifest else None
 
     if base.startswith("file://"):
         dest_dir = Path(base[len("file://"):])
         dest_dir.mkdir(parents=True, exist_ok=True)
-        _copy(asset_path,    dest_dir / f"{key}.tar.zst")
-        _copy(manifest_path, dest_dir / f"{key}.manifest.json")
+        _copy(asset_path, dest_dir / asset_path.name)
+        if manifest_path is not None:
+            _copy(manifest_path, dest_dir / manifest_path.name)
         return
 
     parsed = gh_release_url_parse(base)
@@ -141,15 +149,21 @@ def cache_upload(base: str, key: str, asset: str, manifest: str) -> None:
             f"support writes; got: {base}"
         )
     owner_repo, tag = parsed
-    subprocess.run(
-        ["gh", "release", "upload", tag, str(asset_path), str(manifest_path),
-         "-R", owner_repo, "--clobber"],
-        check=True,
-    )
+    cmd = ["gh", "release", "upload", tag, str(asset_path)]
+    if manifest_path is not None:
+        cmd.append(str(manifest_path))
+    cmd.extend(["-R", owner_repo, "--clobber"])
+    subprocess.run(cmd, check=True)
 
 
-def cache_pack(in_dir: str, key: str, out_dir: Optional[str] = None) -> None:
-    """Tar+zstd ``in_dir/llvm-project`` to ``out_dir/<key>.tar.zst``.
+def cache_pack(in_dir: str, key: str, out_dir: Optional[str] = None,
+               *, src_name: str = "llvm-project",
+               key_suffix: str = "") -> None:
+    """Tar+zstd ``in_dir/<src_name>`` to ``out_dir/<key><key_suffix>.tar.zst``.
+
+    Defaults match the install tree (src_name="llvm-project",
+    key_suffix=""). For a sibling ccache snapshot pass src_name=".ccache",
+    key_suffix=".ccache".
 
     Uses Python's tarfile module to produce the archive (POSIX format,
     same as GNU/BSD tar can read) and pipes through the zstd binary
@@ -159,12 +173,13 @@ def cache_pack(in_dir: str, key: str, out_dir: Optional[str] = None) -> None:
     `out_dir` defaults to the current working directory.
     """
     out_dir_path = Path(out_dir) if out_dir else Path.cwd()
-    out_path = out_dir_path / f"{key}.tar.zst"
-    src = Path(in_dir) / "llvm-project"
+    out_name = f"{key}{key_suffix}.tar.zst"
+    out_path = out_dir_path / out_name
+    src = Path(in_dir) / src_name
     if not src.is_dir():
         raise FileNotFoundError(f"cache_pack: {src} does not exist")
 
-    print(f"::notice::compressing {key}.tar.zst (zstd -19 --long -T0)",
+    print(f"::notice::compressing {out_name} (zstd -19 --long -T0)",
           flush=True)
 
     with out_path.open("wb") as out_f:
@@ -174,7 +189,7 @@ def cache_pack(in_dir: str, key: str, out_dir: Optional[str] = None) -> None:
         )
         try:
             with tarfile.open(fileobj=zstd.stdin, mode="w|") as tar:
-                tar.add(src, arcname="llvm-project")
+                tar.add(src, arcname=src_name)
         finally:
             assert zstd.stdin is not None
             zstd.stdin.close()
@@ -247,13 +262,24 @@ def _main(argv: list[str]) -> int:
         cache_download(base, key, out_dir)
         return 0
     if op == "upload":
-        base, key, asset, manifest = rest
-        cache_upload(base, key, asset, manifest)
+        # upload BASE KEY ASSET [MANIFEST]
+        if len(rest) == 3:
+            base, key, asset = rest
+            cache_upload(base, key, asset)
+        else:
+            base, key, asset, manifest = rest
+            cache_upload(base, key, asset, manifest)
         return 0
     if op == "pack":
+        # pack IN_DIR KEY [OUT_DIR [SRC_NAME [KEY_SUFFIX]]]
         in_dir, key = rest[:2]
         out_dir = rest[2] if len(rest) > 2 else None
-        cache_pack(in_dir, key, out_dir)
+        kwargs = {}
+        if len(rest) > 3:
+            kwargs["src_name"] = rest[3]
+        if len(rest) > 4:
+            kwargs["key_suffix"] = rest[4]
+        cache_pack(in_dir, key, out_dir, **kwargs)
         return 0
     if op == "release-url-parse":
         base = rest[0]

--- a/actions/lib/test_cache_io.py
+++ b/actions/lib/test_cache_io.py
@@ -137,14 +137,34 @@ class CachePackRoundTripTests(unittest.TestCase):
             with self.assertRaises(FileNotFoundError):
                 cache_io.cache_pack(d, "k", d)
 
+    def test_pack_ccache_sibling(self):
+        # cache_pack(src_name=".ccache", key_suffix=".ccache") packs an
+        # arbitrary sibling directory under a suffixed asset name. Used
+        # by publish-recipe to ship a ccache snapshot next to the
+        # install tree.
+        with tempfile.TemporaryDirectory() as d:
+            in_dir = Path(d) / "in"
+            (in_dir / ".ccache" / "0" / "ab").mkdir(parents=True)
+            (in_dir / ".ccache" / "0" / "ab" / "obj.o").write_bytes(b"o")
+
+            out_dir = Path(d) / "out"
+            out_dir.mkdir()
+            cache_io.cache_pack(
+                str(in_dir), "k", str(out_dir),
+                src_name=".ccache", key_suffix=".ccache",
+            )
+
+            asset = out_dir / "k.ccache.tar.zst"
+            self.assertTrue(asset.is_file())
+
 
 @unittest.skipUnless(_have_zstd(), "zstd not available")
 class CacheUploadFileTests(unittest.TestCase):
     def test_file_backend_copies(self):
         with tempfile.TemporaryDirectory() as d:
-            asset = Path(d) / "asset.tar.zst"
+            asset = Path(d) / "k.tar.zst"
             asset.write_bytes(b"compressed")
-            manifest = Path(d) / "manifest.json"
+            manifest = Path(d) / "k.manifest.json"
             manifest.write_text(json.dumps({"k": "v"}))
             dest = Path(d) / "cache"
 
@@ -157,6 +177,21 @@ class CacheUploadFileTests(unittest.TestCase):
                 json.loads((dest / "k.manifest.json").read_text()),
                 {"k": "v"},
             )
+
+    def test_file_backend_optional_manifest(self):
+        # Sibling assets (e.g. <key>.ccache.tar.zst) reuse the install
+        # tree's manifest -- cache_upload accepts a None manifest.
+        with tempfile.TemporaryDirectory() as d:
+            asset = Path(d) / "k.ccache.tar.zst"
+            asset.write_bytes(b"ccache")
+            dest = Path(d) / "cache"
+
+            cache_io.cache_upload(f"file://{dest}", "k", str(asset))
+
+            self.assertEqual(
+                (dest / "k.ccache.tar.zst").read_bytes(), b"ccache"
+            )
+            self.assertEqual(list(dest.iterdir()), [dest / "k.ccache.tar.zst"])
 
     def test_unsupported_backend_raises(self):
         with self.assertRaises(ValueError):

--- a/actions/publish-recipe/action.yml
+++ b/actions/publish-recipe/action.yml
@@ -231,3 +231,23 @@ runs:
         echo "::notice::uploading ${KEY} to ${release_url}"
         python3 "$REPO_ROOT/actions/lib/cache_io.py" upload \
           "$BASE" "$KEY" "${KEY}.tar.zst" "${KEY}.manifest.json"
+
+    # Sibling asset for bin/repro --with-ccache: ships a snapshot of
+    # the recipe build's CCACHE_DIR alongside the install tree under
+    # the same content-hash key. Reuses the install tree's manifest;
+    # cache_upload accepts no manifest in that case.
+    - name: Tar + zstd + upload ccache
+      if: steps.skip.outputs.exists != 'true' && inputs.dry-run != 'true'
+      shell: bash
+      env:
+        KEY: ${{ steps.compute-key.outputs.key }}
+        BASE: ${{ steps.skip.outputs.base }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        REPO_ROOT="$(pwd)"
+        cd "${{ github.workspace }}"
+        python3 "$REPO_ROOT/actions/lib/cache_io.py" pack \
+          . "$KEY" . .ccache .ccache
+        ls -lh "${KEY}.ccache.tar.zst"
+        python3 "$REPO_ROOT/actions/lib/cache_io.py" upload \
+          "$BASE" "$KEY" "${KEY}.ccache.tar.zst"


### PR DESCRIPTION
The GHA actions/cache pool that holds the recipe build's ccache state is fast for in-CI re-runs but invisible outside the workflow -- bin/repro can't fetch it, and the per-repo 10 GB / 7-day TTL bounds make it unsuitable as a durable artifact for dev-repro.

Pack `$CCACHE_DIR` as a Releases sibling `<key>.ccache.tar.zst` after the install upload. The same content-hash key gates both files, so a recipe edit produces a fresh pair and an unchanged recipe shares the existing pair. Consumers opt in to the sibling (initially: bin/repro --with-ccache, follow-up); setup-recipe stays unchanged so cppinterop / clad / cppyy don't pay for a 140 MB ccache they don't use.

Verified locally with `bin/repro -j publish-dryrun -m os:ubuntu-24.04 -- --artifact-server-path /tmp/act-cache`: the dryrun produces both `<key>.tar.zst` and `<key>.ccache.tar.zst` at the file:// backend under the same content hash, and the existing
`Verify asset + manifest landed` step lists both files.