### PR TITLE
publish-recipe: save ccache on failure and cancellation.

### DIFF
--- a/actions/publish-recipe/action.yml
+++ b/actions/publish-recipe/action.yml
@@ -254,8 +254,14 @@ runs:
     # x os x arch x recipe-content), so a PR that touches recipe.yaml /
     # build.{sh,py} / patches / actions/lib gets its own entry; a PR
     # that doesn't simply hits main's. No timestamp-suffixed pile-up.
+    #
+    # always(): a mid-build failure or job cancellation still persists
+    # whatever ccache had written, so the next attempt isn't a cold
+    # rebuild. ccache writes are rename-into-cache and atomic, so the
+    # partial cache is safe to reuse. Runner-death (OOM, network drop)
+    # is still lost; the post-step doesn't run there.
     - name: Save ccache
-      if: steps.skip.outputs.exists != 'true' && steps.ccache.outputs.cache-hit != 'true'
+      if: always() && steps.skip.outputs.exists != 'true' && steps.ccache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: ${{ github.workspace }}/.ccache


### PR DESCRIPTION
The Save-ccache step's `if:` lacked `always()`, so it inherited the default `success()` gate. A Build-recipe failure or job cancellation short-circuits every later step, discarding all compile work routed through ccache up to that point. The wasm recipe just hit this: 333/333 host tblgen objects built and ccache-stored, then the wasm cmake configure failed for an unrelated reason, and the partial cache evaporated.

Add `always()` while keeping the two existing guards (skip-when-already-published, skip-when-exact-cache-hit) so the save still no-ops where it has nothing useful to add. ccache writes are rename-into-cache and atomic, so a partial cache is safe to reuse. Runner-death (OOM, network drop) is still lost; the post-step doesn't run there.