### PR TITLE
[ci] publish-recipe: record cmake args in the manifest.

### DIFF
--- a/actions/lib/llvm_build.py
+++ b/actions/lib/llvm_build.py
@@ -23,6 +23,7 @@ Optional env:
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -116,6 +117,21 @@ def cmake_extra() -> List[str]:
         if v:
             flags.append(f"{flag}={v}")
     return flags
+
+
+def record_cmake_args(args: Sequence[str]) -> None:
+    """Persist the cmake invocation for build_manifest to inline.
+
+    Consumers compare against their own recipe-derived flags to catch
+    drift that would invalidate the sibling ccache.
+    """
+    work = os.environ.get("WORK_DIR", "")
+    if not work:
+        return
+    Path(work).mkdir(parents=True, exist_ok=True)
+    (Path(work) / "cmake-args.json").write_text(
+        json.dumps(list(args), indent=2)
+    )
 
 
 def quick_check_or_continue() -> None:

--- a/actions/lib/test_llvm_build.py
+++ b/actions/lib/test_llvm_build.py
@@ -169,6 +169,26 @@ class CmakeExtraTests(unittest.TestCase):
             self.assertEqual(llvm_build.cmake_extra(), [])
 
 
+class RecordCmakeArgsTests(unittest.TestCase):
+    def test_writes_json_when_work_dir_set(self):
+        import json
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.dict(os.environ, {"WORK_DIR": d}, clear=True):
+                llvm_build.record_cmake_args(
+                    ["cmake", "-G", "Ninja", "-DFOO=bar", "../llvm"]
+                )
+            written = json.loads((Path(d) / "cmake-args.json").read_text())
+            self.assertEqual(
+                written, ["cmake", "-G", "Ninja", "-DFOO=bar", "../llvm"]
+            )
+
+    def test_no_op_without_work_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.dict(os.environ, {}, clear=True):
+                llvm_build.record_cmake_args(["cmake", "../llvm"])
+            self.assertFalse((Path(d) / "cmake-args.json").exists())
+
+
 class CleanupIntermediatesTests(unittest.TestCase):
     def test_removes_o_and_obj_recursively(self):
         with tempfile.TemporaryDirectory() as d:

--- a/actions/publish-recipe/action.yml
+++ b/actions/publish-recipe/action.yml
@@ -212,6 +212,7 @@ runs:
         VERSION: ${{ inputs.version }}
         OS: ${{ steps.slugs.outputs.os }}
         ARCH: ${{ steps.slugs.outputs.arch }}
+        WORK_DIR: ${{ github.workspace }}/_recipe_work
       run: |
         python3 actions/publish-recipe/build_manifest.py \
           "$RECIPE" "$VERSION" "$OS" "$ARCH" "$KEY" \

--- a/actions/publish-recipe/build_manifest.py
+++ b/actions/publish-recipe/build_manifest.py
@@ -59,6 +59,23 @@ def _ccache_config() -> dict:
     return out
 
 
+def _cmake_args() -> list:
+    """cmake invocation written by llvm_build.record_cmake_args.
+
+    Empty list = not recorded (older recipe or no WORK_DIR), not "no flags".
+    """
+    work = os.environ.get("WORK_DIR", "")
+    if not work:
+        return []
+    p = Path(work) / "cmake-args.json"
+    if not p.is_file():
+        return []
+    try:
+        return json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
 def _build_script(recipe_dir: Path) -> Optional[Path]:
     sh = recipe_dir / "build.sh"
     py = recipe_dir / "build.py"
@@ -111,6 +128,7 @@ def build_manifest(recipe: str, version: str, os_: str, arch: str,
             "cxx": os.environ.get("CXX", "unknown"),
             "ccache": _ccache_config(),
         },
+        "cmake_args": _cmake_args(),
         "ci_workflows_sha": os.environ.get("GITHUB_SHA", "unknown"),
         "built_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }

--- a/actions/publish-recipe/test_build_manifest.py
+++ b/actions/publish-recipe/test_build_manifest.py
@@ -141,6 +141,33 @@ class BuildManifestTests(unittest.TestCase):
             # And it must be a real hash (64 hex chars), not "unknown".
             self.assertRegex(m["build_script_sha256"], r"^[0-9a-f]{64}$")
 
+    def test_cmake_args_inlined_from_work_dir(self):
+        with tempfile.TemporaryDirectory() as d, \
+             tempfile.TemporaryDirectory() as work:
+            (Path(work) / "cmake-args.json").write_text(
+                json.dumps(["cmake", "-G", "Ninja", "-DFOO=bar"])
+            )
+            with mock.patch.dict(os.environ, {"WORK_DIR": work}, clear=True):
+                _make_recipe(Path(d), "r")
+                m = build_manifest.build_manifest(
+                    "r", "1", "ubuntu-24.04", "x86_64", "k",
+                    recipe_root=d,
+                )
+            self.assertEqual(
+                m["cmake_args"],
+                ["cmake", "-G", "Ninja", "-DFOO=bar"],
+            )
+
+    def test_cmake_args_empty_when_unrecorded(self):
+        with tempfile.TemporaryDirectory() as d, \
+             mock.patch.dict(os.environ, {}, clear=True):
+            _make_recipe(Path(d), "r")
+            m = build_manifest.build_manifest(
+                "r", "1", "ubuntu-24.04", "x86_64", "k",
+                recipe_root=d,
+            )
+            self.assertEqual(m["cmake_args"], [])
+
     def test_missing_recipe_yaml_unknown(self):
         with tempfile.TemporaryDirectory() as d, \
              mock.patch.dict(os.environ, {}, clear=True):

--- a/recipes/llvm-asan/build.py
+++ b/recipes/llvm-asan/build.py
@@ -99,6 +99,7 @@ def main() -> int:
         + llvm_build.cmake_extra()
         + ["../llvm"]
     )
+    llvm_build.record_cmake_args(cmake_args)
     subprocess.run(cmake_args, check=True)
 
     llvm_build.quick_check_or_continue()

--- a/recipes/llvm-dry-run/build.py
+++ b/recipes/llvm-dry-run/build.py
@@ -66,6 +66,7 @@ def main() -> int:
         '-DLLVM_INCLUDE_EXAMPLES=OFF',
         '-DLLVM_INCLUDE_TESTS=OFF',
     ] + llvm_build.cmake_extra() + ["../llvm"]
+    llvm_build.record_cmake_args(cmake_args)
     subprocess.run(cmake_args, check=True)
 
     subprocess.run(["ninja", "-j", ncpus, "LLVMDemangle"], check=True)

--- a/recipes/llvm-release/build.py
+++ b/recipes/llvm-release/build.py
@@ -133,6 +133,7 @@ def main() -> int:
         + llvm_build.cmake_extra()
         + ["../llvm"]
     )
+    llvm_build.record_cmake_args(cmake_args)
     subprocess.run(cmake_args, check=True)
 
     llvm_build.quick_check_or_continue()

--- a/recipes/llvm-root/build.py
+++ b/recipes/llvm-root/build.py
@@ -85,6 +85,7 @@ def main() -> int:
         + llvm_build.cmake_extra()
         + ["../llvm"]
     )
+    llvm_build.record_cmake_args(cmake_args)
     subprocess.run(cmake_args, check=True)
 
     llvm_build.quick_check_or_continue()


### PR DESCRIPTION
#51 captured the producer's resolved ccache config (compiler_check, hash_dir, base_dir) so consumers can verify their side matches before reusing the sibling cache. The cmake invocation is the matching gap: ccache hashes the full compile command, so drift in -DLLVM_ENABLE_PROJECTS / -DLLVM_USE_SANITIZER / flavor-specific -D flags silently misses every entry, and a consumer reading the manifest has no way to detect it short of re-running the recipe build script.

Add a top-level cmake_args field listing the resolved flag set the recipe passed to cmake. Mechanism: actions/lib/llvm_build gains record_cmake_args(args), which writes $WORK_DIR/cmake-args.json; build_manifest._cmake_args() reads it back and inlines the list. Each LLVM-family recipe (llvm-asan, llvm-release, llvm-root, llvm-dry-run) calls record_cmake_args just before its existing subprocess.run(cmake_args). Recipes predating this commit (or runs without WORK_DIR set in the manifest step) yield an empty list, distinguishable from "no flags" only by being absent from older publishes.

The producer's ccache configure invocations (--max-size, --zero-stats, the three --set-config calls) aren't recorded -- the resolved end state is already in build_env.ccache from #51, and the call history is recoverable from action.yml at ci_workflows_sha if needed.

Consumer-side use (bin/repro --devshell comparing cmake_args against its own derived flags) is a follow-up; this commit only ships the producer side and the manifest shape.