### PR TITLE
[ci] llvm-asan/release: drop static-archive aliases from oop_targets.

### DIFF
--- a/recipes/llvm-asan/build.py
+++ b/recipes/llvm-asan/build.py
@@ -46,8 +46,15 @@ def _oop_targets(build_dir: Path) -> list[str]:
     seen = set()
     for line in out.splitlines():
         m = re.match(r"^(orc_rt[^:]*):", line)
-        if m:
-            seen.add(m.group(1))
+        if not m:
+            continue
+        target = m.group(1)
+        # Skip the static-archive aliases ninja prints next to the
+        # cmake target ("orc_rt-x86_64.lib" on Windows, "...a" on
+        # Linux); only the bare target has an install rule.
+        if target.endswith((".lib", ".a")):
+            continue
+        seen.add(target)
     return sorted(seen)
 
 

--- a/recipes/llvm-release/build.py
+++ b/recipes/llvm-release/build.py
@@ -55,8 +55,15 @@ def _oop_targets(build_dir: Path) -> list[str]:
     seen = set()
     for line in out.splitlines():
         m = re.match(r"^(orc_rt[^:]*):", line)
-        if m:
-            seen.add(m.group(1))
+        if not m:
+            continue
+        target = m.group(1)
+        # Skip the static-archive aliases ninja prints next to the
+        # cmake target ("orc_rt-x86_64.lib" on Windows, "...a" on
+        # Linux); only the bare target has an install rule.
+        if target.endswith((".lib", ".a")):
+            continue
+        seen.add(target)
     return sorted(seen)
 
 


### PR DESCRIPTION
`ninja -t targets all` lists the cmake target ("orc_rt-x86_64") and its static-archive output alias ("orc_rt-x86_64.lib" on Windows, "liborc_rt-x86_64.a" on Linux) as separate phony targets. The _oop_targets discovery regex matched both, and install_distribution fed both to LLVM_DISTRIBUTION_COMPONENTS. Only the bare target has an `install-<name>` rule; the alias does not, and
llvm_distribution_add_targets aborts cmake with:

  Specified distribution component 'orc_rt-x86_64.lib' doesn't have
  an install target

Surfaced on Windows publish-recipe runs of llvm-release. The same latent bug existed in llvm-asan -- not yet hit because the windows-2025 cell isn't currently published for that recipe -- so the fix lands in both copies of the helper.

Filter alias suffixes (".lib", ".a") before adding to the set. The deduplication-into-actions/lib comment in llvm-release/build.py is unchanged: lift to a shared helper when the third LLVM-family recipe needs it, not on a bug-fix touch.