### PR TITLE
llvm-wasm: include lld-cmake-exports + lld-headers in DIST.

### DIFF
--- a/recipes/llvm-wasm/build.py
+++ b/recipes/llvm-wasm/build.py
@@ -191,6 +191,12 @@ def _wasm_dist_components(build_dir: Path) -> list[str]:
     return [
         "clang-headers", "clang-cmake-exports", "clang-resource-headers",
         "clangInterpreter",
+        # lld-cmake-exports installs lib/cmake/lld/LLDConfig.cmake; without
+        # it, consumers passing `-DLLD_DIR=$LLVM_BUILD_DIR/lib/cmake/lld`
+        # hit `Could not find a package configuration file provided by "LLD"`.
+        # lld-headers ships include/lld/ for `#include "lld/..."` from the
+        # consumer side.
+        "lld-cmake-exports", "lld-headers",
         "cmake-exports", "llvm-headers",
     ] + _walk_built_libs(build_dir)
 


### PR DESCRIPTION
The wasm install tree shipped liblldCommon.a / liblldWasm.a / liblldELF.a (picked up by `_walk_built_libs`) but no LLDConfig.cmake under lib/cmake/lld/. CppInterOp's wasm consumer passes `-DLLD_DIR=$LLVM_BUILD_DIR/lib/cmake/lld` and find_package(LLD) fails configure with "Could not find a package configuration file provided by LLD".

Add `lld-cmake-exports` (writes lib/cmake/lld/LLDConfig.cmake) and `lld-headers` (writes include/lld/) to the wasm DIST set, mirroring how `clang-cmake-exports` + `clang-headers` cover the clang side. The corresponding install rules already exist in LLVM's lld/ tree; they just weren't listed in our DIST so `ninja install-distribution` skipped them.