### PR TITLE
[ci] publish-recipe: skip the ccache sibling-asset upload on Windows.

### DIFF
--- a/actions/publish-recipe/action.yml
+++ b/actions/publish-recipe/action.yml
@@ -236,8 +236,13 @@ runs:
     # the recipe build's CCACHE_DIR alongside the install tree under
     # the same content-hash key. Reuses the install tree's manifest;
     # cache_upload accepts no manifest in that case.
+    # Windows is gated out for now: bin/repro under nektos/act doesn't
+    # target Windows hosts, so the dev-repro consumer of the sibling
+    # asset has no Windows use case yet. Skipping here lets us avoid
+    # the chocolatey zstandard package's recurrent 404s on the publish
+    # path; revisit on demand.
     - name: Tar + zstd + upload ccache
-      if: steps.skip.outputs.exists != 'true' && inputs.dry-run != 'true'
+      if: steps.skip.outputs.exists != 'true' && inputs.dry-run != 'true' && runner.os != 'Windows'
       shell: bash
       env:
         KEY: ${{ steps.compute-key.outputs.key }}


### PR DESCRIPTION
The bin/repro --with-ccache consumer (the only intended user of the sibling asset shipped by 085a408) runs under nektos/act on Linux hosts. There is no use case yet for the Windows-row sibling, and producing it requires a working `zstd` on the Windows runner -- chocolatey's `zstandard` package has churned its upstream-release URL recently and `choco install -y zstandard` fails with HTTP 404.

Gate the new step on `runner.os != 'Windows'` so the Windows publish row stays green without us having to chase the chocolatey package flake. Linux and macOS still produce <key>.ccache.tar.zst; revisit when a real Windows consumer of the sibling appears.