### PR TITLE
[ci] publish-recipe: make the sibling ccache asset portable.

### DIFF
--- a/actions/publish-recipe/action.yml
+++ b/actions/publish-recipe/action.yml
@@ -130,6 +130,20 @@ runs:
         ccache --max-size=5G
         ccache --zero-stats
 
+    # Decouple the ccache key from runner-local state so the sibling
+    # asset is reusable off-runner. Skipped on Windows: `cl` rejects
+    # `--version`, and the sibling upload is already Windows-gated.
+    - name: Configure ccache portable hashing
+      if: steps.skip.outputs.exists != 'true' && runner.os != 'Windows'
+      shell: bash
+      env:
+        WS: ${{ github.workspace }}
+      run: |
+        cc_version=$("$CC" --version | head -1)
+        ccache --set-config="compiler_check=string:$cc_version"
+        ccache --set-config="hash_dir=false"
+        ccache --set-config="base_dir=$WS"
+
     # Only github-Releases backends need a Release object created up
     # front. file:// backends just need the directory to exist; the
     # cache_upload helper handles that.

--- a/actions/publish-recipe/build_manifest.py
+++ b/actions/publish-recipe/build_manifest.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import os
 import re
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,6 +41,22 @@ def _grep_yaml_value(yaml_path: Path, key: str) -> Optional[str]:
     except OSError:
         pass
     return None
+
+
+def _ccache_config() -> dict:
+    """Snapshot the ccache knobs that decide off-runner reuse."""
+    keys = ("compiler_check", "hash_dir", "base_dir")
+    out: dict[str, str] = {}
+    for k in keys:
+        try:
+            r = subprocess.run(
+                ["ccache", "--get-config", k],
+                check=True, capture_output=True, text=True,
+            )
+            out[k] = r.stdout.strip()
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            out[k] = "unknown"
+    return out
 
 
 def _build_script(recipe_dir: Path) -> Optional[Path]:
@@ -86,6 +103,13 @@ def build_manifest(recipe: str, version: str, os_: str, arch: str,
             "repo":   repo,
             "branch": branch,
             "commit": os.environ.get("SRC_COMMIT", "unknown"),
+        },
+        # Toolchain + ccache config consumers (bin/repro --devshell)
+        # need to replicate to hit the sibling cache.
+        "build_env": {
+            "cc":  os.environ.get("CC",  "unknown"),
+            "cxx": os.environ.get("CXX", "unknown"),
+            "ccache": _ccache_config(),
         },
         "ci_workflows_sha": os.environ.get("GITHUB_SHA", "unknown"),
         "built_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),


### PR DESCRIPTION
A default ccache config keys on the absolute source path and on the (size, mtime) of the compiler binary, both runner-local. The <key>.ccache.tar.zst sibling shipped by 085a408 inherits those keys, so a consumer on a different runner -- or even a fresh apt install of the same compiler version -- produces a different key for every compile and hits zero entries in the published cache. Validated end to end: bin/repro --devshell on the cling-llvm20 cell, with paths mirroring publish-recipe's runner workspace and the same clang version installed, still misses 273/273 cacheable calls.

Decouple the key from the runner instance by setting three ccache config flags before the build step:

  compiler_check=string:<cc --version>
      Use the compiler's printed version string instead of the
      (size, mtime) tuple. Same package version on any runner
      produces the same string, so the consumer doesn't need a
      bit-identical compiler binary.

  hash_dir=false
      Drop the absolute source-directory component from the key so
      a /home/runner/work/...  source matches a /work/...  source
      provided the relative paths align.

  base_dir=$github.workspace
      Rewrite absolute paths under the workspace into relative form
      before they enter the key, so cmake-emitted -I and source
      paths produce the same hash regardless of where the workspace
      lives on disk.

Record the resolved values of the same three knobs in the manifest under build_env.ccache. A consumer reading the manifest can then verify it has a compatible compiler version string, set hash_dir off on its side, and pick its workdir bind-mount from base_dir instead of hardcoding the runner layout. cc / cxx are kept as plain names alongside; compiler_check carries the version detail.

Republish on the next push (or workflow_dispatch) refreshes the sibling assets with the portable keys; older orphans age out via prune-cache.