### PR TITLE
setup-llvm: try ubuntu archive before apt-llvm.org on flavor=system.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -238,17 +238,15 @@ jobs:
           test -f extract/install/lib/cmake/llvm/LLVMConfig.cmake
           echo "::notice::publish-dryrun OK on ${{ matrix.os }}"
 
-  # setup-llvm flavor=system smoke. Exercises the apt-llvm.org path
-  # with an older LLVM major (20) that's been stable on apt-llvm.org
-  # for noble for a long time, so the install should reliably succeed.
-  # Asserts:
-  #   - source output reports package-manager
-  #   - prefix is a symlink (not a real directory) — catches a
-  #     regression where the install lands at a real path
-  #   - LLVMConfig.cmake is reachable through it
-  # The second invocation step is a regression test for the
-  # symlink-over-directory bug: `ln` without `rm -rf` first fails on
-  # the second call when the first left a real symlink at the path.
+  # setup-llvm flavor=system smoke. Matrix covers both install paths:
+  #   - version 20 → not in noble archive → falls through to apt-llvm.org
+  #   - version 14 → in noble archive → exercises the direct-apt branch
+  # Asserts source output reports package-manager, prefix is a symlink
+  # (regression test for "install lands at a real path"), and
+  # LLVMConfig.cmake is reachable. The second invocation step is a
+  # regression test for the symlink-over-directory bug: `ln` without
+  # `rm -rf` first fails on the second call when the first left a real
+  # symlink at the path.
   #
   # Default-flavor smoke (recipe-cache path) is NOT included here:
   # setup-llvm's internal `uses: compiler-research/...@main` would
@@ -258,13 +256,17 @@ jobs:
   # the recipe path indirectly.
   setup-llvm-system-smoke:
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ['20', '14']
     steps:
       - uses: actions/checkout@v4
-      - name: flavor=system smoke (apt-llvm.org llvm-20)
+      - name: flavor=system smoke (llvm-${{ matrix.version }})
         id: first
         uses: ./actions/setup-llvm
         with:
-          version: '20'
+          version: ${{ matrix.version }}
           os: ubuntu-24.04
           arch: x86_64
           flavor: system
@@ -305,7 +307,7 @@ jobs:
         id: second
         uses: ./actions/setup-llvm
         with:
-          version: '20'
+          version: ${{ matrix.version }}
           os: ubuntu-24.04
           arch: x86_64
           flavor: system

--- a/actions/setup-llvm/action.yml
+++ b/actions/setup-llvm/action.yml
@@ -179,10 +179,12 @@ runs:
         echo "recipe-version=${FLAVOR_VERSION:-$VERSION}"       >> "$GITHUB_OUTPUT"
         echo "arch=$arch"                                       >> "$GITHUB_OUTPUT"
 
-    # System path (Linux): apt-llvm.org. No fallback — if the major
-    # isn't available, the action fails so the consumer knows their
-    # matrix row needs a different flavor or a different version.
-    - name: System install (apt-llvm.org)
+    # System path (Linux): try the ubuntu archive first (covers old
+    # versions that live there: jammy ships llvm-11..14, noble starts
+    # at 17 in the archive), fall back to apt-llvm.org for majors the
+    # archive doesn't carry. Mirrors the install ladder consumers
+    # had inline before this action existed.
+    - name: System install (apt)
       if: inputs.flavor == 'system' && runner.os == 'Linux'
       shell: bash
       env:
@@ -194,11 +196,19 @@ runs:
           echo "::error::no UBUNTU_CODENAME in /etc/os-release; flavor=system requires an Ubuntu host" >&2
           exit 1
         fi
-        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
-          | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
-        echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${VERSION} main" \
-          | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
         sudo apt-get update -qq
+        # Try the ubuntu archive directly. `apt-cache show` is a
+        # release-data lookup (no install side effects, no sudo
+        # password prompt under set -e), so we can probe whether the
+        # archive has llvm-N-dev before deciding to add apt-llvm.org.
+        if ! apt-cache show "llvm-${VERSION}-dev" >/dev/null 2>&1; then
+          echo "::notice::llvm-${VERSION}-dev not in ${codename} archive; adding apt-llvm.org"
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
+          echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${VERSION} main" \
+            | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
+          sudo apt-get update -qq
+        fi
         sudo apt-get install -y \
           llvm-${VERSION}-dev libclang-${VERSION}-dev clang-${VERSION} \
           libpolly-${VERSION}-dev libzstd-dev
@@ -227,7 +237,7 @@ runs:
         # directory fails on both GNU and BSD ln.
         rm -rf "${GITHUB_WORKSPACE}/install"
         ln -s "/usr/lib/llvm-${VERSION}" "${GITHUB_WORKSPACE}/install"
-        echo "::notice::flavor=system: apt-llvm.org llvm-${VERSION} on ${codename}"
+        echo "::notice::flavor=system: llvm-${VERSION} on ${codename}"
 
     - name: System install (Homebrew)
       if: inputs.flavor == 'system' && runner.os == 'macOS'


### PR DESCRIPTION
The Linux system path went straight to apt-llvm.org, whose codename coverage tracks recent majors only -- noble starts at llvm-17, jammy starts at llvm-14. Consumer matrices with older majors on those codenames hit `does not have a Release file` even though the ubuntu archive itself carries the package (jammy ships llvm-11..14 directly, noble ships llvm-14..16).

Probe `apt-cache show llvm-N-dev` first; install from the archive when present, fall back to apt-llvm.org otherwise. This matches the install ladder consumers had inline before adopting this action (clad's pre-migration ci.yml is the reference). The verify-side smoke matrixes the existing test over `version: ['20', '14']` -- 20 forces apt-llvm.org, 14 stays in the noble archive -- so each branch is exercised on every PR.