### PR TITLE
cache_io: rename install-tree convention from `llvm-project` to `install`.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -235,7 +235,7 @@ jobs:
           mkdir extract
           python3 actions/lib/cache_io.py download \
             "file://$RUNNER_TEMP/dryrun_cache" "$key" extract
-          test -f extract/llvm-project/lib/cmake/llvm/LLVMConfig.cmake
+          test -f extract/install/lib/cmake/llvm/LLVMConfig.cmake
           echo "::notice::publish-dryrun OK on ${{ matrix.os }}"
 
   # setup-llvm flavor=system smoke. Exercises the apt-llvm.org path

--- a/actions/lib/cache_io.py
+++ b/actions/lib/cache_io.py
@@ -73,7 +73,7 @@ def cache_probe(base: str, key: str) -> bool:
 def cache_download(base: str, key: str, out_dir: str) -> None:
     """Fetch the asset for `key` and extract into `out_dir`.
 
-    The recipe's tarball root (e.g. ``llvm-project/``) lands directly
+    The recipe's tarball root (e.g. ``install/``) lands directly
     under `out_dir`.
     """
     base = _strip_trailing_slash(base)
@@ -157,11 +157,11 @@ def cache_upload(base: str, key: str, asset: str,
 
 
 def cache_pack(in_dir: str, key: str, out_dir: Optional[str] = None,
-               *, src_name: str = "llvm-project",
+               *, src_name: str = "install",
                key_suffix: str = "") -> None:
     """Tar+zstd ``in_dir/<src_name>`` to ``out_dir/<key><key_suffix>.tar.zst``.
 
-    Defaults match the install tree (src_name="llvm-project",
+    Defaults match the install tree (src_name="install",
     key_suffix=""). For a sibling ccache snapshot pass src_name=".ccache",
     key_suffix=".ccache".
 

--- a/actions/lib/llvm_build.py
+++ b/actions/lib/llvm_build.py
@@ -11,7 +11,7 @@ in the recipe's own build.py.
 Required env (every recipe; setup_env asserts these):
   RECIPE_VERSION   recipe-defined version/flavor selector
   WORK_DIR         scratch directory; clone + build live here
-  OUT_DIR          install prefix is "$OUT_DIR/llvm-project"; the
+  OUT_DIR          install prefix is "$OUT_DIR/install"; the
                    install lands directly there for tar/upload.
 
 Optional env:
@@ -265,7 +265,7 @@ def smoke(required_files: Optional[Sequence[str]] = None,
     exist (e.g. "lib/libclingInterpreter.a" — cling has no Config.cmake).
     """
     out_dir = os.environ["OUT_DIR"]
-    prefix = Path(out_dir) / "llvm-project"
+    prefix = Path(out_dir) / "install"
     pkg_calls = "\n".join(
         f'find_package({p} REQUIRED CONFIG PATHS "${{SMOKE_LLVM_PREFIX}}/lib/cmake/{p.lower()}" NO_DEFAULT_PATH)'
         for p in packages

--- a/actions/lib/test_cache_io.py
+++ b/actions/lib/test_cache_io.py
@@ -100,10 +100,10 @@ def _have_zstd() -> bool:
 @unittest.skipUnless(_have_zstd(), "zstd not available")
 class CachePackRoundTripTests(unittest.TestCase):
     def _make_install_tree(self, root: Path) -> None:
-        (root / "llvm-project" / "lib").mkdir(parents=True)
-        (root / "llvm-project" / "lib" / "libfoo.a").write_bytes(b"binary")
-        (root / "llvm-project" / "include").mkdir()
-        (root / "llvm-project" / "include" / "foo.h").write_text("hdr\n")
+        (root / "install" / "lib").mkdir(parents=True)
+        (root / "install" / "lib" / "libfoo.a").write_bytes(b"binary")
+        (root / "install" / "include").mkdir()
+        (root / "install" / "include" / "foo.h").write_text("hdr\n")
 
     def test_pack_extract_diff(self):
         with tempfile.TemporaryDirectory() as d:
@@ -124,11 +124,11 @@ class CachePackRoundTripTests(unittest.TestCase):
             cache_io.cache_download(f"file://{out_dir}", "k", str(extract))
 
             self.assertEqual(
-                (extract / "llvm-project" / "include" / "foo.h").read_text(),
+                (extract / "install" / "include" / "foo.h").read_text(),
                 "hdr\n",
             )
             self.assertEqual(
-                (extract / "llvm-project" / "lib" / "libfoo.a").read_bytes(),
+                (extract / "install" / "lib" / "libfoo.a").read_bytes(),
                 b"binary",
             )
 

--- a/actions/publish-recipe/fetch_bootstrap.py
+++ b/actions/publish-recipe/fetch_bootstrap.py
@@ -132,8 +132,8 @@ def main() -> int:
     download_dir.mkdir(parents=True, exist_ok=True)
     cache_io.cache_download(base, key, str(download_dir))
 
-    # Cells extract as <download_dir>/llvm-project/{bin,lib,include}.
-    bin_dir = download_dir / "llvm-project" / "bin"
+    # Cells extract as <download_dir>/install/{bin,lib,include}.
+    bin_dir = download_dir / "install" / "bin"
     if not (bin_dir / "clang").is_file():
         print(f"fetch_bootstrap: bootstrap cell extracted but "
               f"{bin_dir}/clang is missing; cell layout changed?",

--- a/actions/publish-recipe/test_fetch_bootstrap.py
+++ b/actions/publish-recipe/test_fetch_bootstrap.py
@@ -168,7 +168,7 @@ class MainTests(unittest.TestCase):
 
             # Simulate cache_download materialising the expected layout.
             def _materialise(base, key, out_dir):
-                bin_dir = Path(out_dir) / "llvm-project" / "bin"
+                bin_dir = Path(out_dir) / "install" / "bin"
                 bin_dir.mkdir(parents=True)
                 (bin_dir / "clang").write_text("#!/bin/false\n")
                 (bin_dir / "clang").chmod(0o755)
@@ -183,7 +183,7 @@ class MainTests(unittest.TestCase):
             # expected path needs the same resolution to compare on
             # macOS where /var symlinks to /private/var.
             expected_bin = (
-                download_dir.resolve() / "llvm-project" / "bin"
+                download_dir.resolve() / "install" / "bin"
             )
             self.assertEqual(out.strip(), str(expected_bin))
             # Verify compute_key.py was called with the bootstrap
@@ -218,7 +218,7 @@ class MainTests(unittest.TestCase):
             _write_recipe_yaml(recipe_dir, with_bootstrap=True)
 
             def _materialise(base, key, out_dir):
-                bin_dir = Path(out_dir) / "llvm-project" / "bin"
+                bin_dir = Path(out_dir) / "install" / "bin"
                 bin_dir.mkdir(parents=True)
                 (bin_dir / "clang").write_text("#!/bin/false\n")
                 (bin_dir / "clang").chmod(0o755)
@@ -231,7 +231,7 @@ class MainTests(unittest.TestCase):
             self.assertEqual(rc, 0, msg=err)
             expected_bin = (
                 (recipe_dir / "_bootstrap").resolve()
-                / "llvm-project" / "bin"
+                / "install" / "bin"
             )
             self.assertEqual(out.strip(), str(expected_bin))
 

--- a/actions/setup-llvm/action.yml
+++ b/actions/setup-llvm/action.yml
@@ -23,7 +23,7 @@ description: |
 
     'cling'   Recipe `llvm-root` plus a cling-on-top build.
 
-  All paths land at $GITHUB_WORKSPACE/llvm-project. The `source`
+  All paths land at $GITHUB_WORKSPACE/install. The `source`
   output reports which path won.
 
   If the install ships <install>/etc/cmake-toolchain.cmake, this
@@ -102,7 +102,7 @@ outputs:
     description: '"recipe-cache" | "inline-build" | "package-manager"'
     value: ${{ steps.finalize.outputs.source }}
   prefix:
-    description: 'Install prefix (always $GITHUB_WORKSPACE/llvm-project).'
+    description: 'Install prefix (always $GITHUB_WORKSPACE/install).'
     value: ${{ steps.finalize.outputs.prefix }}
 
 runs:
@@ -216,8 +216,8 @@ runs:
         # invokes setup-llvm twice) leave a real directory or stale
         # symlink at this path, and `ln -s` over a non-symlink
         # directory fails on both GNU and BSD ln.
-        rm -rf "${GITHUB_WORKSPACE}/llvm-project"
-        ln -s "/usr/lib/llvm-${VERSION}" "${GITHUB_WORKSPACE}/llvm-project"
+        rm -rf "${GITHUB_WORKSPACE}/install"
+        ln -s "/usr/lib/llvm-${VERSION}" "${GITHUB_WORKSPACE}/install"
         echo "::notice::flavor=system: apt-llvm.org llvm-${VERSION} on ${codename}"
 
     - name: System install (Homebrew)
@@ -236,8 +236,8 @@ runs:
         # brew's llvm@N formula bundles compiler-rt as part of the
         # install, so no separate runtime probe needed (unlike
         # apt-llvm.org's split libclang-rt-N-dev package).
-        rm -rf "${GITHUB_WORKSPACE}/llvm-project"
-        ln -s "${prefix}" "${GITHUB_WORKSPACE}/llvm-project"
+        rm -rf "${GITHUB_WORKSPACE}/install"
+        ln -s "${prefix}" "${GITHUB_WORKSPACE}/install"
         echo "::notice::flavor=system: brew llvm@${VERSION} at ${prefix}"
 
     # Recipe path (everything except flavor=system): delegate to
@@ -282,7 +282,7 @@ runs:
         else
           ncpus=$(nproc)
         fi
-        LLVM_PREFIX="${GITHUB_WORKSPACE}/llvm-project"
+        LLVM_PREFIX="${GITHUB_WORKSPACE}/install"
         rm -rf cling
         if [[ -n "${CLING_REF}" ]]; then
           git clone --depth=1 -b "${CLING_REF}" "${CLING_REPO}" cling
@@ -313,7 +313,7 @@ runs:
       run: |
         $ErrorActionPreference = 'Stop'
         $ncpus = [Environment]::ProcessorCount
-        $LLVM_PREFIX = "$env:GITHUB_WORKSPACE\llvm-project"
+        $LLVM_PREFIX = "$env:GITHUB_WORKSPACE\install"
         if (Test-Path cling) { Remove-Item -Recurse -Force cling }
         if ($env:CLING_REF) {
           git clone --depth=1 -b $env:CLING_REF $env:CLING_REPO cling
@@ -347,7 +347,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        tc="${GITHUB_WORKSPACE}/llvm-project/etc/cmake-toolchain.cmake"
+        tc="${GITHUB_WORKSPACE}/install/etc/cmake-toolchain.cmake"
         if [[ -f "$tc" ]]; then
           echo "CMAKE_TOOLCHAIN_FILE=$tc" >> "$GITHUB_ENV"
           echo "::notice title=setup-llvm::recipe ships cmake-toolchain.cmake; CMAKE_TOOLCHAIN_FILE=$tc"
@@ -369,5 +369,5 @@ runs:
           src=inline-build
         fi
         echo "source=${src}"                            >> "$GITHUB_OUTPUT"
-        echo "prefix=${GITHUB_WORKSPACE}/llvm-project"  >> "$GITHUB_OUTPUT"
-        echo "::notice title=setup-llvm::flavor=${FLAVOR:-llvm-release} source=${src} prefix=${GITHUB_WORKSPACE}/llvm-project"
+        echo "prefix=${GITHUB_WORKSPACE}/install"  >> "$GITHUB_OUTPUT"
+        echo "::notice title=setup-llvm::flavor=${FLAVOR:-llvm-release} source=${src} prefix=${GITHUB_WORKSPACE}/install"

--- a/actions/setup-recipe/action.yml
+++ b/actions/setup-recipe/action.yml
@@ -67,7 +67,7 @@ outputs:
     description: 'Computed cache key'
     value: ${{ steps.compute-key.outputs.key }}
   src-commit:
-    description: 'llvm-project HEAD sha (only set on inline build path)'
+    description: 'Source HEAD sha (only set on inline build path)'
     value: ${{ env.SRC_COMMIT }}
 
 runs:
@@ -163,23 +163,23 @@ runs:
         cd __ci_workflows__
         mkdir -p _llvm_dl
         python3 actions/lib/cache_io.py download "$BASE" "$KEY" _llvm_dl
-        # Recipe's tarball root is `llvm-project/`; surface at $GITHUB_WORKSPACE.
-        # `rm -rf ../llvm-project` first so the step is idempotent: a
+        # Recipe's tarball root is `install/`; surface at $GITHUB_WORKSPACE.
+        # `rm -rf ../install` first so the step is idempotent: a
         # re-run in the same workspace (act with reused containers, or
         # any flow that calls setup-recipe twice) would otherwise trip
-        # `mv: cannot overwrite '../llvm-project': Directory not empty`
+        # `mv: cannot overwrite '../install': Directory not empty`
         # on the existing tree from the prior run. Mirrors the pattern
         # in the cache-miss "Build inline" branch below.
-        if [[ -d _llvm_dl/llvm-project ]]; then
-          rm -rf ../llvm-project
-          mv _llvm_dl/llvm-project ../
+        if [[ -d _llvm_dl/install ]]; then
+          rm -rf ../install
+          mv _llvm_dl/install ../
         else
           # Defensive: some recipes may tar a different root in future.
           mv _llvm_dl/* ../ 2>/dev/null || true
         fi
         rm -rf _llvm_dl
         cd ..
-        extracted=$(python3 -c "import os, sys; sz = sum(p.stat().st_size for p in __import__('pathlib').Path('llvm-project').rglob('*') if p.is_file()); print(f'{sz/1048576:.0f} MiB')" 2>/dev/null || echo '?')
+        extracted=$(python3 -c "import os, sys; sz = sum(p.stat().st_size for p in __import__('pathlib').Path('install').rglob('*') if p.is_file()); print(f'{sz/1048576:.0f} MiB')" 2>/dev/null || echo '?')
 
         # Provenance notices: every operator looking at this run can
         # see at a glance what was loaded plus a clickable URL to the
@@ -202,16 +202,16 @@ runs:
         # Dispatch by recipe build script: prefer build.py (Python,
         # native on every OS) over build.sh (bash, requires git-bash
         # on Windows). Recipes migrate one at a time; both forms
-        # produce $OUT_DIR/llvm-project as a relocatable install tree.
+        # produce $OUT_DIR/install as a relocatable install tree.
         recipe_dir=__ci_workflows__/recipes/${{ inputs.recipe }}
         if [[ -f "$recipe_dir/build.py" ]]; then
           python3 "$recipe_dir/build.py"
         else
           bash "$recipe_dir/build.sh"
         fi
-        if [[ -d "$OUT_DIR/llvm-project" ]]; then
-          rm -rf "$GITHUB_WORKSPACE/llvm-project"
-          mv "$OUT_DIR/llvm-project" "$GITHUB_WORKSPACE/llvm-project"
+        if [[ -d "$OUT_DIR/install" ]]; then
+          rm -rf "$GITHUB_WORKSPACE/install"
+          mv "$OUT_DIR/install" "$GITHUB_WORKSPACE/install"
         fi
 
     - name: Fail on miss when build-on-miss=false
@@ -240,5 +240,5 @@ runs:
       env:
         HIT: ${{ steps.probe.outputs.hit }}
       run: |
-        echo "path=${{ github.workspace }}/llvm-project" >> "$GITHUB_OUTPUT"
+        echo "path=${{ github.workspace }}/install" >> "$GITHUB_OUTPUT"
         echo "cache-hit=${HIT}" >> "$GITHUB_OUTPUT"

--- a/bin/recipe-cache
+++ b/bin/recipe-cache
@@ -123,7 +123,7 @@ def cmd_pack(args: argparse.Namespace) -> int:
     cache_dir = _cache_dir()
     cache_dir.mkdir(parents=True, exist_ok=True)
 
-    # Pack the directory as if it were named llvm-project (matches what
+    # Pack the directory as if it were named install (matches what
     # build.sh would produce). Use tarfile directly with arcname so we
     # don't need to materialise a symlink (which doesn't work cleanly
     # on Windows for non-admins).
@@ -135,7 +135,7 @@ def cmd_pack(args: argparse.Namespace) -> int:
         )
         try:
             with tarfile.open(fileobj=zstd.stdin, mode="w|") as tar:
-                tar.add(src, arcname="llvm-project")
+                tar.add(src, arcname="install")
         finally:
             assert zstd.stdin is not None
             zstd.stdin.close()

--- a/bin/repro
+++ b/bin/repro
@@ -54,8 +54,8 @@ unattended runs stay clean.
 
 Pre-flight workspace clash check: bin/repro mounts the consumer's
 working tree into the act container. If a top-level dir matching a
-known offender (`build/`, `llvm-project/`) already exists, the
-workflow's `mkdir build` / setup-recipe's `mv ../llvm-project` will
+known offender (`build/`, `install/`) already exists, the
+workflow's `mkdir build` / setup-recipe's `mv ../install` will
 trip under `set -e` before any actionable error appears. The
 pre-flight lists the colliding paths and refuses to proceed by
 default. Move them aside (`mv build build.local`) or pass
@@ -79,7 +79,7 @@ consumer working tree, however, accumulates whatever the workflow
 writes into $GITHUB_WORKSPACE -- act bind-mounts the working tree
 into the container, so `mkdir build`, setup-recipe's `mv ../llvm-
 project`, etc. land directly on the host. The workspace-clash
-pre-flight (above) catches the resulting `build/` / `llvm-project/`
+pre-flight (above) catches the resulting `build/` / `install/`
 on the next run; clean them up by hand if you want a pristine tree.
 
 Anything after `--` is passed verbatim to act.
@@ -947,7 +947,7 @@ DEVSHELL_RUNNER_WORKSPACE = "/home/runner/work/ci-workflows/ci-workflows"
 DEVSHELL_CCACHE_SUBDIR    = ".ccache"
 DEVSHELL_SRC_SUBDIR       = "_recipe_work/llvm-project"
 DEVSHELL_BUILD_SUBDIR     = "_recipe_work/llvm-project/build"
-DEVSHELL_INSTALL_SUBDIR   = "_recipe_out/llvm-project"
+DEVSHELL_INSTALL_SUBDIR   = "_recipe_out/install"
 
 DEVSHELL_CONFIG_SCRIPT = REPO_ROOT / "scripts" / "repro-config"
 
@@ -1058,10 +1058,10 @@ def _devshell_fetch(base: str, key: str, work: Path,
     ccache_root = work
     manifest = work / "manifest.json"
 
-    # Install tree: archive's top-level dir is `llvm-project/`, so
+    # Install tree: archive's top-level dir is `install/`, so
     # extracting to `<work>/_recipe_out/` lands the install at
-    # `<work>/_recipe_out/llvm-project/`.
-    install_root = install_parent / "llvm-project"
+    # `<work>/_recipe_out/install/`.
+    install_root = install_parent / "install"
     if refetch or not install_root.is_dir():
         if install_parent.is_dir():
             shutil.rmtree(install_parent)
@@ -1406,7 +1406,10 @@ def _confirm(prompt: str, default: bool = True) -> bool:
 # we don't care about. Add names here when a new clash bites someone.
 _LIKELY_CLASH_DIRS = (
     "build",
-    "llvm-project",
+    "install",       # setup-recipe's extract target.
+    "llvm-project",  # consumer workflows (CppInterOp main.yml et al.)
+                     # clone llvm-project at workspace root; independent
+                     # clash, not redundant with `install` above.
 )
 
 

--- a/bin/test_recipe_cache.py
+++ b/bin/test_recipe_cache.py
@@ -96,12 +96,12 @@ class PackGetRmTests(_CLITestCase):
             self.assertEqual(manifest_data["kind"], "mockup")
             self.assertEqual(manifest_data["recipe"], "llvm-asan")
 
-            # Get extracts the tarball under --out/llvm-project/.
+            # Get extracts the tarball under --out/install/.
             self._run(
                 "get", "llvm-asan", "22", "ubuntu-24.04", "x86_64",
                 "--out", out_dir,
             )
-            extracted = Path(out_dir) / "llvm-project"
+            extracted = Path(out_dir) / "install"
             self.assertTrue(extracted.is_dir())
             self.assertEqual(
                 (extracted / "include" / "llvm" / "foo.h").read_text(),

--- a/recipes/llvm-asan/build.py
+++ b/recipes/llvm-asan/build.py
@@ -83,7 +83,7 @@ def main() -> int:
     # - compiler-rt is enabled solely for orc_rt_<platform>, which the
     #   OOP-JIT path needs; everything else under compiler-rt is OFF.
     cmake_args = (
-        llvm_build.base_cmake_args(str(out_dir / "llvm-project"))
+        llvm_build.base_cmake_args(str(out_dir / "install"))
         + [
             '-DLLVM_ENABLE_PROJECTS=clang;compiler-rt',
             '-DLLVM_USE_SANITIZER=Address;Undefined',
@@ -133,7 +133,7 @@ def main() -> int:
     # consumers find it next to clang at $LLVM/bin/llvm-jitlink-executor.
     src_jitlink = build_dir / "bin" / "llvm-jitlink-executor"
     if src_jitlink.is_file():
-        dst = out_dir / "llvm-project" / "bin" / "llvm-jitlink-executor"
+        dst = out_dir / "install" / "bin" / "llvm-jitlink-executor"
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(src_jitlink, dst)
         dst.chmod(dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)

--- a/recipes/llvm-dry-run/build.py
+++ b/recipes/llvm-dry-run/build.py
@@ -59,7 +59,7 @@ def main() -> int:
     # since it never builds clang.
     cmake_args = [
         "cmake", "-G", "Ninja",
-        f"-DCMAKE_INSTALL_PREFIX={out_dir / 'llvm-project'}",
+        f"-DCMAKE_INSTALL_PREFIX={out_dir / 'install'}",
         '-DLLVM_TARGETS_TO_BUILD=host',
         '-DCMAKE_BUILD_TYPE=Release',
         '-DLLVM_INCLUDE_BENCHMARKS=OFF',

--- a/recipes/llvm-msan/build.py
+++ b/recipes/llvm-msan/build.py
@@ -110,8 +110,8 @@ def _build_msan_runtime_into(src_dir: Path, build_dir: Path,
     bootstrap clang has the runtime *before* stage 1 needs to link
     libc++.
     """
-    # bootstrap_bin is `<extract>/llvm-project/bin`. The bootstrap
-    # clang searches `<extract>/llvm-project/lib/clang/<N>/lib/<triple>/`
+    # bootstrap_bin is `<extract>/install/bin`. The bootstrap
+    # clang searches `<extract>/install/lib/clang/<N>/lib/<triple>/`
     # for runtime archives, so install directly into the resource-dir
     # (with PER_TARGET_RUNTIME_DIR on, files land at
     # `<prefix>/lib/<triple>/libclang_rt.*`). Probe the bootstrap's
@@ -212,7 +212,7 @@ def _emit_toolchain_file(install_prefix: Path) -> None:
     CMAKE_TOOLCHAIN_FILE generically, so consumer matrix rows stay a
     one-line `flavor: msan`. ${CMAKE_CURRENT_LIST_DIR}/.. resolves the
     install root, so the same file works at OUT_DIR (recipe build) and
-    $GITHUB_WORKSPACE/llvm-project (extracted cell).
+    $GITHUB_WORKSPACE/install (extracted cell).
     """
     etc_dir = install_prefix / "etc"
     etc_dir.mkdir(parents=True, exist_ok=True)
@@ -284,7 +284,7 @@ def main() -> int:
         return 1
 
     src_dir = work_dir / "llvm-project"
-    install_prefix = out_dir / "llvm-project"
+    install_prefix = out_dir / "install"
     libcxx_install = work_dir / "libcxx_msan"
 
     os.chdir(work_dir)

--- a/recipes/llvm-release/build.py
+++ b/recipes/llvm-release/build.py
@@ -127,7 +127,7 @@ def main() -> int:
         compiler_rt_flags = []
 
     cmake_args = (
-        llvm_build.base_cmake_args(str(out_dir / "llvm-project"))
+        llvm_build.base_cmake_args(str(out_dir / "install"))
         + [f"-DLLVM_ENABLE_PROJECTS={projects}"]
         + compiler_rt_flags
         + llvm_build.cmake_extra()
@@ -169,7 +169,7 @@ def main() -> int:
     # clang at $LLVM/bin/llvm-jitlink-executor.
     src_jitlink = build_dir / "bin" / "llvm-jitlink-executor"
     if src_jitlink.is_file():
-        dst = out_dir / "llvm-project" / "bin" / "llvm-jitlink-executor"
+        dst = out_dir / "install" / "bin" / "llvm-jitlink-executor"
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(src_jitlink, dst)
         dst.chmod(dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)

--- a/recipes/llvm-root/build.py
+++ b/recipes/llvm-root/build.py
@@ -80,7 +80,7 @@ def main() -> int:
     os.chdir(build_dir)
 
     cmake_args = (
-        llvm_build.base_cmake_args(str(out_dir / "llvm-project"))
+        llvm_build.base_cmake_args(str(out_dir / "install"))
         + ['-DLLVM_ENABLE_PROJECTS=clang']
         + llvm_build.cmake_extra()
         + ["../llvm"]

--- a/recipes/llvm-wasm/build.py
+++ b/recipes/llvm-wasm/build.py
@@ -228,8 +228,8 @@ def main() -> int:
 
     trim_source_tree(repo)
 
-    # Move the trimmed tree to OUT_DIR/llvm-project for the publish step.
-    dst = out_dir / "llvm-project"
+    # Move the trimmed tree to OUT_DIR/install for the publish step.
+    dst = out_dir / "install"
     if dst.exists():
         shutil.rmtree(dst)
     shutil.move(str(repo), str(dst))

--- a/recipes/llvm-wasm/recipe.yaml
+++ b/recipes/llvm-wasm/recipe.yaml
@@ -5,13 +5,13 @@ description: |
   emscripten matrix.
 
   Two stages: (1) host llvm-tblgen + clang-tblgen under
-  llvm-project/native_build/ -- the wasm clang cannot build host
-  binaries, LLVM_NATIVE_TOOL_DIR points at this; (2) emcmake/emmake
-  cross-build under llvm-project/build/. Source-tree layout is
-  preserved (not a cmake install): consumers point at
-  build/lib/cmake/ for find_package and at {llvm,clang}/include for
-  headers; LLVM_DISTRIBUTION_COMPONENTS does not apply across the
-  host/wasm boundary.
+  install/native_build/ -- the wasm clang cannot build host binaries,
+  LLVM_NATIVE_TOOL_DIR points at this; (2) emcmake/emmake cross-build
+  under install/build/. Source-tree layout is preserved (not a cmake
+  install): consumers point at install/build/lib/cmake/ for
+  find_package and at install/{llvm,clang}/include for headers;
+  LLVM_DISTRIBUTION_COMPONENTS does not apply across the host/wasm
+  boundary.
 
   Per-LLVM-major patches under patches/ apply by file glob
   (`emscripten-clang{N}-*.patch`); adding a new major needs no
@@ -20,10 +20,10 @@ description: |
   cell-level field.
 
   Consumer cmake contract:
-    -DLLVM_DIR=$LLVM/llvm-project/build/lib/cmake/llvm
-    -DClang_DIR=$LLVM/llvm-project/build/lib/cmake/clang
+    -DLLVM_DIR=$LLVM/install/build/lib/cmake/llvm
+    -DClang_DIR=$LLVM/install/build/lib/cmake/clang
     -DCMAKE_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake
-    -DLLVM_NATIVE_TOOL_DIR=$LLVM/llvm-project/native_build/bin
+    -DLLVM_NATIVE_TOOL_DIR=$LLVM/install/native_build/bin
 
 # Only fields read by build_manifest.py live here. The cmake invocation,
 # patch glob, and emsdk version pin are authoritative in build.py.


### PR DESCRIPTION
The cache_pack default `src_name` was "llvm-project" because the first recipes that landed all built LLVM and used its source-tree name for their install dir. cpython-debug already had to lie about its contents ("install at OUT_DIR/llvm-project even though we ship a Python tree"); any future non-LLVM recipe would have to do the same. Rename to a neutral "install" that describes what the directory contains, not where the source came from.

Mechanical changes touch every install-context reference: actions/lib/cache_io.py default, every recipe's build.py install prefix, llvm_build.py's smoke prefix, setup-llvm + setup-recipe extract paths and outputs, publish-recipe's bootstrap fetcher, bin/recipe-cache's pack arcname, bin/repro's DEVSHELL_INSTALL_SUBDIR, the publish-dryrun verify job's extract assertion, the wasm recipe's consumer cmake-contract doc block, and the relevant tests. Source- clone paths (work_dir/llvm-project) and github URLs stay -- those refer to the upstream repo, not the cell layout.

Backward-incompatible. Cells already published with the old name become unreadable by the post-rename setup-recipe; they get republished on the merge-to-main push. Consumer workflows that hardcode $GITHUB_WORKSPACE/llvm-project need to switch to setup-llvm's `prefix` output or to /install -- the symlink the action writes is at the new path. ccache hits are unaffected: compile commands reference work_dir/llvm-project (source clone, unrenamed), not out_dir/install.