### PR TITLE
setup-llvm: export LLVM_DIR / Clang_DIR via outputs and $GITHUB_ENV.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -273,6 +273,8 @@ jobs:
         env:
           SOURCE: ${{ steps.first.outputs.source }}
           PREFIX: ${{ steps.first.outputs.prefix }}
+          LLVM_DIR_OUT: ${{ steps.first.outputs.llvm-dir }}
+          CLANG_DIR_OUT: ${{ steps.first.outputs.clang-dir }}
         run: |
           set -euo pipefail
           if [[ "$SOURCE" != "package-manager" ]]; then
@@ -288,6 +290,16 @@ jobs:
             ls -la "$PREFIX/lib/cmake/llvm/" || true
             exit 1
           }
+          # llvm-dir / clang-dir outputs match the documented formula.
+          [[ "$LLVM_DIR_OUT" == "$PREFIX/lib/cmake/llvm" ]] || {
+            echo "::error::llvm-dir output mismatch: $LLVM_DIR_OUT"; exit 1; }
+          [[ "$CLANG_DIR_OUT" == "$PREFIX/lib/cmake/clang" ]] || {
+            echo "::error::clang-dir output mismatch: $CLANG_DIR_OUT"; exit 1; }
+          # Env-var exports propagate to subsequent steps via $GITHUB_ENV.
+          [[ "$LLVM_DIR" == "$PREFIX/lib/cmake/llvm" ]] || {
+            echo "::error::LLVM_DIR env mismatch: $LLVM_DIR"; exit 1; }
+          [[ "$Clang_DIR" == "$PREFIX/lib/cmake/clang" ]] || {
+            echo "::error::Clang_DIR env mismatch: $Clang_DIR"; exit 1; }
           echo "::notice::flavor=system smoke OK: source=$SOURCE prefix=$PREFIX"
       - name: Idempotency (re-invoke against existing symlink)
         id: second
@@ -308,4 +320,3 @@ jobs:
             exit 1
           fi
           echo "::notice::flavor=system idempotency OK"
-

--- a/actions/setup-llvm/action.yml
+++ b/actions/setup-llvm/action.yml
@@ -24,7 +24,10 @@ description: |
     'cling'   Recipe `llvm-root` plus a cling-on-top build.
 
   All paths land at $GITHUB_WORKSPACE/install. The `source`
-  output reports which path won.
+  output reports which path won; `prefix`, `llvm-dir`, `clang-dir`
+  outputs name the install layout. LLVM_DIR and Clang_DIR are also
+  exported via $GITHUB_ENV so consumer cmake steps can reference
+  them directly without pinning a step id.
 
   If the install ships <install>/etc/cmake-toolchain.cmake, this
   action exports CMAKE_TOOLCHAIN_FILE pointing at it -- consumers
@@ -104,6 +107,12 @@ outputs:
   prefix:
     description: 'Install prefix (always $GITHUB_WORKSPACE/install).'
     value: ${{ steps.finalize.outputs.prefix }}
+  llvm-dir:
+    description: 'LLVMConfig.cmake directory ($prefix/lib/cmake/llvm).'
+    value: ${{ steps.finalize.outputs.llvm-dir }}
+  clang-dir:
+    description: 'ClangConfig.cmake directory ($prefix/lib/cmake/clang).'
+    value: ${{ steps.finalize.outputs.clang-dir }}
 
 runs:
   using: composite
@@ -368,6 +377,13 @@ runs:
         else
           src=inline-build
         fi
-        echo "source=${src}"                            >> "$GITHUB_OUTPUT"
-        echo "prefix=${GITHUB_WORKSPACE}/install"  >> "$GITHUB_OUTPUT"
-        echo "::notice title=setup-llvm::flavor=${FLAVOR:-llvm-release} source=${src} prefix=${GITHUB_WORKSPACE}/install"
+        prefix="${GITHUB_WORKSPACE}/install"
+        llvm_dir="${prefix}/lib/cmake/llvm"
+        clang_dir="${prefix}/lib/cmake/clang"
+        echo "source=${src}"        >> "$GITHUB_OUTPUT"
+        echo "prefix=${prefix}"     >> "$GITHUB_OUTPUT"
+        echo "llvm-dir=${llvm_dir}" >> "$GITHUB_OUTPUT"
+        echo "clang-dir=${clang_dir}" >> "$GITHUB_OUTPUT"
+        echo "LLVM_DIR=${llvm_dir}"   >> "$GITHUB_ENV"
+        echo "Clang_DIR=${clang_dir}" >> "$GITHUB_ENV"
+        echo "::notice title=setup-llvm::flavor=${FLAVOR:-llvm-release} source=${src} prefix=${prefix}"


### PR DESCRIPTION
Today consumers wanting `LLVM_DIR` for `find_package(LLVM)` either pin an `id:` on the setup-llvm step and read `outputs.prefix` + append `/lib/cmake/llvm`, or just hardcode `$GITHUB_WORKSPACE/...` and break on every install-tree rename (CppInterOp's Build_and_Test_CppInterOp action.yml just hit this on the llvm-project -> install rename).

Add two new step outputs (`llvm-dir`, `clang-dir`) and write the same paths to $GITHUB_ENV so consumer cmake steps can reference $LLVM_DIR / $Clang_DIR directly. Purely additive: existing consumers reading `outputs.prefix` keep working unchanged. Downstream consumer steps that go through setup-llvm can drop their bash probes and trust $LLVM_DIR. Extends the existing setup-llvm-system-smoke verify job to assert both the new outputs and the env exports against apt-llvm.org's llvm-20.