### PR TITLE
[ci] prune-cache: keep .ccache.tar.zst siblings with their install.

### DIFF
--- a/.github/workflows/prune-cache.yml
+++ b/.github/workflows/prune-cache.yml
@@ -119,8 +119,9 @@ jobs:
           while IFS= read -r asset; do
             name=$(echo "$asset" | jq -r .name)
             case "$name" in
+              *.ccache.tar.zst) key="${name%.ccache.tar.zst}" ;;
               *.tar.zst)        key="${name%.tar.zst}" ;;
-              *.manifest.json)  continue ;;  # handled with its tarball
+              *.manifest.json)  continue ;;
               *)                echo "::warning::unexpected asset: $name"; continue ;;
             esac
             if grep -qxF "$key" /tmp/expected_keys.txt; then
@@ -142,6 +143,8 @@ jobs:
             fi
             echo "::notice::dropping orphan ($age_days days old): $key"
             gh release delete-asset cache "${key}.tar.zst" \
+              -R "$GITHUB_REPOSITORY" --yes || true
+            gh release delete-asset cache "${key}.ccache.tar.zst" \
               -R "$GITHUB_REPOSITORY" --yes || true
             gh release delete-asset cache "${key}.manifest.json" \
               -R "$GITHUB_REPOSITORY" --yes || true


### PR DESCRIPTION
publish-recipe (085a408) started shipping `<key>.ccache.tar.zst` next to `<key>.tar.zst` for every published cell, but prune-cache kept its flat asset classifier: anything that ends in `.tar.zst` has its key read as `${name%.tar.zst}`. For the sibling that produces a key like `...-c02694f6fd496bb5.ccache`, which never matches an entry in expected_keys.txt (entries there are bare `<recipe>-<version>-<os>- <arch>-<hash>` from compute_key.py). Result: every sibling is classified as orphan, kept only for caps.grace_days, then deleted on the next scheduled prune -- and immediately under workflow_dispatch force=true.

Strip the sibling suffix before the lookup so the sibling collapses to the install asset's key: an in-cells.yaml install ⇒ matching sibling kept, an orphan install ⇒ sibling dropped alongside.

Bring the delete branch in line: `gh release delete-asset` the sibling whenever the install is dropped. `|| true` covers older recipes from before 085a408 that have no sibling (gh returns 404 on the missing asset, which the rest of the loop already tolerates for the manifest case).