### PR TITLE
[cppjit] Fix recurring name and drop redundant cling var

### DIFF
--- a/.github/workflows/cppjit.yml
+++ b/.github/workflows/cppjit.yml
@@ -39,10 +39,6 @@ on:
         type: string
         default: ''
         description: "setup-llvm flavor-version (e.g. 'cling-llvm20' for flavor:cling); empty otherwise."
-      cling:
-        type: boolean
-        default: false
-        description: 'Build CppInterOp with Cling (CPPJIT_USE_CLING=ON, llvm-flavor: cling)'
       python-version:
         type: string
         required: true
@@ -55,7 +51,7 @@ on:
         type: boolean
         default: false
         description: 'Run the valgrind pass (Linux only).'
-      run-sweeps:
+      run-xfail-crashing-tests:
         type: boolean
         default: false
         description: 'Run the xfail-crash and xfail->skipif sweeps.'
@@ -74,7 +70,7 @@ permissions:
 jobs:
   build-test:
     runs-on: ${{ inputs.os }}
-    name: ${{ inputs.os }}-llvm${{ inputs.llvm-version }}-py${{ inputs.python-version }}-cxx${{ inputs.cxx-standard }}${{ inputs.valgrind && '-vg' || '' }}
+    name: Build & Test
     outputs:
       summary: ${{ steps.summary.outputs.line }}
     steps:
@@ -105,8 +101,8 @@ jobs:
           cxx-standard: ${{ inputs.cxx-standard }}
           llvm-version: ${{ inputs.llvm-version }}
           valgrind: ${{ inputs.valgrind }}
-          run-sweeps: ${{ inputs.run-sweeps }}
-          cling: ${{ inputs.cling }}
+          run-xfail-crashing-tests: ${{ inputs.run-xfail-crashing-tests }}
+          cling: ${{ inputs.llvm-flavor == 'cling' }}
 
       - name: Capture summary
         id: summary
@@ -123,6 +119,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: result-${{ inputs.os }}-llvm${{ inputs.llvm-version }}-py${{ inputs.python-version }}-cxx${{ inputs.cxx-standard }}${{ inputs.valgrind && '-vg' || '' }}
+          name: result-${{ inputs.os }}-llvm${{ inputs.llvm-version }}-py${{ inputs.python-version }}-cxx${{ inputs.cxx-standard }}${{ inputs.valgrind && '-vg' || '' }}${{ inputs.llvm-flavor == 'cling' && '-cling' || '' }}
           path: ${{ github.workspace }}/pytest-summary.txt
           if-no-files-found: warn

--- a/actions/build-and-test-cppjit/action.yml
+++ b/actions/build-and-test-cppjit/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
     default: 'false'
     description: 'Run the valgrind pass ("true"/"false"), linux only.'
-  run-sweeps:
+  run-xfail-crashing-tests:
     required: false
     default: 'false'
     description: 'Also run the disabled xfail crash/skipif tests'
@@ -90,7 +90,7 @@ runs:
       env:
         CXX_STD: ${{ inputs.cxx-standard }}
         VALGRIND: ${{ inputs.valgrind }}
-        RUN_SWEEPS: ${{ inputs.run-sweeps }}
+        RUN_XFAIL_CRASHING_TESTS: ${{ inputs.run-xfail-crashing-tests }}
         LLVM_VERSION: ${{ inputs.llvm-version }}
       run: |
         set -uo pipefail
@@ -112,7 +112,7 @@ runs:
         tail -n1 complete_testrun.log > "${GITHUB_WORKSPACE}/pytest-summary.txt" || true
         echo "::endgroup::"
 
-        if [[ "${RUN_SWEEPS}" == "true" ]]; then
+        if [[ "${RUN_XFAIL_CRASHING_TESTS}" == "true" ]]; then
           # A crash here = an xfail that stopped crashing and should drop its marker.
           echo "::group::xfail-crash sweep"
           find . -name "*.py" -exec "${SED}" -i '/run=False/!s/^ *@mark.xfail\(.*\)/#&/' {} \;


### PR DESCRIPTION
This addresses parts of the review in https://github.com/compiler-research/cppjit/pull/6

Drops redundant Cling variable, deduplicates the naming, and renames "run-sweeps:" to a more meaningful one.