### PR TITLE
[ci] publish-recipe: record cmake state + installed packages in manifest.

### DIFF
--- a/actions/publish-recipe/build_manifest.py
+++ b/actions/publish-recipe/build_manifest.py
@@ -43,6 +43,69 @@ def _grep_yaml_value(yaml_path: Path, key: str) -> Optional[str]:
     return None
 
 
+def _cmake_state() -> dict:
+    """Snapshot of cmake's configured-state files from the build dir.
+
+    Captures the producer's cmake-probe output so consumers can detect
+    environment drift before iterating. Three files:
+      CMakeCache.txt           top-level vars (CMAKE_CXX_COMPILER,
+                               _STANDARD, _FLAGS, _COMPILER_LAUNCHER, ...)
+      CMakeCXXCompiler.cmake   compiler probe + IMPLICIT_INCLUDE_DIRECTORIES
+                               (the libstdc++ resolution that decides
+                               what /usr/include/c++/N is loaded)
+      CMakeCCompiler.cmake     same for C
+    The content lets consumers diff against their own equivalents and
+    fail loudly on mismatches -- the libstdc++-13 vs libstdc++-14 drift
+    that produced 100% ccache miss in the catthehacker/ubuntu container
+    would have surfaced as a one-line diff against
+    CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES.
+    """
+    work = os.environ.get("WORK_DIR", "")
+    if not work:
+        return {}
+    workp = Path(work)
+    out: dict[str, str] = {}
+    cache = next(workp.glob("**/build/CMakeCache.txt"), None)
+    if cache:
+        try:
+            out["CMakeCache.txt"] = cache.read_text()
+        except OSError:
+            pass
+    for name in ("CMakeCXXCompiler.cmake", "CMakeCCompiler.cmake"):
+        for p in workp.glob(f"**/CMakeFiles/*/{name}"):
+            try:
+                out[name] = p.read_text()
+                break
+            except OSError:
+                continue
+    return out
+
+
+def _installed_packages() -> dict:
+    """Map {pkg-name: version} of packages installed on the producer.
+
+    Recorded so consumers can diff against their local package set and
+    apt-install whatever's missing. Catches any divergence cmake's
+    IMPLICIT_INCLUDE doesn't surface (zlib-dev, libedit-dev, libtinfo,
+    ...) plus the libstdc++ case (libstdc++-N-dev). dpkg-query is
+    debian-only; the empty fallback on macOS/Windows is fine since the
+    runtime-package class of ccache-miss only happens on Linux.
+    """
+    try:
+        r = subprocess.run(
+            ["dpkg-query", "-W", "-f=${Package}\\t${Version}\\n"],
+            check=True, capture_output=True, text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return {}
+    out: dict[str, str] = {}
+    for line in r.stdout.splitlines():
+        if "\t" in line:
+            name, ver = line.split("\t", 1)
+            out[name] = ver
+    return out
+
+
 def _ccache_config() -> dict:
     """Snapshot the ccache knobs that decide off-runner reuse."""
     keys = ("compiler_check", "hash_dir", "base_dir")
@@ -127,8 +190,10 @@ def build_manifest(recipe: str, version: str, os_: str, arch: str,
             "cc":  os.environ.get("CC",  "unknown"),
             "cxx": os.environ.get("CXX", "unknown"),
             "ccache": _ccache_config(),
+            "installed_packages": _installed_packages(),
         },
         "cmake_args": _cmake_args(),
+        "cmake_state": _cmake_state(),
         "ci_workflows_sha": os.environ.get("GITHUB_SHA", "unknown"),
         "built_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }

--- a/actions/publish-recipe/test_build_manifest.py
+++ b/actions/publish-recipe/test_build_manifest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -167,6 +168,65 @@ class BuildManifestTests(unittest.TestCase):
                 recipe_root=d,
             )
             self.assertEqual(m["cmake_args"], [])
+
+    def test_cmake_state_collects_three_files(self):
+        # Embed CMakeCache.txt + CMake{C,CXX}Compiler.cmake content
+        # from the build dir under $WORK_DIR.
+        with tempfile.TemporaryDirectory() as work:
+            build = Path(work) / "llvm-project" / "build"
+            cmf = build / "CMakeFiles" / "3.28.3"
+            cmf.mkdir(parents=True)
+            (build / "CMakeCache.txt").write_text(
+                "CMAKE_CXX_COMPILER:FILEPATH=/usr/bin/clang++\n"
+                "CMAKE_CXX_STANDARD:STRING=17\n"
+            )
+            (cmf / "CMakeCXXCompiler.cmake").write_text(
+                'set(CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES '
+                '"/usr/include/c++/14")\n'
+            )
+            (cmf / "CMakeCCompiler.cmake").write_text(
+                'set(CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES "/usr/include")\n'
+            )
+            with mock.patch.dict(os.environ, {"WORK_DIR": work}, clear=True):
+                state = build_manifest._cmake_state()
+        self.assertIn("CMakeCache.txt", state)
+        self.assertIn("CMakeCXXCompiler.cmake", state)
+        self.assertIn("CMakeCCompiler.cmake", state)
+        self.assertIn("CMAKE_CXX_STANDARD:STRING=17", state["CMakeCache.txt"])
+        self.assertIn("/usr/include/c++/14",
+                      state["CMakeCXXCompiler.cmake"])
+        self.assertIn("/usr/include", state["CMakeCCompiler.cmake"])
+
+    def test_cmake_state_empty_without_work_dir(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(build_manifest._cmake_state(), {})
+
+    def test_cmake_state_empty_when_files_absent(self):
+        with tempfile.TemporaryDirectory() as work, \
+             mock.patch.dict(os.environ, {"WORK_DIR": work}, clear=True):
+            self.assertEqual(build_manifest._cmake_state(), {})
+
+    def test_installed_packages_parses_dpkg_query(self):
+        sample = (
+            "libstdc++-14-dev\t14.2.0-4ubuntu2~24.04.1\n"
+            "clang-18\t1:18.1.3-1ubuntu1\n"
+            "libedit-dev\t3.1-20230828-1build1\n"
+        )
+        with mock.patch.object(build_manifest.subprocess, "run") as run:
+            run.return_value = subprocess.CompletedProcess(
+                [], 0, stdout=sample, stderr="",
+            )
+            pkgs = build_manifest._installed_packages()
+        self.assertEqual(pkgs, {
+            "libstdc++-14-dev": "14.2.0-4ubuntu2~24.04.1",
+            "clang-18": "1:18.1.3-1ubuntu1",
+            "libedit-dev": "3.1-20230828-1build1",
+        })
+
+    def test_installed_packages_empty_without_dpkg(self):
+        with mock.patch.object(build_manifest.subprocess, "run",
+                               side_effect=FileNotFoundError):
+            self.assertEqual(build_manifest._installed_packages(), {})
 
     def test_missing_recipe_yaml_unknown(self):
         with tempfile.TemporaryDirectory() as d, \


### PR DESCRIPTION
A devshell session against the published llvm-release/22/ubuntu-24.04 asset just produced 100% ccache miss despite identical compiler version, identical ccache portable-hashing knobs, identical cmake flags, and matching paths. Root cause: the producer's GHA-hosted ubuntu-24.04 runner has libstdc++-14-dev installed; the consumer's catthehacker/ubuntu:act-24.04 container only has libstdc++-13-dev. Clang silently picks the highest libstdc++ version available, so every C++ TU preprocessed against /usr/include/c++/14 on the producer and /usr/include/c++/13 on the consumer -- different headers, different ccache hashes, no producer entry ever matched.

The producer-side manifest already records what's needed to detect that class of drift, but only what we thought to surface. Move from guessing to a complete picture: embed cmake's configured-state files and the installed-package set directly in the manifest. Two new fields:

  build_env.installed_packages  {pkg: version} from `dpkg-query -W`.
                                Lets a consumer compare its local
                                package set and apt-install whatever
                                the producer had that it doesn't --
                                catches the libstdc++ case and any
                                future "we forgot package X" surprise.
                                Linux-only (debian dpkg); empty on
                                macOS/Windows where this class of
                                drift doesn't apply.

  cmake_state                   {filename: content} for CMakeCache.txt,
                                CMakeCXXCompiler.cmake, and
                                CMakeCCompiler.cmake. CMakeCache holds
                                top-level vars (compiler path, flags,
                                standard, launcher); the per-compiler
                                files hold cmake's compiler-probe
                                output including
                                CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES
                                (which is NOT in CMakeCache.txt -- that
                                was the smoking-gun field for the
                                libstdc++ incident). Together they
                                describe everything cmake passes to the
                                compile commands ccache will hash.

Manifest grows from ~3 KB to ~120 KB per cell; the cmake_state dominates and is bounded by CMakeCache.txt size. Empty-fallback behaviour (no WORK_DIR, files absent, dpkg unavailable) keeps the manifest valid on every existing test fixture and on non-debian platforms.

Consumer-side detection (devshell-side warning that suggests `apt install <missing-pkg>` and refuses to start on a libstdc++ mismatch) is the next branch and reads from these fields.