### PR TITLE
[ci] setup-recipe: install zstd on Windows before cache extract.

### DIFF
--- a/actions/setup-recipe/action.yml
+++ b/actions/setup-recipe/action.yml
@@ -140,6 +140,14 @@ runs:
           echo "hit=false" >> "$GITHUB_OUTPUT"
         fi
 
+    - name: Ensure zstd (Windows)
+      if: steps.probe.outputs.hit == 'true' && runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        if (-not (Get-Command zstd -ErrorAction SilentlyContinue)) {
+          choco install -y zstandard
+        }
+
     - name: Download + extract from cache
       if: steps.probe.outputs.hit == 'true'
       shell: bash


### PR DESCRIPTION
Linux GHA runner images ship zstd by default; macOS does via the Xcode CLT. Windows runners (windows-2025, windows-11-arm) don't, so cache_io.py's _zstd_decode_into_tar -- a `subprocess.Popen(["zstd", "-d", "-c"])` shell-out -- fails the cache extract with `FileNotFoundError: [WinError 2]` on every Windows consumer that hits a published cell. Surfaced on CppInterOp's win11-msvc-llvm22 row consuming llvm-release / 22 / windows-11-arm.

Probe via Get-Command and `choco install -y zstandard` if missing, gated on cache hit so we don't pay the install on a fail-fast miss. Producer side already covered: install-build-deps does the same.