### PR TITLE
setup-llvm: do not require libpolly-N-dev on flavor=system.

### DIFF
--- a/actions/setup-llvm/action.yml
+++ b/actions/setup-llvm/action.yml
@@ -211,7 +211,15 @@ runs:
         fi
         sudo apt-get install -y \
           llvm-${VERSION}-dev libclang-${VERSION}-dev clang-${VERSION} \
-          libpolly-${VERSION}-dev libzstd-dev
+          libzstd-dev
+        # libpolly-N-dev: missing from some (codename, major) combos
+        # (e.g. jammy/llvm-13); apt-llvm.org carries it. Probe-and-skip
+        # so old-jammy rows don't fail on a Polly-less archive.
+        if apt-cache show "libpolly-${VERSION}-dev" >/dev/null 2>&1; then
+          sudo apt-get install -y "libpolly-${VERSION}-dev"
+        else
+          echo "::notice::libpolly-${VERSION}-dev not packaged for ${codename}; skipping (harmless unless the consumer links Polly)"
+        fi
         # libclang-rt-N-dev: ships compiler-rt's orc_rt + jitlink-executor
         # for the OOP-JIT runtime that LLVM >= 22 callers expect (matches
         # recipe llvm-release's compiler-rt branch). Hard-fail when


### PR DESCRIPTION
When the apt path took the "archive ships llvm-N-dev" branch (skipping apt-llvm.org), the install line still asked for libpolly-N-dev. Jammy's llvm-toolchain-13 (and the same-era 11/12 source packages) carry the llvm/clang -dev binaries but no Polly binary, so old-jammy rows failed with
`E: Unable to locate package libpolly-13-dev`.

Split libpolly off the mandatory install and gate it on the same `apt-cache show` probe used above for llvm-N-dev: install when the archive in scope carries it, emit a GH notice and continue when not. No setup-llvm consumer is currently known to link Polly, so a skip is harmless.