### PR TITLE
llvm-wasm: publish ubuntu-arm and macos-26 cells.

### DIFF
--- a/cells.yaml
+++ b/cells.yaml
@@ -36,9 +36,15 @@ cells:
   # MSan-instrumented libc++ stage build cleanly (libcxxabi-on-Mach-O
   # uses Apple's libunwind), and Windows lacks MSan support upstream.
   - { recipe: llvm-msan,  version: '22',            os: ubuntu-24.04,    arch: x86_64 }
-  # llvm-wasm: Linux x86_64 first; macOS / Windows added once the
-  # recipe's bash-via-subprocess emsdk activation is validated there.
+  # llvm-wasm: cells cover CppInterOp's Unix emscripten rows.
+  # build.py's emsdk install/activate goes through `subprocess.run`
+  # against the extensionless `emsdk` script, which only resolves
+  # under bash; the per-major patch glob is OS-agnostic. The Windows
+  # row in CppInterOp's matrix still inline-builds via build-on-miss
+  # until the recipe grows `emsdk.bat`/`.ps1` plumbing.
   - { recipe: llvm-wasm,  version: '22',            os: ubuntu-24.04,    arch: x86_64 }
+  - { recipe: llvm-wasm,  version: '22',            os: ubuntu-24.04-arm, arch: arm64  }
+  - { recipe: llvm-wasm,  version: '22',            os: macos-26,        arch: arm64  }
   # cpython-debug: --with-pydebug + --with-trace-refs + --with-assertions.
   # Linux x86_64 only -- macOS / Windows have stock CPython via the
   # platform package manager; the CI cost of building debug Python on


### PR DESCRIPTION
cells.yaml only listed ubuntu-24.04 x86_64 for llvm-wasm; the other three rows in CppInterOp's emscripten matrix (ubuntu-24.04-arm, macos-26 arm64, windows-2025) all fell through setup-recipe's `build-on-miss=true` path and inline-built the wasm32 LLVM/Clang tree on every PR. That is the exact load the recipe was meant to retire.

Add the two Unix rows. The recipe's emsdk install/activate runs through `subprocess.run` against the extensionless `emsdk` script (recipes/llvm-wasm/build.py:83), which resolves only under POSIX shell -- both ubuntu-24.04-arm and macos-26 ship bash, so no recipe change is needed. Per-major patches under
patches/emscripten-clang*.patch are plain text applied via `git apply`, OS-independent. The Windows row stays on build-on-miss until the recipe grows `emsdk.bat`/`.ps1` plumbing. Pairs with compiler-research/CppInterOp's switch from the local Build_LLVM_WASM action to setup-recipe@main; once these cells warm on push, the two Unix rows there stop doing per-PR cross-builds.