### PR TITLE
[ci] bin/repro: add --devshell mode for LLVM dev iteration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,48 @@ Stage / temp-workflow files are cleaned at exit; disk after the
 run is zero (image cache aside). See `bin/repro --help` and
 [docs/developer-guide.md](docs/developer-guide.md) for the rest.
 
+## Iterating on LLVM with a warm ccache: `--devshell`
+
+`bin/repro <cell> --devshell` skips the workflow and instead drops
+you into a long-lived container with the cell's published install,
+sibling ccache, and matching LLVM source already in place. Edits to
+`llvm-project/` rebuild incrementally against the producer's cache,
+so a single TU changes in seconds rather than the ~30 minutes a
+cold compile would take.
+
+```bash
+bin/repro ubu24-x86-gcc14-cling-llvm20-cppyy --devshell
+# inside the container:
+cd $DEVSHELL_BUILD && ninja clang
+```
+
+The cell argument is either a matrix-row name (validated against
+`act -n --json` for the consumer repo) or a direct
+`recipe/version/os/arch` coord (e.g. `llvm-release/22/ubuntu-24.04/x86_64`)
+for cells no consumer matrix references yet. Files live under
+`~/.cache/ci-workflows/devshell/<cell>/`; the container is named
+`devshell-<cell>` and persists across invocations. Common knobs:
+
+| flag | effect |
+|------|--------|
+| `--devshell-rm` | remove the container; preserve the host workdir |
+| `--devshell-refetch` | re-download install / ccache / manifest |
+| `--devshell-script PATH` | run PATH inside the container instead of an interactive shell (CI / smoke use) |
+
+`scripts/repro-config` runs at first entry and on each subsequent
+fetch: it installs the same apt deps as `install-build-deps`,
+auto-installs the libstdc++-N-dev that matches the producer's
+`/usr/include/c++/N` (catches the ~100% ccache-miss class caused by
+catthehacker's libstdc++-13 vs GHA's libstdc++-14), applies the
+producer's ccache `compiler_check`, replays the recipe's own cmake
+invocation from `manifest.cmake_args`, and warns on dev-package
+version drift. A smoke compile of `lib/Support/Allocator.cpp.o`
+verifies that the producer cache actually reaches the consumer
+environment before handing off the shell.
+
+Linux-only for now (Ubuntu cells); macOS hosts work via the bundled
+Linux container, with the platform-mismatch overhead under Rosetta.
+
 ## Layout
 
 ```

--- a/bin/repro
+++ b/bin/repro
@@ -151,6 +151,29 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
                    help="preserve the act container after the script "
                         "exits (disk NOT cleaned up). bin/repro prints "
                         "the docker exec command to re-enter it later.")
+    p.add_argument("--devshell", action="store_true",
+                   help="provision the recipe install + sibling ccache + "
+                        "matching LLVM source (per the manifest's "
+                        "SRC_COMMIT) into ~/.cache/ci-workflows/devshell/"
+                        "<cell>/ and drop into a container shell with "
+                        "CCACHE_DIR + CMAKE_*_COMPILER_LAUNCHER preset. "
+                        "Does NOT run the workflow -- this is the "
+                        "dev-bootstrap mode for editing LLVM source and "
+                        "rebuilding incrementally with ccache hits.")
+    p.add_argument("--devshell-refetch", action="store_true",
+                   help="with --devshell: re-download install/ccache/"
+                        "manifest even if the local copy already exists.")
+    p.add_argument("--devshell-script", metavar="PATH",
+                   help="with --devshell: instead of dropping into an "
+                        "interactive shell, run this script (host path) "
+                        "inside the container as the final action and "
+                        "exit with its return code. Batch mode for CI / "
+                        "automated smoke tests; the interactive shell is "
+                        "the default when this flag is omitted.")
+    p.add_argument("--devshell-rm", action="store_true",
+                   help="with --devshell: remove the persistent container "
+                        "and exit (does NOT delete ~/.cache/ci-workflows/"
+                        "devshell/<cell>/).")
 
     advanced = p.add_argument_group(
         "advanced",
@@ -902,6 +925,399 @@ def remove_container(cid: str) -> None:
                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
+# --- devshell mode -------------------------------------------------------
+#
+# `bin/repro --devshell <cell>` provisions the cell's recipe install +
+# sibling ccache + matching LLVM source under a persistent host dir, then
+# drops into a container shell with CCACHE_DIR + CMAKE_*_COMPILER_LAUNCHER
+# preset. Devs editing LLVM source for cppyy/cppinterop debugging can
+# rebuild incrementally with ~all unmodified objects served from the
+# recipe's pre-warmed ccache.
+#
+# Distinct from the act-driven repro path: no workflow runs, no
+# nektos/act involvement, no GHA cache emulation. The container is a
+# bare runner image with the workdir bind-mounted.
+
+DEVSHELL_HOME = Path.home() / ".cache" / "ci-workflows" / "devshell"
+
+# Fallback bind-mount path for pre-#51 manifests that don't carry
+# build_env.ccache.base_dir. _devshell_workspace prefers the manifest
+# value when present.
+DEVSHELL_RUNNER_WORKSPACE = "/home/runner/work/ci-workflows/ci-workflows"
+DEVSHELL_CCACHE_SUBDIR    = ".ccache"
+DEVSHELL_SRC_SUBDIR       = "_recipe_work/llvm-project"
+DEVSHELL_BUILD_SUBDIR     = "_recipe_work/llvm-project/build"
+DEVSHELL_INSTALL_SUBDIR   = "_recipe_out/llvm-project"
+
+DEVSHELL_CONFIG_SCRIPT = REPO_ROOT / "scripts" / "repro-config"
+
+
+def _devshell_cell(args: argparse.Namespace) -> Dict[str, str]:
+    """Resolve the matrix-row name in args.matrix to a cell coord.
+
+    Mirrors `_print_fast_cells_hint._cell_for`: walks act's dry-run
+    matrix output, then validates the (recipe, version, os, arch)
+    tuple against cells.yaml (so a typo doesn't silently produce a
+    URL that 404s). Exits with a clear message on miss.
+    """
+    name = _matrix_get(args.matrix or [], "name")
+    if not name:
+        sys.exit("error: --devshell needs a row name "
+                 "(positional alias or `-m name:<row>`)")
+    # Direct-coord shorthand for cells not in any consumer matrix
+    # (e.g. llvm-release/22/ubuntu-24.04/x86_64). Skip the act matrix
+    # lookup; jump straight to cells.yaml validation below.
+    if "/" in name:
+        parts = name.split("/")
+        if len(parts) != 4:
+            sys.exit(f"error: --devshell direct-coord must be "
+                     f"recipe/version/os/arch; got '{name}'")
+        coord = {
+            "recipe": parts[0], "version": parts[1],
+            "os":     parts[2], "arch":    parts[3],
+        }
+        cells = published_cells()
+        if cells and not any(all(coord[k] == c[k]
+                                 for k in ("recipe", "version", "os", "arch"))
+                             for c in cells):
+            sys.exit(f"error: cell {coord} not in cells.yaml")
+        return coord
+    matrix_by_row = {r["row_name"]: r["matrix"]
+                     for r in _act_dryrun_rows()}
+    m = matrix_by_row.get(name)
+    if m is None:
+        sys.exit(f"error: row '{name}' not found in matrix discovery")
+    coord = {
+        "recipe":  m.get("use-recipe"),
+        "version": (m.get("recipe-version") or m.get("clang-runtime")),
+        "os":      m.get("os"),
+        "arch":    m.get("recipe-arch") or "x86_64",
+    }
+    if not all(coord.values()):
+        sys.exit(f"error: row '{name}' doesn't pull from a recipe cache "
+                 f"(matrix.use-recipe missing)")
+    cells = published_cells()
+    if cells and not any(all(coord[k] == c[k]
+                             for k in ("recipe", "version", "os", "arch"))
+                         for c in cells):
+        sys.exit(f"error: cell {coord} not in cells.yaml -- the asset "
+                 f"likely doesn't exist on Releases")
+    return coord
+
+
+def _devshell_image(os_slug: str) -> str:
+    """Pick a container image matching the cell's runner image.
+
+    Mirrors act's default mapping for the catthehacker images, since
+    that's what the recipe was built against. Linux only for now;
+    macOS/Windows cells aren't reproducible in a container shell.
+    """
+    if os_slug == "ubuntu-24.04":
+        return "ghcr.io/catthehacker/ubuntu:act-24.04"
+    if os_slug == "ubuntu-22.04":
+        return "ghcr.io/catthehacker/ubuntu:act-22.04"
+    sys.exit(f"error: --devshell currently supports Linux Ubuntu cells "
+             f"only (cell os={os_slug})")
+
+
+def _devshell_compute_key(coord: Dict[str, str]) -> str:
+    """Run actions/setup-recipe/compute_key.py the same way
+    publish-recipe/setup-recipe do, to get a content-hash key that
+    matches the published asset on Releases.
+    """
+    out = subprocess.check_output(
+        ["python3",
+         str(REPO_ROOT / "actions" / "setup-recipe" / "compute_key.py"),
+         coord["recipe"], coord["version"], coord["os"], coord["arch"]],
+        cwd=str(REPO_ROOT),
+    ).decode().strip()
+    # compute_key.py output: `key=<recipe>-<version>-<os>-<arch>-<hash>`
+    if not out.startswith("key="):
+        sys.exit(f"error: compute_key.py returned: {out!r}")
+    return out[len("key="):]
+
+
+def _devshell_fetch(base: str, key: str, work: Path,
+                    refetch: bool) -> Dict:
+    """Download <key>.tar.zst (install), <key>.ccache.tar.zst (sibling),
+    and <key>.manifest.json into `work`. Returns the parsed manifest.
+
+    `refetch` re-downloads even when the local copy is present.
+    Each download is gated independently so a partial run resumes
+    cheaply.
+    """
+    sys.path.insert(0, str(REPO_ROOT / "actions" / "lib"))
+    import cache_io  # noqa: E402
+    import json
+    import urllib.request
+
+    # Layout under `work` (host) mirrors publish-recipe's runner
+    # workspace; _devshell_ensure_container bind-mounts it inside the
+    # container at the path recorded in the manifest.
+    install_parent = work / "_recipe_out"
+    ccache_root = work
+    manifest = work / "manifest.json"
+
+    # Install tree: archive's top-level dir is `llvm-project/`, so
+    # extracting to `<work>/_recipe_out/` lands the install at
+    # `<work>/_recipe_out/llvm-project/`.
+    install_root = install_parent / "llvm-project"
+    if refetch or not install_root.is_dir():
+        if install_parent.is_dir():
+            shutil.rmtree(install_parent)
+        install_parent.mkdir(parents=True)
+        _log(f"repro: fetching install ({key}.tar.zst)...")
+        cache_io.cache_download(base, key, str(install_parent))
+
+    # Sibling ccache: archive's top-level dir is `.ccache/`, extracting
+    # to `<work>/` lands the ccache at `<work>/.ccache/`.
+    ccache_dir = ccache_root / DEVSHELL_CCACHE_SUBDIR
+    if refetch or not ccache_dir.is_dir():
+        if ccache_dir.is_dir():
+            shutil.rmtree(ccache_dir)
+        asset = f"{key}.ccache.tar.zst"
+        _log(f"repro: fetching ccache ({asset})...")
+        if base.startswith("file://"):
+            with (Path(base[len("file://"):]) / asset).open("rb") as f:
+                cache_io._zstd_decode_into_tar(f, ccache_root)
+        else:
+            with urllib.request.urlopen(
+                    f"{base.rstrip('/')}/{asset}", timeout=300) as r:
+                cache_io._zstd_decode_into_tar(r, ccache_root)
+
+    # Manifest: plain JSON, no zstd/tar.
+    if refetch or not manifest.is_file():
+        url = f"{base.rstrip('/')}/{key}.manifest.json"
+        _log(f"repro: fetching manifest ({key}.manifest.json)...")
+        if base.startswith("file://"):
+            shutil.copy(Path(base[len("file://"):]) / f"{key}.manifest.json",
+                        manifest)
+        else:
+            with urllib.request.urlopen(url, timeout=60) as r:
+                manifest.write_bytes(r.read())
+
+    return json.loads(manifest.read_text())
+
+
+def _devshell_source(work: Path, manifest: Dict) -> Path:
+    """Shallow-clone llvm-project at the manifest's SRC_COMMIT.
+
+    `git init` + `git fetch --depth=1 origin <commit>` instead of a
+    full-history clone: llvm-project's full history is ~3 GB and
+    several minutes; the recipe-pinned SHA only needs that one commit
+    to build. The dev can `git fetch --unshallow` from inside the
+    container if they need history (e.g. for `git blame`).
+
+    Persistent across invocations: subsequent calls find the local
+    .git, just re-fetch the commit (no-op if already present) and
+    re-checkout. Recipe ladder bumps that move SRC_COMMIT pull only
+    the new commit.
+    """
+    src = manifest.get("source") or {}
+    repo = src.get("repo")
+    commit = src.get("commit")
+    if not repo or not commit or commit == "unknown":
+        sys.exit(f"error: manifest missing source.{{repo,commit}}; "
+                 f"cannot reproduce")
+    src_dir = work / DEVSHELL_SRC_SUBDIR
+    if not (src_dir / ".git").is_dir():
+        _log(f"repro: shallow-fetching {repo} @ {commit[:12]} "
+             f"(use `git fetch --unshallow` inside the container "
+             f"for history)...")
+        src_dir.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "-C", str(src_dir), "init", "-q"],
+                       check=True)
+        subprocess.run(["git", "-C", str(src_dir),
+                        "remote", "add", "origin", repo], check=True)
+    subprocess.run(["git", "-C", str(src_dir),
+                    "fetch", "--depth=1", "origin", commit],
+                   check=True)
+    _log(f"repro: checking out {commit[:12]}...")
+    subprocess.run(["git", "-C", str(src_dir),
+                    "checkout", "--detach", commit], check=True)
+    return src_dir
+
+
+def _devshell_ccache_cfg(manifest: Dict) -> Dict[str, str]:
+    """build_env.ccache from the manifest, or {} for pre-#51 publishes."""
+    return ((manifest.get("build_env") or {}).get("ccache") or {})
+
+
+def _devshell_workspace(manifest: Dict) -> str:
+    """In-container path mirroring the recipe's runner workspace.
+
+    Drives the bind-mount and CCACHE_BASEDIR so recipe-side ccache
+    entries key on the same path as dev-side compiles.
+    """
+    base = _devshell_ccache_cfg(manifest).get("base_dir", "")
+    if base and base != "unknown":
+        return base
+    return DEVSHELL_RUNNER_WORKSPACE
+
+
+def _devshell_container_name(cell_id: str) -> str:
+    return f"devshell-{cell_id}"
+
+
+def _devshell_container_running(name: str) -> bool:
+    r = subprocess.run(
+        ["docker", "container", "inspect", "-f", "{{.State.Running}}", name],
+        capture_output=True, text=True,
+    )
+    return r.returncode == 0 and r.stdout.strip() == "true"
+
+
+def _devshell_container_exists(name: str) -> bool:
+    r = subprocess.run(
+        ["docker", "container", "inspect", name],
+        capture_output=True, text=True,
+    )
+    return r.returncode == 0
+
+
+def _devshell_ensure_container(name: str, image: str, work: Path,
+                               manifest: Dict) -> None:
+    """Idempotently start a long-lived container named `name` with
+    `work` bind-mounted at the manifest's recorded workspace path and
+    the dev-env vars exported. Tool installation + build-dir configure
+    happens via scripts/repro-config -- see _devshell_run_config().
+    """
+    if _devshell_container_exists(name):
+        if not _devshell_container_running(name):
+            subprocess.run(["docker", "start", name], check=True,
+                           stdout=subprocess.DEVNULL)
+        return
+    ws = _devshell_workspace(manifest)
+    cfg = _devshell_ccache_cfg(manifest)
+    no_hash_dir = "true" if cfg.get("hash_dir") == "false" else "false"
+    env_args: list[str] = [
+        "-e", "CC=clang",
+        "-e", "CXX=clang++",
+        "-e", f"CCACHE_DIR={ws}/{DEVSHELL_CCACHE_SUBDIR}",
+        "-e", f"CCACHE_BASEDIR={ws}",
+        "-e", f"CCACHE_NOHASHDIR={no_hash_dir}",
+        "-e", "CMAKE_C_COMPILER_LAUNCHER=ccache",
+        "-e", "CMAKE_CXX_COMPILER_LAUNCHER=ccache",
+        "-e", f"LLVM_PREFIX={ws}/{DEVSHELL_INSTALL_SUBDIR}",
+        "-e", f"DEVSHELL_SRC={ws}/{DEVSHELL_SRC_SUBDIR}",
+        "-e", f"DEVSHELL_BUILD={ws}/{DEVSHELL_BUILD_SUBDIR}",
+        "-e", f"DEVSHELL_MANIFEST={ws}/manifest.json",
+        "-e", f"CCACHE_LOGFILE={ws}/{DEVSHELL_CCACHE_SUBDIR}/ccache.log",
+    ]
+    cc = cfg.get("compiler_check", "")
+    if cc and cc != "unknown":
+        # Producer's ccache.compiler_check verbatim. repro-config
+        # applies it on the consumer side and warns on $CC --version
+        # divergence.
+        env_args += ["-e", f"DEVSHELL_PRODUCER_COMPILER_CHECK={cc}"]
+    subprocess.run(
+        ["docker", "run", "-d",
+         "--name", name,
+         "-v", f"{work}:{ws}",
+         "-v", f"{REPO_ROOT}:/ci-workflows:ro",
+         "-w", ws,
+         *env_args,
+         image, "sleep", "infinity"],
+        check=True, stdout=subprocess.DEVNULL,
+    )
+
+
+def _devshell_run_config(name: str, work: Path, manifest: Dict) -> None:
+    """Stage scripts/repro-config into /work and run it inside the
+    container. Idempotent on re-runs (script is no-op when build dir
+    already configured + tools already installed). Emits the hint
+    block for the dev to copy-paste.
+    """
+    if not DEVSHELL_CONFIG_SCRIPT.is_file():
+        sys.exit(f"error: {DEVSHELL_CONFIG_SCRIPT} not found "
+                 f"-- ci-workflows checkout incomplete?")
+    staged = work / "repro-config"
+    shutil.copy(DEVSHELL_CONFIG_SCRIPT, staged)
+    os.chmod(staged, 0o755)
+    ws = _devshell_workspace(manifest)
+    subprocess.run(
+        ["docker", "exec", "-w", ws, name,
+         "bash", f"{ws}/repro-config"],
+        check=True,
+    )
+
+
+def cmd_devshell(args: argparse.Namespace) -> int:
+    """Provision install + ccache + LLVM source for the cell, then
+    drop into a container shell. See module-level comment.
+    """
+    sys.path.insert(0, str(REPO_ROOT / "actions" / "lib"))
+    import cache_io  # noqa: E402
+
+    coord = _devshell_cell(args)
+    image = _devshell_image(coord["os"])
+    key = _devshell_compute_key(coord)
+    base = cache_io.resolve_cache_base()
+
+    cell_id = "-".join(coord[k] for k in ("recipe", "version", "os", "arch"))
+    name = _devshell_container_name(cell_id)
+    work = DEVSHELL_HOME / cell_id
+
+    if args.devshell_rm:
+        if _devshell_container_exists(name):
+            _log(f"repro: removing devshell container {name}")
+            subprocess.run(["docker", "rm", "-f", name],
+                           check=True, stdout=subprocess.DEVNULL)
+        else:
+            _log(f"repro: no container named {name}; nothing to remove")
+        _log(f"repro: workdir at {work} preserved")
+        return 0
+
+    work.mkdir(parents=True, exist_ok=True)
+
+    manifest = _devshell_fetch(base, key, work, args.devshell_refetch)
+    src_dir = _devshell_source(work, manifest)
+
+    fresh = not _devshell_container_exists(name)
+    _devshell_ensure_container(name, image, work, manifest)
+    _devshell_run_config(name, work, manifest)
+
+    ws = _devshell_workspace(manifest)
+    _log("")
+    _log(f"repro: --devshell ready ({cell_id})")
+    _log(f"  {ws}/{DEVSHELL_INSTALL_SUBDIR}")
+    _log(f"      <- {key}.tar.zst (install tree)")
+    _log(f"  {ws}/{DEVSHELL_CCACHE_SUBDIR}")
+    _log(f"      <- {key}.ccache.tar.zst (warm ccache, paths match recipe build)")
+    _log(f"  {ws}/{DEVSHELL_SRC_SUBDIR}")
+    _log(f"      <- {manifest['source']['repo']} @ "
+         f"{manifest['source']['commit'][:12]}")
+    _log(f"  container              {name} ({'fresh' if fresh else 'reused'})")
+    _log("")
+    _log(f"repro: re-enter later with `bin/repro --devshell <cell>` "
+         f"or `docker exec -it {name} bash`")
+    _log(f"repro: tear down with `bin/repro --devshell --devshell-rm <cell>`")
+    _log("")
+
+    if args.devshell_script:
+        # Batch mode: stage the host script into the bind-mounted workdir
+        # so the container can exec it without a second mount, run it,
+        # exit with its rc. No interactive shell.
+        script_host = Path(args.devshell_script).resolve()
+        if not script_host.is_file():
+            sys.exit(f"error: --devshell-script: {script_host} not a file")
+        staged = work / ".devshell-script.sh"
+        shutil.copy(script_host, staged)
+        os.chmod(staged, 0o755)
+        _log(f"repro: running --devshell-script ({script_host.name})...")
+        return subprocess.run(
+            ["docker", "exec", "-w", ws, name,
+             "bash", f"{ws}/.devshell-script.sh"]).returncode
+
+    # scripts/repro-config printed its own next-step hints above;
+    # don't duplicate. The quickstart-once marker is no longer
+    # needed.
+
+    return _run_interactive(["docker", "exec", "-it", name, "bash"])
+
+
+
+
 def _container_tree_dirty(cid: str, workspace: str) -> bool:
     """True when `git -C <workspace> diff HEAD` reports changes.
 
@@ -1163,6 +1579,12 @@ def main() -> int:
         pattern = args.passthrough[0]
         args.passthrough = args.passthrough[1:]
         _resolve_pattern(pattern, args)
+
+    # --devshell short-circuits the act run: provision the cell's
+    # recipe install + sibling ccache + matching LLVM source, then
+    # spawn a container shell. No workflow execution.
+    if args.devshell:
+        return cmd_devshell(args)
 
     # Auto-fill -W / -j from `-m name:<row>` when both are omitted.
     # discover_matrix_rows already cross-references act -l + act -n,

--- a/bin/test_repro.py
+++ b/bin/test_repro.py
@@ -1373,5 +1373,90 @@ class SubprocessTests(unittest.TestCase):
         self.assertIn("-j NAME, --list, or -m name:", r.stderr)
 
 
+class DevshellCellTests(unittest.TestCase):
+    """Pin --devshell's cell-coord resolution: matrix-row name lookup,
+    direct recipe/version/os/arch shorthand, and the fail-fast paths
+    (typo, missing matrix.use-recipe).
+    """
+
+    def setUp(self):
+        self.repro = _load_repro()
+
+    def _ns(self, name):
+        return argparse.Namespace(matrix=[f"name:{name}"])
+
+    def test_direct_coord_shorthand_returns_parsed_dict(self):
+        with mock.patch.object(self.repro, "published_cells",
+                               return_value=[]):
+            coord = self.repro._devshell_cell(
+                self._ns("llvm-release/22/ubuntu-24.04/x86_64"))
+        self.assertEqual(coord, {
+            "recipe": "llvm-release", "version": "22",
+            "os": "ubuntu-24.04", "arch": "x86_64",
+        })
+
+    def test_direct_coord_with_too_few_parts_exits(self):
+        with self.assertRaises(SystemExit) as cm:
+            self.repro._devshell_cell(self._ns("llvm-release/22"))
+        self.assertIn("recipe/version/os/arch", str(cm.exception))
+
+    def test_direct_coord_validates_against_cells_yaml(self):
+        with mock.patch.object(
+            self.repro, "published_cells",
+            return_value=[{"recipe": "llvm-release", "version": "22",
+                           "os": "ubuntu-24.04", "arch": "arm64"}],
+        ):
+            with self.assertRaises(SystemExit) as cm:
+                # Same coord but x86_64 is not in the published list.
+                self.repro._devshell_cell(
+                    self._ns("llvm-release/22/ubuntu-24.04/x86_64"))
+        self.assertIn("not in cells.yaml", str(cm.exception))
+
+    def test_row_name_lookup_returns_recipe_coord(self):
+        rows = [{
+            "row_name": "ubu24-x86-gcc14-cling-llvm20-cppyy",
+            "matrix": {"use-recipe": "llvm-cling", "recipe-version": "20",
+                       "os": "ubuntu-24.04", "recipe-arch": "x86_64"},
+        }]
+        with mock.patch.object(self.repro, "_act_dryrun_rows",
+                               return_value=rows), \
+             mock.patch.object(self.repro, "published_cells",
+                               return_value=[]):
+            coord = self.repro._devshell_cell(
+                self._ns("ubu24-x86-gcc14-cling-llvm20-cppyy"))
+        self.assertEqual(coord["recipe"], "llvm-cling")
+        self.assertEqual(coord["version"], "20")
+
+    def test_row_without_use_recipe_exits(self):
+        rows = [{"row_name": "no-recipe-row",
+                 "matrix": {"os": "ubuntu-24.04"}}]
+        with mock.patch.object(self.repro, "_act_dryrun_rows",
+                               return_value=rows):
+            with self.assertRaises(SystemExit) as cm:
+                self.repro._devshell_cell(self._ns("no-recipe-row"))
+        self.assertIn("doesn't pull from a recipe cache", str(cm.exception))
+
+
+class DevshellImageTests(unittest.TestCase):
+    """Pin --devshell's runner-image mapping: matches act's catthehacker
+    defaults for supported Ubuntu cells, refuses other OSes."""
+
+    def setUp(self):
+        self.repro = _load_repro()
+
+    def test_ubuntu_24_04_maps_to_act_image(self):
+        self.assertIn("act-24.04",
+                      self.repro._devshell_image("ubuntu-24.04"))
+
+    def test_ubuntu_22_04_maps_to_act_image(self):
+        self.assertIn("act-22.04",
+                      self.repro._devshell_image("ubuntu-22.04"))
+
+    def test_unsupported_os_exits_with_explanation(self):
+        with self.assertRaises(SystemExit) as cm:
+            self.repro._devshell_image("macos-14")
+        self.assertIn("Linux Ubuntu cells", str(cm.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -366,3 +366,106 @@ bin/repro consumes via `--ci-workflows <path>`.
   exit; if a run is killed hard, remove
   `.github/act-ci-workflows-stage/` and
   `.github/workflows/act-*-localized-*.yml` by hand.
+
+## Iterating on LLVM with `--devshell`
+
+`bin/repro <cell> --devshell` is a different mode: it doesn't run
+a workflow. It downloads the cell's published install +
+sibling-ccache + manifest, shallow-clones llvm-project at the
+manifest's pinned `SRC_COMMIT`, and drops you into a long-lived
+container ready for incremental rebuilds against the producer's
+ccache.
+
+Use it when:
+
+- A workflow ran clean in CI but you want to edit something *in
+  LLVM itself* and rebuild fast (the `bin/repro <row>` shell only
+  reproduces the row's own build, which doesn't iterate well).
+- You're triaging a cppyy / CppInterOp issue that needs a
+  patched LLVM.
+- You want to verify a recipe's published install actually compiles
+  the next dependent layer (CppInterOp, cling) before relying on it.
+
+### Cell argument
+
+Either form works:
+
+- A matrix-row name from a consumer repo (`bin/repro --list` from
+  that repo enumerates them). Looked up against `act -n --json`,
+  which gives `bin/repro` the recipe coord to download.
+- A direct `recipe/version/os/arch` coord, e.g.
+  `llvm-release/22/ubuntu-24.04/x86_64`. Use this when no consumer
+  matrix references the cell yet (e.g. you just published it and
+  haven't migrated downstream `setup-llvm` callers).
+
+The cell is validated against `cells.yaml`; a typo fails fast
+rather than 404'ing on Releases.
+
+### Workdir layout
+
+```
+~/.cache/ci-workflows/devshell/<cell>/
+  _recipe_out/llvm-project/        install tree (LLVM_PREFIX)
+  .ccache/                         producer's sibling ccache
+  _recipe_work/llvm-project/       shallow llvm-project @ SRC_COMMIT
+  manifest.json                    producer manifest
+```
+
+The container (`devshell-<cell>`) bind-mounts this directory at the
+recipe's runner workspace path (read from
+`manifest.build_env.ccache.base_dir`), so ccache's recorded paths
+match. Re-invoking `bin/repro <cell> --devshell` re-uses the
+container; `--devshell-rm` deletes it but keeps the workdir.
+
+### Knobs
+
+| flag | effect |
+|------|--------|
+| `--devshell-rm` | remove the container; workdir is kept |
+| `--devshell-refetch` | re-download install/ccache/manifest |
+| `--devshell-script PATH` | run host PATH inside the container, exit with its rc (batch mode) |
+
+### What `scripts/repro-config` does on entry
+
+Idempotent — runs once per fetch, no-ops on rebuild:
+
+1. **apt deps**: same set as `install-build-deps` Linux step
+   (clang, cmake, ninja, ccache, libedit-dev, ...).
+2. **libstdc++ auto-detect**: reads
+   `manifest.cmake_state.CMakeCXXCompiler.cmake`, extracts the
+   `CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES` path, and apt-installs
+   the matching `libstdc++-N-dev` if it isn't local. Catches the
+   catthehacker `libstdc++-13` vs GHA `libstdc++-14` drift that
+   makes every C++ TU's preprocessed output diverge — 100%
+   ccache-miss against the producer cache. For pre-`cmake_state`
+   manifests, defaults to `libstdc++-14-dev` (matches the GHA
+   `ubuntu-24.04` runner the recipes target).
+3. **package-drift warning**: diffs the producer's
+   `manifest.build_env.installed_packages` against local
+   `dpkg-query` output, filtered to dev / clang / cmake / ninja /
+   ccache / lld packages. Surfaces a `::warning::` line per
+   divergent package; no auto-install.
+4. **ccache `compiler_check`**: applies the producer's value
+   verbatim (exported by `bin/repro` from
+   `manifest.build_env.ccache.compiler_check`). Warns when the
+   consumer's `$CC --version` diverges.
+5. **cmake configure**: replays the recipe's own cmake invocation
+   from `manifest.cmake_args`, substituting
+   `CMAKE_INSTALL_PREFIX` and the source path. Pre-`cmake_args`
+   manifests fall back to `llvm_build.base_cmake_args() +
+   LLVM_ENABLE_PROJECTS=clang`.
+6. **smoke compile**: builds
+   `lib/Support/CMakeFiles/LLVMSupport.dir/Allocator.cpp.o`. Zero
+   ccache hits ⇒ producer cache isn't reaching the consumer (drift
+   the earlier checks didn't catch); surfaces a `::warning::`
+   rather than aborting.
+
+### Limits
+
+- Linux Ubuntu cells only (`ubuntu-22.04`, `ubuntu-24.04`); other
+  cell OSes refuse with a clear error.
+- macOS hosts work via the Linux container, paying Rosetta
+  emulation overhead on Apple Silicon.
+- Pre-portable-ccache manifests (no `build_env.ccache`) provision
+  correctly but miss on the first compile until a republish writes
+  the portable-hashing config alongside.

--- a/scripts/repro-config
+++ b/scripts/repro-config
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# bin/repro --devshell stages this inside the container and runs it.
+# Paths come from the env (DEVSHELL_SRC, DEVSHELL_BUILD, LLVM_PREFIX);
+# ccache knobs come from DEVSHELL_PRODUCER_COMPILER_CHECK + the
+# CCACHE_* vars bin/repro reads from the recipe's manifest. Idempotent:
+# tools install once, cmake configure no-ops when CMakeCache.txt exists.
+
+set -e
+
+if ! command -v ccache >/dev/null 2>&1; then
+  apt-get update -qq
+  # Match .github/actions/install-build-deps/action.yml (Linux path)
+  # exactly: same compiler (clang) and same set of build deps the
+  # publish-recipe pipeline used.
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    cmake ninja-build zstd ccache rsync clang libedit-dev git
+fi
+
+# Detect & install whatever libstdc++-N-dev the producer used. Read
+# CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES out of the manifest's
+# cmake_state and check for the corresponding /usr/include/c++/N
+# locally; apt-install if missing. catthehacker/ubuntu:act-24.04
+# ships libstdc++-13-dev, but the GHA-hosted ubuntu-24.04 runner has
+# libstdc++-14-dev. Clang picks the highest available libstdc++,
+# so a mismatch makes every C++ TU's preprocessor output diverge --
+# 100% ccache miss against the producer cache. For pre-cmake_state
+# manifests fall back to libstdc++-14-dev as the empirical default.
+need_cxx_n=$(python3 - <<'PY' "$DEVSHELL_MANIFEST"
+import json, os, re, sys
+try:
+    m = json.load(open(sys.argv[1]))
+except (OSError, json.JSONDecodeError):
+    sys.exit(0)
+cmf = (m.get("cmake_state") or {}).get("CMakeCXXCompiler.cmake", "")
+match = re.search(
+    r'CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES\s+"([^"]*)"', cmf
+)
+if match:
+    for p in match.group(1).split(";"):
+        m2 = re.match(r"/usr/include/c\+\+/(\d+)$", p)
+        if m2 and not os.path.isdir(p):
+            print(m2.group(1))
+            sys.exit(0)
+elif not os.path.isdir("/usr/include/c++/14"):
+    print("14")
+PY
+)
+if [[ -n "$need_cxx_n" ]]; then
+  echo "::warning::installing libstdc++-${need_cxx_n}-dev (producer used /usr/include/c++/${need_cxx_n} but it's not installed locally)"
+  apt-get update -qq
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    "libstdc++-${need_cxx_n}-dev"
+fi
+
+# Generic dev-package divergence check. Compare the producer's
+# installed_packages map (manifest field, post-cmake_state branch)
+# against ours; for each *-dev / clang* / cmake / ninja* / ccache the
+# producer had with a different version, surface a single warning
+# line. No auto-install (versions may not be available in the local
+# apt sources, and dev tools rarely matter beyond libstdc++ which the
+# block above already handles); the warning lets the dev decide.
+python3 - <<'PY' "$DEVSHELL_MANIFEST" || true
+import json, os, subprocess, sys
+try:
+    m = json.load(open(sys.argv[1]))
+except (OSError, json.JSONDecodeError):
+    sys.exit(0)
+producer = (m.get("build_env") or {}).get("installed_packages") or {}
+if not producer:
+    sys.exit(0)
+RELEVANT = ("-dev",)
+RELEVANT_PREFIX = ("clang", "cmake", "ninja", "ccache", "lld",
+                   "libedit", "libtinfo", "libxml2", "zlib")
+candidates = {
+    n: v for n, v in producer.items()
+    if n.endswith(RELEVANT) or n.startswith(RELEVANT_PREFIX)
+}
+if not candidates:
+    sys.exit(0)
+try:
+    r = subprocess.run(
+        ["dpkg-query", "-W", "-f=${Package}\\t${Version}\\n",
+         *candidates.keys()],
+        capture_output=True, text=True,
+    )
+except FileNotFoundError:
+    sys.exit(0)
+local: dict[str, str] = {}
+for line in r.stdout.splitlines():
+    if "\t" in line:
+        n, v = line.split("\t", 1)
+        local[n] = v
+diffs = []
+for n, v in candidates.items():
+    lv = local.get(n)
+    if lv is None:
+        diffs.append(f"{n}: missing locally (producer={v})")
+    elif lv != v:
+        diffs.append(f"{n}: producer={v} local={lv}")
+if diffs:
+    print("::warning::package-version drift vs producer (may cause ccache miss):", file=sys.stderr)
+    for d in diffs[:10]:
+        print(f"  {d}", file=sys.stderr)
+    if len(diffs) > 10:
+        print(f"  ... +{len(diffs)-10} more", file=sys.stderr)
+PY
+
+ccache --max-size=5G
+# Mirror publish-recipe's compiler_check. When the manifest records
+# the producer's value, apply it verbatim (consumer's $CC --version
+# may differ in package metadata even with matching binaries) and
+# warn if the version line genuinely diverges.
+cc_version=$("$CC" --version | head -1)
+if [[ -n "${DEVSHELL_PRODUCER_COMPILER_CHECK:-}" ]]; then
+  ccache --set-config="compiler_check=$DEVSHELL_PRODUCER_COMPILER_CHECK"
+  recorded="${DEVSHELL_PRODUCER_COMPILER_CHECK#string:}"
+  if [[ "$recorded" != "$cc_version" ]]; then
+    echo "warning: compiler version differs from recipe; ccache will miss." >&2
+    echo "  recipe: $recorded" >&2
+    echo "  here:   $cc_version" >&2
+  fi
+else
+  ccache --set-config="compiler_check=string:$cc_version"
+fi
+
+build="${DEVSHELL_BUILD:?env not set; bin/repro --devshell exports it}"
+src="${DEVSHELL_SRC:?env not set; bin/repro --devshell exports it}/llvm"
+prefix="${LLVM_PREFIX:?env not set; bin/repro --devshell exports it}"
+manifest="${DEVSHELL_MANIFEST:?env not set; bin/repro --devshell exports it}"
+
+if [[ ! -f "$build/CMakeCache.txt" ]]; then
+  mkdir -p "$build"
+  cd "$build"
+  # Replay the recipe's own cmake invocation from the manifest's
+  # cmake_args field (post-#53). Substitute CMAKE_INSTALL_PREFIX with
+  # the consumer's local LLVM_PREFIX and resolve the source path
+  # relative to the build dir. ccache hashes the full compile command,
+  # so any drift here defeats the sibling-cache pre-warm. The fallback
+  # path (no cmake_args in manifest) computes flags via llvm_build for
+  # backwards compatibility with pre-#53 publishes.
+  exec_cmake_args=$(python3 - <<'PY'
+import json, os, shlex, sys
+manifest = json.load(open(os.environ["DEVSHELL_MANIFEST"]))
+args = manifest.get("cmake_args") or []
+prefix = os.environ["LLVM_PREFIX"]
+src = os.environ["DEVSHELL_SRC"] + "/llvm"
+if args:
+    out = []
+    for a in args:
+        if a == "cmake":
+            continue
+        if a.startswith("-DCMAKE_INSTALL_PREFIX="):
+            out.append(f"-DCMAKE_INSTALL_PREFIX={prefix}")
+            continue
+        if a == "../llvm":
+            out.append(src)
+            continue
+        out.append(a)
+else:
+    sys.path.insert(0, "/ci-workflows/actions/lib")
+    import llvm_build
+    out = (llvm_build.base_cmake_args(prefix)
+           + ["-DLLVM_ENABLE_PROJECTS=clang"]
+           + llvm_build.cmake_extra()
+           + [src])
+print(" ".join(shlex.quote(x) for x in out))
+PY
+)
+  eval cmake "$exec_cmake_args"
+fi
+
+# Sanity check: smoke-compile one TU every LLVM build has
+# (lib/Support/Allocator.cpp) and verify ccache hits the producer's
+# cache. Zero hits => the producer's cache doesn't reach this
+# environment (libstdc++ / compile-flag / compiler-version drift the
+# earlier checks didn't catch). Surface as ::warning:: rather than
+# exiting -- the dev may still want to iterate, just on a cold cache.
+sanity_tu="lib/Support/CMakeFiles/LLVMSupport.dir/Allocator.cpp.o"
+if [[ -f "$build/build.ninja" ]] \
+   && (cd "$build" && ninja -t commands "$sanity_tu" >/dev/null 2>&1); then
+  ccache --zero-stats
+  rm -f "$build/$sanity_tu"
+  if (cd "$build" && ninja "$sanity_tu" >/dev/null 2>&1); then
+    sanity_hits=$(ccache --show-stats \
+      | awk '/^[[:space:]]*Hits:[[:space:]]+[0-9]/ { print $2; exit }')
+    : "${sanity_hits:=0}"
+    if [[ "$sanity_hits" == "0" ]]; then
+      echo "::warning title=ccache sanity::smoke-compile of ${sanity_tu##*/} produced 0 ccache hits; producer cache likely won't apply to your builds. Compare 'ccache --show-config' to manifest.build_env.ccache and the recorded CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES."
+    else
+      echo "ccache sanity: ${sanity_hits} hit(s) on Allocator.cpp -- producer cache is reaching this consumer."
+    fi
+  fi
+fi
+
+cat <<EOF
+
+DevEnv ready. Common next steps:
+  cd \$DEVSHELL_BUILD
+  ninja clang clangInterpreter clangStaticAnalyzerCore \\
+        LLVMOrcDebugging LLVMLineEditor
+  ccache --show-stats
+  ninja install-distribution
+
+Source: \$DEVSHELL_SRC  (shallow checkout @ recipe SHA;
+                         git fetch --unshallow for history)
+EOF


### PR DESCRIPTION
The publish-recipe pipeline ships `<key>.tar.zst`, `<key>.ccache.tar.zst`, and `<key>.manifest.json` per cell, but no consumer ties them together for a dev who wants to edit llvm-project locally and rebuild. setup-recipe pulls only the install, `bin/repro <row>` replays a CI row but doesn't expose the workspace for editing, and an edit-rebuild cycle from a cold ccache takes ~30 minutes.

`bin/repro <cell> --devshell` does that end-to-end. It downloads the install + sibling ccache + manifest, shallow-clones llvm-project at the manifest's `SRC_COMMIT`, and drops the dev into a long-lived `devshell-<cell>` container with the workdir bind-mounted at the recipe's runner workspace path. The cell argument is either a matrix-row name (validated against `act -n --json`) or a direct `recipe/version/os/arch` coord. `scripts/repro-config` handles the in-container provisioning: matching apt deps, libstdc++-N-dev auto-detect (catches the catthehacker libstdc++-13 vs GHA libstdc++-14 drift that produces ~100% ccache miss), the producer's ccache `compiler_check`, cmake replay from `manifest.cmake_args`, and a smoke compile of `Allocator.cpp.o` to surface any remaining cache-reach drift as a warning.

Linux Ubuntu cells only; macOS hosts work via the Linux container at the cost of Rosetta overhead on Apple Silicon. `--devshell-rm` tears the container down (workdir preserved); `--devshell-script PATH` swaps the interactive shell for batch execution. Tests pin the cell-coord resolution (matrix-row lookup, direct shorthand, fail-fast on typo / missing `use-recipe`) and the runner-image mapping. README + developer-guide gain a section each so callers discover the mode and its knobs.