### PR TITLE
llvm-wasm: add recipe for wasm32 cross-compiled LLVM/Clang.

### DIFF
--- a/cells.yaml
+++ b/cells.yaml
@@ -36,6 +36,9 @@ cells:
   # MSan-instrumented libc++ stage build cleanly (libcxxabi-on-Mach-O
   # uses Apple's libunwind), and Windows lacks MSan support upstream.
   - { recipe: llvm-msan,  version: '22',            os: ubuntu-24.04,    arch: x86_64 }
+  # llvm-wasm: Linux x86_64 first; macOS / Windows added once the
+  # recipe's bash-via-subprocess emsdk activation is validated there.
+  - { recipe: llvm-wasm,  version: '22',            os: ubuntu-24.04,    arch: x86_64 }
   # llvm-release: vanilla LLVM/Clang for the latest major across every
   # supported runner image. setup-llvm's default flavor pulls these
   # cells; consumers asking for older majors pick `flavor: system`,

--- a/recipes/llvm-wasm/build.py
+++ b/recipes/llvm-wasm/build.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Builds an LLVM/Clang install tree cross-compiled for wasm32 via emsdk.
+
+Recipe-specific bits live here (emsdk install/activate, source clone,
+patch application, native-tblgen bootstrap, emcmake/emmake, source-tree
+trim). The shared install-tree publish flow's helpers (env validation,
+SRC_COMMIT recording) come from actions/lib/llvm_build.py; the wasm
+artifact is the trimmed source+build tree, not a cmake --install tree,
+so the LLVM_DISTRIBUTION_COMPONENTS / smoke() path doesn't apply.
+
+Inputs (env): see actions/lib/llvm_build.py docstring.
+  RECIPE_VERSION         major LLVM version (release/{version}.x).
+  EMSDK_VERSION          emsdk tag to install/activate. Defaulted from
+                         recipe.yaml's `emsdk_version`.
+
+Outputs (env, written to GITHUB_ENV when present):
+  SRC_COMMIT             sha of llvm-project HEAD that was built
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / ".." / ".." / "actions" / "lib"))
+
+import llvm_build  # noqa: E402
+
+
+# Wasm cmake flags. List form is what record_cmake_args expects.
+COMMON_FLAGS: list[str] = [
+    "-G", "Ninja",
+    "-DCMAKE_BUILD_TYPE=Release",
+    "-DLLVM_HOST_TRIPLE=wasm32-unknown-emscripten",
+    "-DLLVM_TARGETS_TO_BUILD=WebAssembly",
+    "-DLLVM_ENABLE_PROJECTS=clang;lld",
+    "-DLLVM_ENABLE_LIBEDIT=OFF",
+    "-DLLVM_ENABLE_ZSTD=OFF",
+    "-DLLVM_ENABLE_LIBXML2=OFF",
+    "-DLLVM_ENABLE_LIBPFM=OFF",
+    "-DLLVM_ENABLE_THREADS=OFF",
+    "-DLLVM_INCLUDE_BENCHMARKS=OFF",
+    "-DLLVM_INCLUDE_EXAMPLES=OFF",
+    "-DLLVM_INCLUDE_TESTS=OFF",
+    "-DLLVM_BUILD_TOOLS=OFF",
+    "-DCLANG_BUILD_TOOLS=OFF",
+    "-DCLANG_ENABLE_STATIC_ANALYZER=OFF",
+    "-DCLANG_ENABLE_ARCMT=OFF",
+    "-DCLANG_ENABLE_BOOTSTRAP=OFF",
+    # emscripten libc lacks wait4; redirect to the syscall wrapper.
+    "-DCMAKE_CXX_FLAGS=-Dwait4=__syscall_wait4",
+    "-DCMAKE_C_FLAGS_RELEASE=-Oz -g0 -DNDEBUG",
+    "-DCMAKE_CXX_FLAGS_RELEASE=-Oz -g0 -DNDEBUG",
+    "-DLLVM_ENABLE_LTO=Full",
+]
+
+# Targets to build for the wasm cell. Matches CppInterOp's
+# Build_LLVM_WASM non-cling path. cling rows (clang/cling/lld/
+# gtest_main) are not built today; see recipe.yaml.
+WASM_TARGETS: list[str] = ["libclang", "clangInterpreter", "clangStaticAnalyzerCore"]
+
+
+def install_emsdk(work_dir: Path, version: str) -> Path:
+    """Clone emsdk into work_dir, install + activate the requested version.
+
+    Returns the emsdk install root. Idempotent on a re-run with cache.
+    """
+    emsdk_dir = work_dir / "emsdk"
+    if not emsdk_dir.exists():
+        subprocess.run(
+            ["git", "clone", "--depth=1",
+             "https://github.com/emscripten-core/emsdk.git", str(emsdk_dir)],
+            check=True,
+        )
+    # `emsdk install` / `activate` are idempotent and quick on a hit.
+    emsdk = str(emsdk_dir / "emsdk")
+    subprocess.run([emsdk, "install", version], check=True, cwd=emsdk_dir)
+    subprocess.run([emsdk, "activate", version], check=True, cwd=emsdk_dir)
+    return emsdk_dir
+
+
+def apply_patches(repo: Path, version: str) -> None:
+    """Apply patches/emscripten-clang{version}-*.patch in lexical order.
+
+    No-op when the major has no matching patches (LLVM 19 today). Skip
+    is a notice, not an error -- adding a new major without patches is
+    a valid state.
+    """
+    pattern = str(SCRIPT_DIR / "patches" / f"emscripten-clang{version}-*.patch")
+    patches = sorted(glob.glob(pattern))
+    if not patches:
+        print(f"build.py: no patches matched {pattern}; "
+              "proceeding without -- valid if the major needs none.",
+              file=sys.stderr)
+        return
+    for patch in patches:
+        subprocess.run(["git", "apply", "-v", patch], check=True, cwd=repo)
+
+
+def run_in_emsdk(cmd: list[str], emsdk_dir: Path, cwd: Path) -> None:
+    """Run `cmd` (a shell-friendly list) under a shell that has sourced
+    emsdk_env.sh. emcmake / emmake rely on EMSDK / PATH set by that
+    script; subprocess starts a fresh shell each call, so source-then-run
+    via bash -c is the simplest cross-cell idiom on Linux/macOS.
+
+    shlex.quote every arg: cmake values like LLVM_ENABLE_PROJECTS=clang;lld
+    contain shell metacharacters and bash would otherwise split them.
+    """
+    env_sh = shlex.quote(str(emsdk_dir / "emsdk_env.sh"))
+    joined = " ".join(shlex.quote(c) for c in cmd)
+    subprocess.run(
+        ["bash", "-c", f"source {env_sh} && {joined}"],
+        check=True, cwd=cwd,
+    )
+
+
+def trim_source_tree(repo: Path) -> None:
+    """Drop everything from llvm-project/ except build/ + native_build/
+    + the trimmed llvm/ and clang/ subtrees (include + cmake only).
+
+    Source-tree `lib/` dirs hold .cpp that's already linked into
+    build/lib/*.a; nothing on the consumer include path references them.
+    """
+    keep_top = {"build", "llvm", "clang", "native_build"}
+    for entry in repo.iterdir():
+        if entry.name in keep_top:
+            continue
+        if entry.is_dir():
+            shutil.rmtree(entry, ignore_errors=True)
+        else:
+            entry.unlink(missing_ok=True)
+    keep_sub = {"include", "cmake"}
+    for d in ("llvm", "clang"):
+        sub = repo / d
+        if not sub.is_dir():
+            continue
+        for entry in sub.iterdir():
+            if entry.name in keep_sub:
+                continue
+            if entry.is_dir():
+                shutil.rmtree(entry, ignore_errors=True)
+            else:
+                entry.unlink(missing_ok=True)
+
+
+def main() -> int:
+    llvm_build.setup_env()
+    work_dir = Path(os.environ["WORK_DIR"])
+    out_dir = Path(os.environ["OUT_DIR"])
+    version = os.environ["RECIPE_VERSION"]
+    ncpus = os.environ["NCPUS"]
+    # Default mirrors recipe.yaml's emsdk_version; publish-recipe could
+    # also set it from a cell-level override later if needed.
+    emsdk_version = os.environ.get("EMSDK_VERSION", "4.0.9")
+
+    os.chdir(work_dir)
+    emsdk_dir = install_emsdk(work_dir, emsdk_version)
+
+    llvm_build.clone_shallow(
+        "https://github.com/llvm/llvm-project.git",
+        f"release/{version}.x",
+        work_dir / "llvm-project",
+    )
+    src_commit = llvm_build.record_src_commit(work_dir / "llvm-project")
+
+    repo = work_dir / "llvm-project"
+    apply_patches(repo, version)
+
+    # Native tblgen bootstrap. emcmake's wasm clang can't build host
+    # binaries; LLVM_NATIVE_TOOL_DIR points at this directory.
+    native_build = repo / "native_build"
+    native_build.mkdir(exist_ok=True)
+    subprocess.run(
+        ["cmake",
+         "-DLLVM_ENABLE_PROJECTS=clang",
+         "-DLLVM_TARGETS_TO_BUILD=host",
+         "-DCMAKE_BUILD_TYPE=Release",
+         "-G", "Ninja",
+         "../llvm"],
+        check=True, cwd=native_build,
+    )
+    subprocess.run(
+        ["cmake", "--build", ".",
+         "--target", "llvm-tblgen", "clang-tblgen",
+         "--parallel", ncpus],
+        check=True, cwd=native_build,
+    )
+
+    build = repo / "build"
+    build.mkdir(exist_ok=True)
+    cmake_args = list(COMMON_FLAGS) + [
+        f"-DLLVM_NATIVE_TOOL_DIR={native_build / 'bin'}",
+        "../llvm",
+    ]
+    llvm_build.record_cmake_args(["emcmake", "cmake", *cmake_args])
+    run_in_emsdk(["emcmake", "cmake", *cmake_args], emsdk_dir, build)
+
+    # Smoke-test hook: emmake the demangle library only and exit. emcmake
+    # configure is the wasm-side regression surface (toolchain file, patch
+    # apply); running just one wasm target keeps the dry-run minutes
+    # instead of hours.
+    if os.environ.get("RECIPE_QUICK_CHECK") == "1":
+        run_in_emsdk(
+            ["emmake", "ninja", "-j", ncpus, "LLVMDemangle"],
+            emsdk_dir, build,
+        )
+        print("build.py: RECIPE_QUICK_CHECK=1 -> built LLVMDemangle, exiting.",
+              flush=True)
+        return 0
+
+    # EMCC_CFLAGS=-fwasm-exceptions: wasm exception ABI for the targets
+    # CppInterOp links against. Build_LLVM_WASM passes this same flag.
+    env_sh = shlex.quote(str(emsdk_dir / "emsdk_env.sh"))
+    targets = " ".join(shlex.quote(t) for t in WASM_TARGETS)
+    subprocess.run(
+        ["bash", "-c",
+         f"source {env_sh} && "
+         f"EMCC_CFLAGS=-fwasm-exceptions "
+         f"emmake ninja -j {shlex.quote(ncpus)} {targets}"],
+        check=True, cwd=build,
+    )
+
+    trim_source_tree(repo)
+
+    # Move the trimmed tree to OUT_DIR/llvm-project for the publish step.
+    dst = out_dir / "llvm-project"
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.move(str(repo), str(dst))
+
+    print(f"build.py: done. SRC_COMMIT={src_commit}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/recipes/llvm-wasm/patches/emscripten-clang22-1-enable_exception_handling.patch
+++ b/recipes/llvm-wasm/patches/emscripten-clang22-1-enable_exception_handling.patch
@@ -1,0 +1,91 @@
+diff --git a/clang/include/clang/Frontend/CompilerInstance.h b/clang/include/clang/Frontend/CompilerInstance.h
+index f56da69a05caf..f5dfc36953308 100644
+--- a/clang/include/clang/Frontend/CompilerInstance.h
++++ b/clang/include/clang/Frontend/CompilerInstance.h
+@@ -246,6 +246,11 @@ class CompilerInstance : public ModuleLoader {
+   /// Load the list of plugins requested in the \c FrontendOptions.
+   void LoadRequestedPlugins();
+ 
++  /// Parse and apply LLVM command line arguments from FrontendOptions.
++  /// This processes the LLVMArgs option that comes from -mllvm flags.
++  /// This should be called after plugins are loaded and before ExecuteAction.
++  void parseLLVMArgs();
++
+   /// @}
+   /// @name Compiler Invocation and Options
+   /// @{
+diff --git a/clang/lib/Frontend/CompilerInstance.cpp b/clang/lib/Frontend/CompilerInstance.cpp
+index 2cd7888b0d192..a1ea9486ac406 100644
+--- a/clang/lib/Frontend/CompilerInstance.cpp
++++ b/clang/lib/Frontend/CompilerInstance.cpp
+@@ -1102,6 +1102,20 @@ void CompilerInstance::LoadRequestedPlugins() {
+   }
+ }
+ 
++void CompilerInstance::parseLLVMArgs() {
++  if (!getFrontendOpts().LLVMArgs.empty()) {
++    unsigned NumArgs = getFrontendOpts().LLVMArgs.size();
++    auto Args = std::make_unique<const char *[]>(NumArgs + 2);
++    Args[0] = "clang (LLVM option parsing)";
++    for (unsigned i = 0; i != NumArgs; ++i)
++      Args[i + 1] = getFrontendOpts().LLVMArgs[i].c_str();
++    Args[NumArgs + 1] = nullptr;
++    llvm::cl::ParseCommandLineOptions(NumArgs + 1, Args.get(), /*Overview=*/"",
++                                      /*Errs=*/nullptr,
++                                      /*VFS=*/&getVirtualFileSystem());
++  }
++}
++
+ /// Determine the appropriate source input kind based on language
+ /// options.
+ static Language getLanguageFromOptions(const LangOptions &LangOpts) {
+diff --git a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+index 05f646b43e3c4..9fa6fbb0017e1 100644
+--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
++++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+@@ -237,17 +237,7 @@ bool ExecuteCompilerInvocation(CompilerInstance *Clang) {
+   //
+   // FIXME: Remove this, one day.
+   // This should happen AFTER plugins have been loaded!
+-  if (!Clang->getFrontendOpts().LLVMArgs.empty()) {
+-    unsigned NumArgs = Clang->getFrontendOpts().LLVMArgs.size();
+-    auto Args = std::make_unique<const char*[]>(NumArgs + 2);
+-    Args[0] = "clang (LLVM option parsing)";
+-    for (unsigned i = 0; i != NumArgs; ++i)
+-      Args[i + 1] = Clang->getFrontendOpts().LLVMArgs[i].c_str();
+-    Args[NumArgs + 1] = nullptr;
+-    llvm::cl::ParseCommandLineOptions(NumArgs + 1, Args.get(), /*Overview=*/"",
+-                                      /*Errs=*/nullptr,
+-                                      /*VFS=*/&Clang->getVirtualFileSystem());
+-  }
++  Clang->parseLLVMArgs();
+ 
+ #if CLANG_ENABLE_STATIC_ANALYZER
+   // These should happen AFTER plugins have been loaded!
+diff --git a/clang/lib/Interpreter/Interpreter.cpp b/clang/lib/Interpreter/Interpreter.cpp
+index 9c94cfa5ee381..bfb6c2a0505d1 100644
+--- a/clang/lib/Interpreter/Interpreter.cpp
++++ b/clang/lib/Interpreter/Interpreter.cpp
+@@ -257,6 +257,9 @@ Interpreter::Interpreter(std::unique_ptr<CompilerInstance> Instance,
+   auto LLVMCtx = std::make_unique<llvm::LLVMContext>();
+   TSCtx = std::make_unique<llvm::orc::ThreadSafeContext>(std::move(LLVMCtx));
+ 
++  // Honor -mllvm options
++  CI->parseLLVMArgs();
++
+   Act = TSCtx->withContextDo([&](llvm::LLVMContext *Ctx) {
+     return std::make_unique<IncrementalAction>(*CI, *Ctx, ErrOut, *this,
+                                                std::move(Consumer));
+@@ -465,6 +468,12 @@ Interpreter::Parse(llvm::StringRef Code) {
+       return std::move(Err);
+   }
+ 
++  // Re-apply stored -mllvm options; wasm builds reset LLVM opts in wasm-ld.
++  llvm::Triple Triple(getCompilerInstance()->getTargetOpts().Triple);
++  if (Triple.isWasm()) {
++    getCompilerInstance()->parseLLVMArgs();
++  }
++
+   // Tell the interpreter sliently ignore unused expressions since value
+   // printing could cause it.
+   getCompilerInstance()->getDiagnostics().setSeverity(

--- a/recipes/llvm-wasm/patches/emscripten-clang22-2-webassembly_target_machine_reordering.patch
+++ b/recipes/llvm-wasm/patches/emscripten-clang22-2-webassembly_target_machine_reordering.patch
@@ -1,0 +1,14 @@
+diff --git a/llvm/lib/Target/WebAssembly/WebAssemblyTargetMachine.cpp b/llvm/lib/Target/WebAssembly/WebAssemblyTargetMachine.cpp
+index 6827ee652794..3ad7ec5d32b6 100644
+--- a/llvm/lib/Target/WebAssembly/WebAssemblyTargetMachine.cpp
++++ b/llvm/lib/Target/WebAssembly/WebAssemblyTargetMachine.cpp
+@@ -227,8 +227,8 @@ WebAssemblyTargetMachine::WebAssemblyTargetMachine(
+   this->Options.DataSections = true;
+   this->Options.UniqueSectionNames = true;
+ 
+-  initAsmInfo();
+   basicCheckForEHAndSjLj(this);
++  initAsmInfo();
+   // Note that we don't use setRequiresStructuredCFG(true). It disables
+   // optimizations than we're ok with, and want, such as critical edge
+   // splitting and tail merging.

--- a/recipes/llvm-wasm/recipe.yaml
+++ b/recipes/llvm-wasm/recipe.yaml
@@ -1,0 +1,32 @@
+recipe: llvm-wasm
+description: |
+  LLVM/Clang cross-compiled for wasm32-unknown-emscripten via emsdk,
+  against release/{version}.x. Consumed today by CppInterOp's
+  emscripten matrix.
+
+  Two stages: (1) host llvm-tblgen + clang-tblgen under
+  llvm-project/native_build/ -- the wasm clang cannot build host
+  binaries, LLVM_NATIVE_TOOL_DIR points at this; (2) emcmake/emmake
+  cross-build under llvm-project/build/. Source-tree layout is
+  preserved (not a cmake install): consumers point at
+  build/lib/cmake/ for find_package and at {llvm,clang}/include for
+  headers; LLVM_DISTRIBUTION_COMPONENTS does not apply across the
+  host/wasm boundary.
+
+  Per-LLVM-major patches under patches/ apply by file glob
+  (`emscripten-clang{N}-*.patch`); adding a new major needs no
+  build.py change. Cling+wasm cells are not built today -- a follow-up
+  gates the cling clone + LookupHelper patch + wider target list on a
+  cell-level field.
+
+  Consumer cmake contract:
+    -DLLVM_DIR=$LLVM/llvm-project/build/lib/cmake/llvm
+    -DClang_DIR=$LLVM/llvm-project/build/lib/cmake/clang
+    -DCMAKE_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake
+    -DLLVM_NATIVE_TOOL_DIR=$LLVM/llvm-project/native_build/bin
+
+# Only fields read by build_manifest.py live here. The cmake invocation,
+# patch glob, and emsdk version pin are authoritative in build.py.
+source:
+  repo: https://github.com/llvm/llvm-project
+  branch_template: release/{version}.x


### PR DESCRIPTION
New cell builds llvm-project release/{version}.x for wasm32-unknown-emscripten via emsdk. Today CppInterOp's emscripten matrix caches the wasm tree per-fork via actions/cache@v4; moving it into the release-asset cache that already backs llvm-asan and llvm-msan gets a single warm build shared across every consumer and durable across forks.

Two stages: (1) host llvm-tblgen + clang-tblgen under llvm-project/native_build/ -- the wasm clang cannot build host binaries, LLVM_NATIVE_TOOL_DIR points at this; (2) emcmake/emmake cross-build under llvm-project/build/. Per-LLVM-major emscripten patches ship under patches/ and apply by file glob (`emscripten-clang{N}-*.patch`); adding a new major needs no build.py change. The artifact is the trimmed source+build tree; LLVM_DISTRIBUTION_COMPONENTS and llvm_build::smoke don't apply across the host/wasm boundary.

Initial cell is Linux x86_64; macOS / Windows added once bash-via-subprocess emsdk activation is validated there. Cling+wasm cells are a follow-up. RECIPE_QUICK_CHECK=1 builds LLVMDemangle and exits, matching the smoke idiom in llvm-asan / llvm-msan.