### PR TITLE
[ci] install-build-deps: pass arch to msvc-dev-cmd on ARM64 hosts.

### DIFF
--- a/.github/actions/install-build-deps/action.yml
+++ b/.github/actions/install-build-deps/action.yml
@@ -50,9 +50,18 @@ runs:
     # MSVC env: sets cl.exe on PATH plus INCLUDE/LIB/LIBPATH. Pinned
     # to a tagged release (not @v1) so a future ilammy/msvc-dev-cmd
     # behavior change can't silently break our publish runs.
+    #
+    # arch follows runner.arch so the publish runner targets its own
+    # architecture. The action's default is x64, which on a windows-
+    # 11-arm runner cross-compiles to x64 -- the resulting .lib files
+    # land at lib/<name>.lib but carry x64 machine type, so consumers
+    # on the same arm64 runner image fail to link with LNK4272 ("library
+    # machine type 'x64' conflicts with target machine type 'ARM64'").
     - name: Set up MSVC developer environment (Windows)
       if: runner.os == 'Windows'
       uses: ilammy/msvc-dev-cmd@v1.13.0
+      with:
+        arch: ${{ runner.arch == 'ARM64' && 'arm64' || 'x64' }}
 
     - name: Install build dependencies (Windows)
       if: runner.os == 'Windows'


### PR DESCRIPTION
`ilammy/msvc-dev-cmd@v1.13.0`'s `arch` input defaults to x64. On a windows-2025 publish runner that's correct (host is x86_64); on a windows-11-arm runner it cross-compiles to x64 -- the resulting `.lib` files land at the expected paths but carry the x64 machine type. Consumers on the same arm64 runner image then fail to link with `LNK4272: library machine type 'x64' conflicts with target machine type 'ARM64'`.

Surfaced on CppInterOp's win11-msvc-llvm22 row trying to link cppinterop-tblgen against the published llvm-release/22/ windows-11-arm/arm64 cell -- 29 unresolved externals.

Drive `arch` from `runner.arch` so the MSVC environment matches the host. The current bad windows-11-arm cell stays orphaned until prune-cache GCs it; an operator should re-dispatch publish-recipe for that cell once this fix is on main so the consumer sees the arm64 binaries.