### PR TITLE
[ci] llvm-msan: new recipe and Linux x86_64 cell.

### DIFF
--- a/.github/workflows/publish-recipe.yml
+++ b/.github/workflows/publish-recipe.yml
@@ -27,6 +27,7 @@ on:
         required: true
         options:
           - llvm-asan
+          - llvm-msan
       version:
         type: string
         required: true

--- a/actions/publish-recipe/action.yml
+++ b/actions/publish-recipe/action.yml
@@ -179,6 +179,31 @@ runs:
             --notes "Rolling cache of prebuilt recipe artifacts. Each asset is keyed by sha256 of (recipe.yaml, build.{sh,py}, patches, version, os, arch). See <key>.manifest.json for the inputs that produced any given <key>.tar.zst."
         fi
 
+    # Cross-recipe build-time dependency. Recipes that need a
+    # prebuilt clang to compile (e.g. llvm-msan, where libc++ from
+    # release/{N}.x uses Clang-{N+}-only builtins) declare a
+    # `bootstrap:` block in recipe.yaml; this step downloads the
+    # named cell and exports its bin/ as BOOTSTRAP_CLANG_BIN. Recipes
+    # without a bootstrap block: fetch_bootstrap.py exits silently and
+    # the env var stays empty.
+    - name: Fetch bootstrap compiler if recipe declares one
+      if: steps.skip.outputs.exists != 'true'
+      shell: bash
+      env:
+        OS: ${{ inputs.os }}
+        ARCH: ${{ inputs.arch }}
+        RECIPE: ${{ inputs.recipe }}
+        WORK_DIR: ${{ github.workspace }}/_recipe_work
+      run: |
+        mkdir -p "$WORK_DIR"
+        bin=$(python3 actions/publish-recipe/fetch_bootstrap.py \
+                "recipes/$RECIPE" "$OS" "$ARCH" \
+                "$WORK_DIR/_bootstrap")
+        if [ -n "$bin" ]; then
+          echo "BOOTSTRAP_CLANG_BIN=$bin" >> "$GITHUB_ENV"
+          echo "::notice::bootstrap compiler at $bin"
+        fi
+
     - name: Build recipe
       if: steps.skip.outputs.exists != 'true'
       shell: bash

--- a/actions/publish-recipe/fetch_bootstrap.py
+++ b/actions/publish-recipe/fetch_bootstrap.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Fetch a recipe's bootstrap cell from the cache and print its bin/.
+
+A recipe declares a cross-recipe build-time dependency by adding a
+top-level `bootstrap:` block to its recipe.yaml:
+
+    bootstrap:
+      recipe: llvm-release
+      version: '22'
+
+This script reads that block, computes the bootstrap cell's cache key
+(via setup-recipe/compute_key.py), downloads it via cache_io to a
+known location, and prints the install bin/ on stdout. The publish-
+recipe action exports that path as BOOTSTRAP_CLANG_BIN, which the
+recipe's build.py picks up to drive its compile.
+
+Recipes without a bootstrap block: this script exits 0 silently and
+prints nothing — publish-recipe treats an empty BOOTSTRAP_CLANG_BIN
+as "no bootstrap required" (the asan and release recipes use that).
+
+Args: RECIPE_DIR OS ARCH [DOWNLOAD_DIR]
+
+  RECIPE_DIR     Path to the recipe directory (contains recipe.yaml).
+  OS, ARCH       Target OS/arch slugs for the cache key (must match
+                 what publish-recipe used when warming the bootstrap
+                 cell — same os/arch as the consuming recipe).
+  DOWNLOAD_DIR   Where to extract the bootstrap cell. Defaults to
+                 a sibling of the recipe build dir.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "actions" / "lib"))
+import cache_io  # noqa: E402
+
+
+def _grep_yaml_block_field(yaml_path: Path, block: str,
+                           field: str) -> Optional[str]:
+    """Return `<block>.<field>` value from a YAML file (no parser).
+
+    Tolerates two-space indented field lines under a top-level block
+    that ends with ':'. Same shape as build_manifest.py's
+    _grep_yaml_value, extended to one level of nesting.
+    """
+    try:
+        text = yaml_path.read_text()
+    except OSError:
+        return None
+    in_block = False
+    block_re = re.compile(rf"^\s*{re.escape(block)}\s*:\s*$")
+    field_re = re.compile(rf"^\s+{re.escape(field)}\s*:\s*(.*?)\s*$")
+    top_re = re.compile(r"^[A-Za-z_]+\s*:")
+    for line in text.splitlines():
+        if in_block and top_re.match(line):
+            in_block = False
+        if block_re.match(line):
+            in_block = True
+            continue
+        if in_block:
+            m = field_re.match(line)
+            if m:
+                return m.group(1).strip().strip('"').strip("'")
+    return None
+
+
+def main() -> int:
+    if len(sys.argv) < 4 or len(sys.argv) > 5:
+        print("usage: fetch_bootstrap.py RECIPE_DIR OS ARCH [DOWNLOAD_DIR]",
+              file=sys.stderr)
+        return 2
+
+    recipe_dir = Path(sys.argv[1]).resolve()
+    os_slug, arch = sys.argv[2], sys.argv[3]
+    download_dir = (Path(sys.argv[4]) if len(sys.argv) == 5
+                    else recipe_dir / "_bootstrap").resolve()
+
+    yaml_path = recipe_dir / "recipe.yaml"
+    if not yaml_path.is_file():
+        print(f"fetch_bootstrap: no recipe.yaml at {yaml_path}",
+              file=sys.stderr)
+        return 1
+
+    bootstrap_recipe = _grep_yaml_block_field(yaml_path, "bootstrap", "recipe")
+    bootstrap_version = _grep_yaml_block_field(
+        yaml_path, "bootstrap", "version",
+    )
+    if not bootstrap_recipe and not bootstrap_version:
+        # No bootstrap declared. Silent no-op so the publish-recipe
+        # step can pipe stdout into BOOTSTRAP_CLANG_BIN unconditionally.
+        return 0
+    if not (bootstrap_recipe and bootstrap_version):
+        print(f"fetch_bootstrap: incomplete bootstrap block in {yaml_path}: "
+              f"need both 'recipe' and 'version'", file=sys.stderr)
+        return 1
+
+    # Compute the bootstrap cell's cache key off the local recipes/
+    # tree -- same content-hash setup-recipe uses on consumers.
+    compute_key = (REPO_ROOT / "actions" / "setup-recipe"
+                   / "compute_key.py")
+    result = subprocess.run(
+        ["python3", str(compute_key),
+         bootstrap_recipe, bootstrap_version, os_slug, arch,
+         str(REPO_ROOT / "recipes")],
+        check=True, capture_output=True, text=True,
+    )
+    # compute_key prints "key=<value>"; strip the prefix.
+    key_line = result.stdout.strip()
+    if not key_line.startswith("key="):
+        print(f"fetch_bootstrap: unexpected compute_key output: "
+              f"{key_line!r}", file=sys.stderr)
+        return 1
+    key = key_line[len("key="):]
+
+    base = cache_io.resolve_cache_base(os.environ.get("RECIPE_CACHE_BASE"))
+    if not cache_io.cache_probe(base, key):
+        print(f"fetch_bootstrap: bootstrap cell not in cache: "
+              f"{bootstrap_recipe} {bootstrap_version} {os_slug} {arch} "
+              f"(key={key}). Publish that cell first; the msan recipe "
+              f"depends on it.", file=sys.stderr)
+        return 1
+
+    download_dir.mkdir(parents=True, exist_ok=True)
+    cache_io.cache_download(base, key, str(download_dir))
+
+    # Cells extract as <download_dir>/llvm-project/{bin,lib,include}.
+    bin_dir = download_dir / "llvm-project" / "bin"
+    if not (bin_dir / "clang").is_file():
+        print(f"fetch_bootstrap: bootstrap cell extracted but "
+              f"{bin_dir}/clang is missing; cell layout changed?",
+              file=sys.stderr)
+        return 1
+    print(bin_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/actions/publish-recipe/test_fetch_bootstrap.py
+++ b/actions/publish-recipe/test_fetch_bootstrap.py
@@ -1,0 +1,270 @@
+"""Unit tests for fetch_bootstrap."""
+
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import fetch_bootstrap
+
+
+def _write_recipe_yaml(d: Path, *, with_bootstrap: bool = False,
+                       partial: bool = False) -> Path:
+    """Write a minimal recipe.yaml. with_bootstrap adds a complete
+    block; partial omits one of the two required subkeys.
+    """
+    body = (
+        "recipe: testrec\n"
+        "description: test fixture\n"
+        "source:\n"
+        "  repo: https://example.com/llvm-project\n"
+        "  branch_template: release/{version}.x\n"
+    )
+    if with_bootstrap:
+        body += "bootstrap:\n  recipe: llvm-release\n"
+        if not partial:
+            body += "  version: '22'\n"
+    elif partial:
+        # partial without with_bootstrap: only `version`, no `recipe`.
+        body += "bootstrap:\n  version: '22'\n"
+    yaml_path = d / "recipe.yaml"
+    yaml_path.write_text(body)
+    return yaml_path
+
+
+class GrepYamlBlockFieldTests(unittest.TestCase):
+    """Direct test for the YAML block-field grepper.
+
+    Most positive / negative paths are covered indirectly through
+    MainTests (which proves the grepper's outputs reach compute_key
+    and trigger the correct main() branch). The one path MainTests
+    cannot reach: cross-block scope bleed -- main() only ever queries
+    `bootstrap.recipe` and `bootstrap.version`, which never collide
+    with `source.*` in production. A regression where the grepper
+    returned a `source.repo` value for a `bootstrap.repo` query would
+    pass every integration test silently.
+    """
+
+    def test_block_scope_does_not_leak(self):
+        with tempfile.TemporaryDirectory() as d:
+            y = _write_recipe_yaml(Path(d), with_bootstrap=True)
+            self.assertIsNone(
+                fetch_bootstrap._grep_yaml_block_field(
+                    y, "bootstrap", "repo"),
+            )
+            # Sanity: the same key IS readable inside its own block.
+            self.assertEqual(
+                fetch_bootstrap._grep_yaml_block_field(
+                    y, "source", "repo"),
+                "https://example.com/llvm-project",
+            )
+
+
+class MainTests(unittest.TestCase):
+    """End-to-end tests of main() with cache_io and compute_key mocked.
+
+    cache mocking matters because the real cache_io would try to hit
+    GitHub Releases for an existing cell on every test run, making the
+    tests both slow and network-dependent.
+    """
+
+    def _run_main(self, argv):
+        """Invoke main() with sys.argv overridden, capturing stdout/err."""
+        old_argv, old_stdout, old_stderr = sys.argv, sys.stdout, sys.stderr
+        sys.argv = argv
+        sys.stdout, sys.stderr = io.StringIO(), io.StringIO()
+        try:
+            rc = fetch_bootstrap.main()
+            return rc, sys.stdout.getvalue(), sys.stderr.getvalue()
+        finally:
+            sys.argv, sys.stdout, sys.stderr = (
+                old_argv, old_stdout, old_stderr,
+            )
+
+    def test_no_bootstrap_block_silent_no_op(self):
+        with tempfile.TemporaryDirectory() as d:
+            recipe_dir = Path(d) / "rec"
+            recipe_dir.mkdir()
+            _write_recipe_yaml(recipe_dir)  # no bootstrap
+            rc, out, err = self._run_main(
+                ["fetch_bootstrap.py", str(recipe_dir),
+                 "ubuntu-24.04", "x86_64"],
+            )
+            self.assertEqual(rc, 0)
+            self.assertEqual(out, "")
+            self.assertEqual(err, "")
+
+    def test_partial_bootstrap_block_errors(self):
+        with tempfile.TemporaryDirectory() as d:
+            recipe_dir = Path(d) / "rec"
+            recipe_dir.mkdir()
+            _write_recipe_yaml(recipe_dir, partial=True)  # version only
+            rc, out, err = self._run_main(
+                ["fetch_bootstrap.py", str(recipe_dir),
+                 "ubuntu-24.04", "x86_64"],
+            )
+            self.assertEqual(rc, 1)
+            self.assertIn("incomplete bootstrap block", err)
+
+    def test_missing_recipe_yaml_errors(self):
+        with tempfile.TemporaryDirectory() as d:
+            recipe_dir = Path(d) / "rec"
+            recipe_dir.mkdir()  # no recipe.yaml inside
+            rc, out, err = self._run_main(
+                ["fetch_bootstrap.py", str(recipe_dir),
+                 "ubuntu-24.04", "x86_64"],
+            )
+            self.assertEqual(rc, 1)
+            self.assertIn("no recipe.yaml", err)
+
+    def test_bad_argv_returns_2(self):
+        rc, _, err = self._run_main(["fetch_bootstrap.py", "only-one-arg"])
+        self.assertEqual(rc, 2)
+        self.assertIn("usage:", err)
+
+    @mock.patch("fetch_bootstrap.subprocess.run")
+    @mock.patch("fetch_bootstrap.cache_io.cache_download")
+    @mock.patch("fetch_bootstrap.cache_io.cache_probe")
+    @mock.patch("fetch_bootstrap.cache_io.resolve_cache_base")
+    def test_cache_miss_errors_with_actionable_message(
+        self, mock_resolve, mock_probe, mock_dl, mock_run,
+    ):
+        mock_resolve.return_value = "file:///fake/cache"
+        mock_probe.return_value = False
+        mock_run.return_value = mock.Mock(stdout="key=fake-key\n")
+        with tempfile.TemporaryDirectory() as d:
+            recipe_dir = Path(d) / "rec"
+            recipe_dir.mkdir()
+            _write_recipe_yaml(recipe_dir, with_bootstrap=True)
+            rc, _, err = self._run_main(
+                ["fetch_bootstrap.py", str(recipe_dir),
+                 "ubuntu-24.04", "x86_64"],
+            )
+            self.assertEqual(rc, 1)
+            self.assertIn("not in cache", err)
+            self.assertIn("Publish that cell first", err)
+            mock_dl.assert_not_called()
+
+    @mock.patch("fetch_bootstrap.subprocess.run")
+    @mock.patch("fetch_bootstrap.cache_io.cache_download")
+    @mock.patch("fetch_bootstrap.cache_io.cache_probe")
+    @mock.patch("fetch_bootstrap.cache_io.resolve_cache_base")
+    def test_cache_hit_prints_bin_dir(
+        self, mock_resolve, mock_probe, mock_dl, mock_run,
+    ):
+        mock_resolve.return_value = "file:///fake/cache"
+        mock_probe.return_value = True
+        mock_run.return_value = mock.Mock(stdout="key=fake-key\n")
+
+        with tempfile.TemporaryDirectory() as d:
+            recipe_dir = Path(d) / "rec"
+            recipe_dir.mkdir()
+            _write_recipe_yaml(recipe_dir, with_bootstrap=True)
+            download_dir = Path(d) / "dl"
+
+            # Simulate cache_download materialising the expected layout.
+            def _materialise(base, key, out_dir):
+                bin_dir = Path(out_dir) / "llvm-project" / "bin"
+                bin_dir.mkdir(parents=True)
+                (bin_dir / "clang").write_text("#!/bin/false\n")
+                (bin_dir / "clang").chmod(0o755)
+            mock_dl.side_effect = _materialise
+
+            rc, out, err = self._run_main(
+                ["fetch_bootstrap.py", str(recipe_dir),
+                 "ubuntu-24.04", "x86_64", str(download_dir)],
+            )
+            self.assertEqual(rc, 0, msg=err)
+            # main() resolves the download_dir before printing, so the
+            # expected path needs the same resolution to compare on
+            # macOS where /var symlinks to /private/var.
+            expected_bin = (
+                download_dir.resolve() / "llvm-project" / "bin"
+            )
+            self.assertEqual(out.strip(), str(expected_bin))
+            # Verify compute_key.py was called with the bootstrap
+            # block's recipe/version (not the consuming recipe's name)
+            # — guards against argv reordering regressions.
+            args = mock_run.call_args.args[0]
+            self.assertIn("llvm-release", args)
+            self.assertIn("22", args)
+            self.assertIn("ubuntu-24.04", args)
+            self.assertIn("x86_64", args)
+
+    @mock.patch("fetch_bootstrap.subprocess.run")
+    @mock.patch("fetch_bootstrap.cache_io.cache_download")
+    @mock.patch("fetch_bootstrap.cache_io.cache_probe")
+    @mock.patch("fetch_bootstrap.cache_io.resolve_cache_base")
+    def test_default_download_dir_is_recipe_sibling(
+        self, mock_resolve, mock_probe, mock_dl, mock_run,
+    ):
+        """4-arg form: download lands at <recipe_dir>/_bootstrap.
+
+        This is the path publish-recipe.yml's pre-build step uses by
+        default; covered explicitly so a future refactor of that
+        default does not silently break the workflow.
+        """
+        mock_resolve.return_value = "file:///fake/cache"
+        mock_probe.return_value = True
+        mock_run.return_value = mock.Mock(stdout="key=fake-key\n")
+
+        with tempfile.TemporaryDirectory() as d:
+            recipe_dir = Path(d) / "rec"
+            recipe_dir.mkdir()
+            _write_recipe_yaml(recipe_dir, with_bootstrap=True)
+
+            def _materialise(base, key, out_dir):
+                bin_dir = Path(out_dir) / "llvm-project" / "bin"
+                bin_dir.mkdir(parents=True)
+                (bin_dir / "clang").write_text("#!/bin/false\n")
+                (bin_dir / "clang").chmod(0o755)
+            mock_dl.side_effect = _materialise
+
+            rc, out, err = self._run_main(
+                ["fetch_bootstrap.py", str(recipe_dir),
+                 "ubuntu-24.04", "x86_64"],
+            )
+            self.assertEqual(rc, 0, msg=err)
+            expected_bin = (
+                (recipe_dir / "_bootstrap").resolve()
+                / "llvm-project" / "bin"
+            )
+            self.assertEqual(out.strip(), str(expected_bin))
+
+    @mock.patch("fetch_bootstrap.subprocess.run")
+    @mock.patch("fetch_bootstrap.cache_io.cache_download")
+    @mock.patch("fetch_bootstrap.cache_io.cache_probe")
+    @mock.patch("fetch_bootstrap.cache_io.resolve_cache_base")
+    def test_extracted_cell_missing_clang_errors(
+        self, mock_resolve, mock_probe, mock_dl, mock_run,
+    ):
+        """Cell layout drift: download succeeds but bin/clang absent.
+
+        Pins the post-extract sanity check; the bootstrap clang's
+        path is the contract publish-recipe's BOOTSTRAP_CLANG_BIN
+        export depends on.
+        """
+        mock_resolve.return_value = "file:///fake/cache"
+        mock_probe.return_value = True
+        mock_run.return_value = mock.Mock(stdout="key=fake-key\n")
+        # cache_download "succeeds" but never writes bin/clang.
+        mock_dl.return_value = None
+
+        with tempfile.TemporaryDirectory() as d:
+            recipe_dir = Path(d) / "rec"
+            recipe_dir.mkdir()
+            _write_recipe_yaml(recipe_dir, with_bootstrap=True)
+            rc, _, err = self._run_main(
+                ["fetch_bootstrap.py", str(recipe_dir),
+                 "ubuntu-24.04", "x86_64"],
+            )
+            self.assertEqual(rc, 1)
+            self.assertIn("cell layout changed", err)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cells.yaml
+++ b/cells.yaml
@@ -32,6 +32,10 @@ caps:
 
 cells:
   - { recipe: llvm-asan, version: '22',            os: ubuntu-24.04,    arch: x86_64 }
+  # llvm-msan: Linux only -- macOS toolchain doesn't ship the
+  # MSan-instrumented libc++ stage build cleanly (libcxxabi-on-Mach-O
+  # uses Apple's libunwind), and Windows lacks MSan support upstream.
+  - { recipe: llvm-msan,  version: '22',            os: ubuntu-24.04,    arch: x86_64 }
   # llvm-release: vanilla LLVM/Clang for the latest major across every
   # supported runner image. setup-llvm's default flavor pulls these
   # cells; consumers asking for older majors pick `flavor: system`,

--- a/recipes/llvm-msan/build.py
+++ b/recipes/llvm-msan/build.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Builds an msan-instrumented Clang/LLVM install tree.
+
+Two-stage bootstrap on top of a prebuilt bootstrap clang (the
+llvm-release cell, fetched by publish-recipe.yml's fetch_bootstrap
+step before this script runs and exposed via BOOTSTRAP_CLANG_BIN):
+
+  Stage 1: msan-instrumented libc++/libcxxabi/libunwind from
+           llvm-project/runtimes, compiled with the bootstrap clang.
+  Stage 2: LLVM/Clang/compiler-rt with -fsanitize=memory, compiled
+           with the bootstrap clang and linked against stage 1's
+           libc++.
+
+Why a separate bootstrap clang: building libc++ from llvm-project
+release/{N}.x requires a Clang at least N (libc++ headers use
+builtins like __builtin_ctzg added in Clang 19+), and apt-noble's
+clang-18 is too old to compile libc++ from llvm-22. The published
+llvm-release cell IS the matching clang, so consume it as the
+bootstrap rather than rebuild scaffolding from source.
+
+Why msan needs an instrumented libc++: MSan tracks per-byte
+initialisation propagation. Every write the resulting LLVM later
+reads must be either instrumented or covered by a compiler-rt
+interceptor; an uninstrumented system libc++ / libstdc++ trips
+false positives on the first allocator-fed buffer the resident
+clang reads. libstdc++ is not a supported MSan stdlib upstream;
+the bundled libc++ is the only correct configuration.
+
+Reference: llvm-zorg's buildbot_bootstrap_msan.sh + buildbot_functions.sh
+build_stage2() msan path.
+
+Inputs (env): see actions/lib/llvm_build.py docstring.
+  RECIPE_VERSION         major LLVM version (release/{version}.x).
+  MSAN_FLAVOR            'Memory' (default) or 'MemoryWithOrigins' for
+                         origin tracking. Origins double the runtime
+                         memory cost but report where uninitialised
+                         values came from.
+
+Outputs (env, written to GITHUB_ENV when present):
+  SRC_COMMIT             sha of llvm-project HEAD that was built
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / ".." / ".." / "actions" / "lib"))
+
+import llvm_build  # noqa: E402
+
+
+# Off by default to keep the published cell smaller and the build
+# tractable; flip via env when origin reports are wanted.
+MSAN_FLAVOR = os.environ.get("MSAN_FLAVOR", "Memory")
+
+
+def _oop_targets(build_dir: Path) -> list[str]:
+    """orc_rt_<platform> ninja targets present in `build_dir`.
+
+    Same logic as llvm-asan's build.py — kept duplicated rather than
+    pulled into llvm_build.py because the two recipes still differ in
+    enough other ways that the right shared abstraction isn't obvious
+    yet (see the 'figure out the abstraction' discussion in the PR
+    that introduces this recipe).
+    """
+    out = subprocess.run(
+        ["ninja", "-t", "targets", "all"],
+        cwd=build_dir, check=False, capture_output=True, text=True,
+    ).stdout
+    seen: set[str] = set()
+    for line in out.splitlines():
+        m = re.match(r"^(orc_rt[^:]*):", line)
+        if not m:
+            continue
+        target = m.group(1)
+        # Skip the static-archive aliases ninja prints next to the
+        # cmake target ("orc_rt-x86_64.lib" on Windows, "...a" on
+        # Linux); only the bare target has an install rule.
+        if target.endswith((".lib", ".a")):
+            continue
+        seen.add(target)
+    return sorted(seen)
+
+
+def _build_msan_runtime_into(src_dir: Path, build_dir: Path,
+                             bootstrap_bin: Path, ncpus: str) -> None:
+    """Build compiler-rt's MSan runtime with the bootstrap clang and
+    install it into the bootstrap clang's resource-dir.
+
+    Why: the published llvm-release cell we use as the bootstrap was
+    built with COMPILER_RT_BUILD_SANITIZERS=OFF, so the bootstrap
+    clang has no libclang_rt.msan-x86_64.a in its lib/clang/<N>/lib/
+    tree -- the moment stage 1's cmake compiler-test tries to link a
+    `-fsanitize=memory` program, ld errors with "cannot find
+    libclang_rt.msan.a". Build it ourselves into the same prefix the
+    bootstrap clang installs to, which is the local extracted dir
+    (writes here don't pollute the published cache cell).
+
+    Cheap with ccache enabled: compiler-rt's source is small and the
+    publish-recipe action exports CMAKE_C_COMPILER_LAUNCHER=ccache
+    which cmake honors; warm runs are seconds. Build as a separate
+    step (rather than rolling compiler-rt into stage 2) so the
+    bootstrap clang has the runtime *before* stage 1 needs to link
+    libc++.
+    """
+    # bootstrap_bin is `<extract>/llvm-project/bin`. The bootstrap
+    # clang searches `<extract>/llvm-project/lib/clang/<N>/lib/<triple>/`
+    # for runtime archives, so install directly into the resource-dir
+    # (with PER_TARGET_RUNTIME_DIR on, files land at
+    # `<prefix>/lib/<triple>/libclang_rt.*`). Probe the bootstrap's
+    # existing resource-dir for the right N rather than hardcoding.
+    resource_dirs = sorted(
+        (bootstrap_bin.parent / "lib" / "clang").glob("[0-9]*"),
+        key=lambda p: int(p.name),
+    )
+    if not resource_dirs:
+        print("build.py: bootstrap clang has no lib/clang/<N>/ "
+              "resource-dir; aborting", file=sys.stderr)
+        sys.exit(1)
+    install_prefix = resource_dirs[-1]
+
+    build_dir.mkdir(exist_ok=True)
+    subprocess.run(
+        ["cmake", "-G", "Ninja",
+         "-S", str(src_dir / "runtimes"),
+         "-B", str(build_dir),
+         f"-DCMAKE_INSTALL_PREFIX={install_prefix}",
+         "-DCMAKE_BUILD_TYPE=Release",
+         f"-DCMAKE_C_COMPILER={bootstrap_bin}/clang",
+         f"-DCMAKE_CXX_COMPILER={bootstrap_bin}/clang++",
+         "-DLLVM_ENABLE_RUNTIMES=compiler-rt",
+         # PER_TARGET_RUNTIME_DIR=ON makes runtimes install at
+         # <prefix>/lib/<triple>/ rather than <prefix>/lib/linux/;
+         # paired with prefix=<resource-dir>, files land exactly
+         # where the bootstrap clang searches.
+         "-DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON",
+         "-DCOMPILER_RT_BUILD_BUILTINS=OFF",
+         "-DCOMPILER_RT_BUILD_LIBFUZZER=OFF",
+         "-DCOMPILER_RT_BUILD_PROFILE=OFF",
+         "-DCOMPILER_RT_BUILD_MEMPROF=OFF",
+         "-DCOMPILER_RT_BUILD_SANITIZERS=ON",
+         "-DCOMPILER_RT_BUILD_XRAY=OFF",
+         "-DCOMPILER_RT_BUILD_GWP_ASAN=OFF",
+         "-DCOMPILER_RT_BUILD_CTX_PROFILE=OFF"],
+        check=True,
+    )
+    # `install-compiler-rt` ships the libraries; `install-compiler-rt-
+    # headers` ships sanitizer/{msan,asan,...}_interface.h which
+    # libc++ #includes from libc/src/__support/macros/sanitizer.h
+    # when LLVM_USE_SANITIZER=Memory. Skip the headers and stage 1
+    # libc++ fails halfway through with "msan_interface.h not found".
+    subprocess.run(
+        ["ninja", "-C", str(build_dir), "-j", ncpus,
+         "install-compiler-rt", "install-compiler-rt-headers"],
+        check=True,
+    )
+
+
+def _build_stage1_libcxx(src_dir: Path, build_dir: Path,
+                         install_dir: Path, bootstrap_bin: Path,
+                         fsanitize: str, ncpus: str) -> Path:
+    """Build + install an msan-instrumented libc++/libcxxabi/libunwind.
+
+    Compiled with the bootstrap clang (release-major-matching) so
+    libc++ headers that use new-Clang builtins compile cleanly.
+    Returns the runtime directory containing libc++.so so stage 2 can
+    point its rpath/-L there. Mirrors the cmake invocation in
+    llvm-zorg's build_stage2() libcxx branch (msan flavor).
+    """
+    build_dir.mkdir(exist_ok=True)
+    subprocess.run(
+        ["cmake", "-G", "Ninja",
+         "-S", str(src_dir / "runtimes"),
+         "-B", str(build_dir),
+         f"-DCMAKE_INSTALL_PREFIX={install_dir}",
+         "-DCMAKE_BUILD_TYPE=Release",
+         f"-DCMAKE_C_COMPILER={bootstrap_bin}/clang",
+         f"-DCMAKE_CXX_COMPILER={bootstrap_bin}/clang++",
+         "-DLLVM_ENABLE_RUNTIMES=libcxx;libcxxabi;libunwind",
+         f"-DLLVM_USE_SANITIZER={MSAN_FLAVOR}",
+         f"-DCMAKE_C_FLAGS={fsanitize}",
+         f"-DCMAKE_CXX_FLAGS={fsanitize}",
+         # libcxxabi-uses-llvm-unwinder OFF matches zorg; avoids a
+         # circular runtime-build dependency we don't need here.
+         "-DLIBCXXABI_USE_LLVM_UNWINDER=OFF",
+         "-DLIBCXX_INCLUDE_BENCHMARKS=OFF",
+         "-DLIBCXX_INCLUDE_TESTS=OFF"],
+        check=True,
+    )
+    subprocess.run(
+        ["ninja", "-C", str(build_dir), "-j", ncpus, "install"], check=True,
+    )
+
+    libcxx_so = next(install_dir.rglob("libc++.so*"), None)
+    if libcxx_so is None:
+        print("build.py: stage 1 produced no libc++; aborting",
+              file=sys.stderr)
+        sys.exit(1)
+    return libcxx_so.parent
+
+
+def main() -> int:
+    llvm_build.setup_env()
+    work_dir = Path(os.environ["WORK_DIR"])
+    out_dir = Path(os.environ["OUT_DIR"])
+    version = os.environ["RECIPE_VERSION"]
+    ncpus = os.environ["NCPUS"]
+
+    bootstrap_bin_str = os.environ.get("BOOTSTRAP_CLANG_BIN", "")
+    if not bootstrap_bin_str:
+        print(
+            "build.py: BOOTSTRAP_CLANG_BIN is not set. The msan recipe "
+            "depends on the llvm-release cell as a bootstrap clang -- "
+            "publish-recipe.yml's fetch_bootstrap step is supposed to "
+            "download it and export this env var. If you're running "
+            "build.py outside publish-recipe (manual repro / local "
+            "dev), point BOOTSTRAP_CLANG_BIN at a clang>=N install's "
+            "bin/ directory where N matches RECIPE_VERSION.",
+            file=sys.stderr,
+        )
+        return 1
+    bootstrap_bin = Path(bootstrap_bin_str)
+    if not (bootstrap_bin / "clang").is_file():
+        print(f"build.py: BOOTSTRAP_CLANG_BIN={bootstrap_bin} has no "
+              f"clang binary; aborting", file=sys.stderr)
+        return 1
+
+    src_dir = work_dir / "llvm-project"
+    install_prefix = out_dir / "llvm-project"
+    libcxx_install = work_dir / "libcxx_msan"
+
+    os.chdir(work_dir)
+    llvm_build.clone_shallow(
+        "https://github.com/llvm/llvm-project.git",
+        f"release/{version}.x",
+        src_dir,
+    )
+    src_commit = llvm_build.record_src_commit(src_dir)
+
+    fsanitize = "-fsanitize=memory"
+    if MSAN_FLAVOR == "MemoryWithOrigins":
+        fsanitize += " -fsanitize-memory-track-origins"
+
+    # ----- Stage 0.5: graft libclang_rt.msan into the bootstrap clang -----
+    # The llvm-release cell ships with COMPILER_RT_BUILD_SANITIZERS=OFF,
+    # so the bootstrap clang has no MSan runtime archive. Build it now
+    # using the bootstrap clang itself; ccache makes warm runs cheap.
+    print("build.py: stage 0.5 -- building MSan compiler-rt runtime "
+          "with bootstrap clang", flush=True)
+    _build_msan_runtime_into(
+        src_dir=src_dir,
+        build_dir=src_dir / "build_compiler_rt_bootstrap",
+        bootstrap_bin=bootstrap_bin,
+        ncpus=ncpus,
+    )
+
+    # ----- Stage 1: msan-instrumented libc++ -----
+    print(f"build.py: stage 1 -- building msan-instrumented libc++ "
+          f"with bootstrap clang at {bootstrap_bin} "
+          f"(MSAN_FLAVOR={MSAN_FLAVOR})", flush=True)
+    libcxx_runtime = _build_stage1_libcxx(
+        src_dir=src_dir,
+        build_dir=src_dir / "build_libcxx_msan",
+        install_dir=libcxx_install,
+        bootstrap_bin=bootstrap_bin,
+        fsanitize=fsanitize,
+        ncpus=ncpus,
+    )
+
+    # ----- Stage 2: msan-instrumented LLVM/Clang -----
+    print("build.py: stage 2 -- building msan-instrumented LLVM/Clang",
+          flush=True)
+    build_dir = src_dir / "build"
+    build_dir.mkdir(exist_ok=True)
+    os.chdir(build_dir)
+
+    # libc++ as the resident stdlib: -nostdinc++ wipes the system
+    # libstdc++ headers, -isystem points at stage 1's libc++ headers,
+    # rpath baked at link time so the bundled runtime is found at
+    # install location without LD_LIBRARY_PATH.
+    sanitizer_cflags = (
+        f"-nostdinc++ "
+        f"-isystem {libcxx_install}/include "
+        f"-isystem {libcxx_install}/include/c++/v1 "
+        f"{fsanitize}"
+    )
+    # Two rpath entries: libcxx_runtime so binaries built and run
+    # during stage 2 (e.g. llvm-min-tblgen invoked by tablegen rules)
+    # find libc++.so.1 immediately, install_prefix/lib so they also
+    # find it after the cell is extracted at the install location.
+    # `-L` only affects link-time search; rpath drives runtime lookup.
+    # `-stdlib=libc++` here (link-side only) instead of via
+    # LLVM_ENABLE_LIBCXX=ON, which would add it to CXX_FLAGS and
+    # spam a "-stdlib=libc++ argument unused during compilation"
+    # warning per TU because -nostdinc++ already wipes the auto-
+    # header path.
+    sanitizer_ldflags = (
+        f"-stdlib=libc++ "
+        f"-Wl,-rpath,{libcxx_runtime} "
+        f"-Wl,-rpath,{install_prefix}/lib "
+        f"-L{libcxx_runtime}"
+    )
+
+    cmake_args = (
+        llvm_build.base_cmake_args(str(install_prefix))
+        + [
+            "-DLLVM_ENABLE_PROJECTS=clang;compiler-rt",
+            f"-DLLVM_USE_SANITIZER={MSAN_FLAVOR}",
+            f"-DCMAKE_C_FLAGS={sanitizer_cflags}",
+            f"-DCMAKE_CXX_FLAGS={sanitizer_cflags}",
+            f"-DCMAKE_EXE_LINKER_FLAGS={sanitizer_ldflags}",
+            f"-DCMAKE_SHARED_LINKER_FLAGS={sanitizer_ldflags}",
+            f"-DCMAKE_C_COMPILER={bootstrap_bin}/clang",
+            f"-DCMAKE_CXX_COMPILER={bootstrap_bin}/clang++",
+            # compiler-rt is enabled solely for orc_rt_<platform>;
+            # everything else under compiler-rt stays OFF (matches
+            # llvm-asan).
+            "-DCOMPILER_RT_BUILD_BUILTINS=OFF",
+            "-DCOMPILER_RT_BUILD_LIBFUZZER=OFF",
+            "-DCOMPILER_RT_BUILD_PROFILE=OFF",
+            "-DCOMPILER_RT_BUILD_MEMPROF=OFF",
+            "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",
+            "-DCOMPILER_RT_BUILD_XRAY=OFF",
+            "-DCOMPILER_RT_BUILD_GWP_ASAN=OFF",
+            "-DCOMPILER_RT_BUILD_CTX_PROFILE=OFF",
+        ]
+        + llvm_build.cmake_extra()
+        + ["../llvm"]
+    )
+    llvm_build.record_cmake_args(cmake_args)
+    subprocess.run(cmake_args, check=True)
+    llvm_build.quick_check_or_continue()
+
+    subprocess.run(
+        ["ninja", "-j", ncpus,
+         "clang", "clangInterpreter", "clangStaticAnalyzerCore"],
+        check=True,
+    )
+
+    oop_targets = _oop_targets(build_dir)
+    if oop_targets:
+        subprocess.run(
+            ["ninja", "-j", ncpus, "llvm-jitlink-executor", *oop_targets],
+            check=True,
+        )
+    else:
+        print("build.py: no orc_rt targets matched; "
+              "OOP-JIT runtime won't be in the artifact.",
+              file=sys.stderr)
+
+    llvm_build.cleanup_intermediates()
+    llvm_build.install_distribution(extras=oop_targets)
+
+    src_jitlink = build_dir / "bin" / "llvm-jitlink-executor"
+    if src_jitlink.is_file():
+        dst = install_prefix / "bin" / "llvm-jitlink-executor"
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(src_jitlink, dst)
+        dst.chmod(dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    # Bundle the stage 1 libc++ runtime + headers alongside the LLVM
+    # install so consumers don't have to ship them separately. The
+    # rpath baked into the stage 2 binaries points at $install/lib, so
+    # the resident clang finds the instrumented libc++ at runtime
+    # without LD_LIBRARY_PATH games. Headers go under $install/include/
+    # c++/v1/ so `-stdlib=libc++` against the cell's clang resolves
+    # `<type_traits>` etc. Consumers compiling code against this LLVM
+    # under -fsanitize=memory must pass -fsanitize=memory on every
+    # link line too -- libc++.so.1 is msan-instrumented but does not
+    # carry the msan compiler-rt runtime as DT_NEEDED, so an unadorned
+    # consumer link trips `undefined reference to __msan_*`.
+    print("build.py: bundling msan-instrumented libc++ runtime + "
+          "headers into install tree", flush=True)
+    dst_lib = install_prefix / "lib"
+    dst_lib.mkdir(parents=True, exist_ok=True)
+    for f in libcxx_install.glob("lib/libc++*"):
+        shutil.copy2(f, dst_lib / f.name, follow_symlinks=False)
+    for f in libcxx_install.glob("lib/libunwind*"):
+        shutil.copy2(f, dst_lib / f.name, follow_symlinks=False)
+    src_inc = libcxx_install / "include" / "c++"
+    dst_inc = install_prefix / "include" / "c++"
+    if src_inc.is_dir():
+        if dst_inc.exists():
+            shutil.rmtree(dst_inc)
+        shutil.copytree(src_inc, dst_inc, symlinks=True)
+
+    # Stage 2 was built with COMPILER_RT_BUILD_SANITIZERS=OFF so the
+    # cell as installed lacks libclang_rt.msan-<arch>.a in its
+    # resource-dir; consumers using the cell's clang to link any code
+    # with -fsanitize=memory get "cannot find libclang_rt.msan.a".
+    # Reuse the stage 0.5 helper -- it builds compiler-rt's sanitizer
+    # runtimes and installs them under the bootstrap_bin's resource-
+    # dir, which is exactly what we want here for the published install.
+    # Second invocation is ccache-warm (same source, same flags) and
+    # adds < 1 minute to the cold-build.
+    print("build.py: stage 2.5 -- grafting MSan compiler-rt runtime "
+          "into install tree", flush=True)
+    _build_msan_runtime_into(
+        src_dir=src_dir,
+        build_dir=src_dir / "build_compiler_rt_install",
+        bootstrap_bin=install_prefix / "bin",
+        ncpus=ncpus,
+    )
+
+    llvm_build.smoke()
+
+    print(f"build.py: done. SRC_COMMIT={src_commit}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/recipes/llvm-msan/recipe.yaml
+++ b/recipes/llvm-msan/recipe.yaml
@@ -1,0 +1,63 @@
+recipe: llvm-msan
+description: |
+  LLVM/Clang built with MemorySanitizer (Memory; Origins available
+  via MSAN_FLAVOR=MemoryWithOrigins), against release/{version}.x.
+  Consumed by projects whose test suites run under -fsanitize=memory.
+
+  Bootstrapped from the llvm-release cell to avoid host-clang version
+  drift: building libc++ from llvm-project release/{N}.x requires a
+  Clang at least N (header builtins like __builtin_ctzg landed in
+  Clang 19), and apt-noble's clang-18 is too old. The published
+  llvm-release cell is exactly the matching clang, so consume it
+  via recipe.yaml's `bootstrap` field rather than rebuilding a
+  scaffolding clang here.
+
+  Two-stage bootstrap on top of that: stage 1 builds msan-instrumented
+  libc++/libcxxabi/libunwind from llvm-project/runtimes; stage 2
+  builds clang/compiler-rt with -fsanitize=memory and links against
+  stage 1's libc++. MSan needs every transitive write to memory it
+  later reads to be either instrumented or covered by a compiler-rt
+  interceptor; an uninstrumented system libc++ / libstdc++ trips
+  false positives on the first allocator-fed buffer the resident
+  clang ever reads. Inspired by llvm-zorg's
+  buildbot_bootstrap_msan.sh.
+
+  Consumer link contract -- every link line that pulls in this cell
+  needs all three:
+    -fsanitize=memory                  (mandatory; libc++.so.1 is
+                                        instrumented but does not
+                                        carry libclang_rt.msan as
+                                        DT_NEEDED, so an unadorned
+                                        link errors with `undefined
+                                        reference to __msan_*`)
+    -stdlib=libc++                     (the bundled libc++ is the only
+                                        supported stdlib -- libstdc++
+                                        has no MSan-aware annotations
+                                        and the MSan docs themselves
+                                        recommend libc++)
+    -L$LLVM/lib -Wl,-rpath,$LLVM/lib   (binaries find libc++.so.1 +
+                                        libunwind.so.1 from this cell
+                                        without LD_LIBRARY_PATH games)
+
+  cmake-driven consumers can shorten the above by setting
+  LLVM_USE_SANITIZER=Memory + LLVM_ENABLE_LIBCXX=ON; LLVM's own
+  HandleLLVMOptions.cmake then does the right thing including
+  dropping `-Wl,-z,defs` (which would otherwise reject libc++.so.1's
+  unresolved __msan_init).
+
+# Only fields read by build_manifest.py live here. The cmake invocation
+# and trim list are authoritative in build.py — having them duplicated
+# here as decorative metadata would silently drift. Add a field here
+# only when something else (manifest, dispatcher) actually reads it.
+source:
+  repo: https://github.com/llvm/llvm-project
+  branch_template: release/{version}.x
+
+# Cross-recipe dependency. publish-recipe's fetch_bootstrap step
+# downloads this cell into the build env and exports its bin/ as
+# BOOTSTRAP_CLANG_BIN before invoking build.py. Pin the version here
+# (not derived from RECIPE_VERSION) so the bootstrap clang is always
+# the same major as this msan build.
+bootstrap:
+  recipe: llvm-release
+  version: '22'


### PR DESCRIPTION
Mirror of llvm-asan for MemorySanitizer: a runtime LLVM/Clang install tree that consumers (CppInterOp's prospective msan row, clad's msan row) can build their own code against under -fsanitize=memory. Asan tolerates an uninstrumented stdlib and ships a single-stage build, but msan tracks per-byte initialisation propagation and trips false positives the moment the resident clang reads from a buffer the stdlib allocator wrote to. The MSan docs themselves recommend libc++; libstdc++ has no MSan-aware annotations and rebuilding it under clang routinely fails on inline-asm bits, so it is not a supported configuration here.

Bootstrap chain (inspired by llvm-zorg's buildbot_bootstrap_msan.sh
+ buildbot_functions.sh build_stage2() msan path):
- recipe.yaml's new `bootstrap:` block declares a cross-recipe build-time dependency on llvm-release. publish-recipe's new fetch_bootstrap step downloads the named cell and exports $BOOTSTRAP_CLANG_BIN before invoking build.py. Building libc++ from llvm-project release/{N}.x requires a Clang at least N (header builtins like __builtin_ctzg landed in Clang 19), and apt-noble's clang-18 is too old for llvm-22; the published llvm-release cell is exactly the matching clang.
- Stage 0.5 grafts the MSan compiler-rt runtime into the bootstrap clang's lib/clang/<N>/lib/<triple>/ resource-dir. The published llvm-release cell ships with COMPILER_RT_BUILD_SANITIZERS=OFF (no libclang_rt.msan-x86_64.a), so the bootstrap clang couldn't link `-fsanitize=memory` programs; rebuilding compiler-rt's sanitizer runtimes locally with the bootstrap clang is cheap under ccache and isolates the change to the msan recipe (no republish of llvm-release required). Install prefix points at the bootstrap's resource-dir directly so PER_TARGET_RUNTIME_DIR layout matches the bootstrap clang's default search path; ninja invokes both install-compiler-rt and install-compiler-rt-headers so sanitizer/msan_interface.h ships alongside the archive.
- Stage 1 builds msan-instrumented libc++/libcxxabi/libunwind from llvm-project/runtimes with the bootstrap clang.
- Stage 2 builds LLVM/Clang/compiler-rt with -fsanitize=memory, links against stage 1's libc++, and bundles libc++.so* / libunwind* into $LLVM/lib so consumers don't have to ship the runtime separately. Rpath baked at the install location AND at stage 1's libcxx_install location -- the latter so binaries built and run during stage 2 (e.g. llvm-min-tblgen called by tablegen rules) find libc++.so.1 immediately. -stdlib=libc++ goes in CMAKE_*_LINKER_FLAGS rather than via LLVM_ENABLE_LIBCXX, which would also add it to CXX_FLAGS and emit a "argument unused during compilation" warning per TU because -nostdinc++ already wipes the auto-header path.

Cell is Linux x86_64 only -- macOS toolchain bundles Apple's libunwind which the stage 1 libc++ build does not cleanly retarget, and Windows lacks upstream MSan support. publish-recipe.yml's workflow_dispatch enum gains llvm-msan so the same dispatch UI as llvm-asan can drive the first publish. The `_oop_targets` helper and the COMPILER_RT_BUILD_*=OFF block are duplicated from llvm-asan/build.py rather than pulled into actions/lib/llvm_build.py on purpose: msan's bootstrap pipeline diverges from asan's single-stage shape in enough ways (stage 0.5, libc++ bundling, sanitizer-flag composition) that the right shared abstraction is not yet obvious; collapse once a third sanitizer recipe lands or when the asan/msan divergence stabilises.

Tests cover the new fetch_bootstrap helper end-to-end with cache_io and subprocess mocked: silent no-op when no `bootstrap:` block, error on partial / missing-file / bad-argv, cache-miss error message includes "Publish that cell first", cache-hit prints the resolved bin/ path and forwards the bootstrap recipe/version to compute_key.py (guards argv reordering), default 4-arg form lands at <recipe_dir>/_bootstrap, and post-extract sanity check fires when the cell layout drifts. One direct grepper test pins cross-block scope (`bootstrap.repo` must not match `source.repo`), which the integration tests can't reach because main() never queries that combination in production. Picked up by the existing python-unit-tests verify job which runs `unittest discover -p 'test_*.py'` under actions/publish-recipe/.