### PR TITLE
Add an llvm-debug recipe and setup-llvm 'debug' flavor

### DIFF
--- a/actions/lib/llvm_build.py
+++ b/actions/lib/llvm_build.py
@@ -51,19 +51,24 @@ def setup_env() -> None:
 
 
 def base_cmake_args(install_prefix: str,
-                    targets: str = "host;NVPTX") -> List[str]:
+                    targets: str = "host;NVPTX",
+                    build_type: str = "Release") -> List[str]:
     """Cmake flags every LLVM-family recipe shares.
 
     Recipes append their flavor-specific flags (LLVM_USE_SANITIZER for
     asan, LLVM_EXTERNAL_PROJECTS=cling for root, etc.) and feed the
     combined list to cmake. Centralising the shared subset means a flag
     bump happens in one place, not three.
+
+    `build_type` is CMAKE_BUILD_TYPE; it defaults to Release (assertions
+    are on regardless — every recipe wants them). The llvm-debug recipe
+    passes Debug for an unoptimised, -g toolchain.
     """
     return [
         "cmake", "-G", "Ninja",
         f"-DCMAKE_INSTALL_PREFIX={install_prefix}",
         f"-DLLVM_TARGETS_TO_BUILD={targets}",
-        "-DCMAKE_BUILD_TYPE=Release",
+        f"-DCMAKE_BUILD_TYPE={build_type}",
         "-DLLVM_ENABLE_ASSERTIONS=ON",
         "-DCLANG_ENABLE_STATIC_ANALYZER=OFF",
         "-DCLANG_ENABLE_ARCMT=OFF",

--- a/actions/setup-llvm/action.yml
+++ b/actions/setup-llvm/action.yml
@@ -23,6 +23,11 @@ description: |
 
     'cling'   Recipe `llvm-root` plus a cling-on-top build.
 
+    'debug'   Recipe `llvm-debug`. Debug (-O0 -g) LLVM/Clang with
+              assertions, carrying the FileCheck/`not` test tools in the
+              install. For downstream debug_build rows that want an
+              unoptimised, debuggable assertions LLVM.
+
   All paths land at $GITHUB_WORKSPACE/install. The `source`
   output reports which path won; `prefix`, `llvm-dir`, `clang-dir`
   outputs name the install layout. LLVM_DIR and Clang_DIR are also
@@ -62,7 +67,7 @@ inputs:
       Selects the LLVM source. One of: '' (llvm-release recipe),
       'system' (package manager), 'asan' (llvm-asan recipe), 'msan'
       (llvm-msan recipe, Linux x86_64 only), 'cling' (llvm-root
-      recipe + cling-on-top).
+      recipe + cling-on-top), 'debug' (llvm-debug recipe, Debug + asserts).
   flavor-version:
     required: false
     default: ''
@@ -146,6 +151,7 @@ runs:
             fi
             ;;
           cling)   recipe=llvm-root    ;;
+          debug)   recipe=llvm-debug   ;;
           system)
             recipe=''
             # Windows: chocolatey doesn't carry pinned LLVM majors with
@@ -156,7 +162,7 @@ runs:
               exit 1
             fi
             ;;
-          *) echo "::error::unknown flavor '${FLAVOR}' (expected: '', 'system', 'asan', 'msan', 'cling')" >&2
+          *) echo "::error::unknown flavor '${FLAVOR}' (expected: '', 'system', 'asan', 'msan', 'cling', 'debug')" >&2
              exit 1 ;;
         esac
         # Derive arch from the os slug when the consumer didn't pass

--- a/cells.yaml
+++ b/cells.yaml
@@ -32,6 +32,11 @@ caps:
 
 cells:
   - { recipe: llvm-asan, version: '22',            os: ubuntu-24.04,    arch: x86_64 }
+  # llvm-debug: Debug (-O0 -g) + asserts LLVM/Clang, carrying FileCheck
+  # and `not` in the install. Serves downstream debug_build rows (clad's
+  # ubu24-clang20-runtime22-debug) that previously built LLVM inline on
+  # every run. Tracks the latest supported LLVM major, like llvm-release.
+  - { recipe: llvm-debug, version: '22',           os: ubuntu-24.04,    arch: x86_64 }
   # llvm-msan: Linux only -- macOS toolchain doesn't ship the
   # MSan-instrumented libc++ stage build cleanly (libcxxabi-on-Mach-O
   # uses Apple's libunwind), and Windows lacks MSan support upstream.

--- a/recipes/llvm-debug/build.py
+++ b/recipes/llvm-debug/build.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Builds a Debug (-O0 -g) Clang/LLVM install tree from release/{version}.x.
+
+Same shape as recipes/llvm-release/build.py, with two differences:
+  * CMAKE_BUILD_TYPE=Debug instead of Release (assertions stay on).
+  * the LLVM test utilities FileCheck and `not` are built and copied
+    into the install, so a consumer's lit suite resolves them under the
+    recipe install prefix -- a from-source debug LLVM has them in
+    build/bin, but install-distribution doesn't ship test tools.
+
+The shared install-tree publish flow (env validation, .o cleanup,
+LLVM_DISTRIBUTION_COMPONENTS, install-distribution, find_package smoke)
+lives in actions/lib/llvm_build.py.
+
+Inputs (env): see actions/lib/llvm_build.py docstring.
+  RECIPE_VERSION         major LLVM version (release/{version}.x).
+
+Outputs (env, written to GITHUB_ENV when present):
+  SRC_COMMIT             sha of llvm-project HEAD that was built
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / ".." / ".." / "actions" / "lib"))
+
+import llvm_build  # noqa: E402
+
+# LLVM utilities a downstream lit suite needs but install-distribution
+# does not ship (they are test tools, not library/dist components).
+# clang-repl rides along because it is cheap once clangInterpreter is
+# built and some consumers exercise the interpreter driver.
+_INSTALLED_TOOLS = ["FileCheck", "not", "clang-repl"]
+
+
+def main() -> int:
+    llvm_build.setup_env()
+    work_dir = Path(os.environ["WORK_DIR"])
+    out_dir = Path(os.environ["OUT_DIR"])
+    version = os.environ["RECIPE_VERSION"]
+    ncpus = os.environ["NCPUS"]
+
+    # The source.branch_template assumes an integer-major release
+    # (release/{version}.x); refuse anything else before any git op.
+    try:
+        int(version.split('.')[0])
+    except ValueError:
+        print(
+            f"::error::recipe llvm-debug expects an integer-like version "
+            f"(e.g. '22' or '22.1'); got '{version}'",
+            file=sys.stderr,
+        )
+        return 1
+
+    os.chdir(work_dir)
+    llvm_build.clone_shallow(
+        "https://github.com/llvm/llvm-project.git",
+        f"release/{version}.x",
+        work_dir / "llvm-project",
+    )
+    src_commit = llvm_build.record_src_commit(work_dir / "llvm-project")
+
+    build_dir = work_dir / "llvm-project" / "build"
+    build_dir.mkdir(exist_ok=True)
+    os.chdir(build_dir)
+
+    cmake_args = (
+        llvm_build.base_cmake_args(str(out_dir / "install"), build_type="Debug")
+        + ["-DLLVM_ENABLE_PROJECTS=clang"]
+        + llvm_build.dylib_flags()
+        + llvm_build.cmake_extra()
+        + ["../llvm"]
+    )
+    llvm_build.record_cmake_args(cmake_args)
+    subprocess.run(cmake_args, check=True)
+
+    llvm_build.quick_check_or_continue()
+
+    subprocess.run(
+        ["ninja", "-j", ncpus,
+         "clang", "clangInterpreter", "clangStaticAnalyzerCore",
+         *_INSTALLED_TOOLS],
+        check=True,
+    )
+
+    llvm_build.cleanup_intermediates()
+    llvm_build.install_distribution()
+
+    # FileCheck / not / clang-repl register install() rules under the
+    # default "Unspecified" component, so they can't ride the
+    # distribution components install_distribution() drives. Copy them
+    # into bin/ by hand (same approach llvm-release uses for
+    # llvm-jitlink-executor) so consumers find them next to clang.
+    for tool in _INSTALLED_TOOLS:
+        src = build_dir / "bin" / tool
+        if not src.is_file():
+            print(f"build.py: warning: {tool} not found at {src}; "
+                  "consumer lit suites relying on it will fail.",
+                  file=sys.stderr)
+            continue
+        dst = out_dir / "install" / "bin" / tool
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(src, dst)
+        dst.chmod(dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    llvm_build.smoke()
+
+    print(f"build.py: done. SRC_COMMIT={src_commit}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/recipes/llvm-debug/recipe.yaml
+++ b/recipes/llvm-debug/recipe.yaml
@@ -1,0 +1,23 @@
+recipe: llvm-debug
+description: |
+  Clang/LLVM built from release/{version}.x with CMAKE_BUILD_TYPE=Debug
+  (-O0 -g) and assertions on. Distinct from llvm-release, which is
+  Release + asserts: this ships an unoptimised, fully-debuggable
+  toolchain for downstream `debug_build` CI rows (clad's, today) that
+  want to run against an assertions-and-debug-info LLVM without paying
+  the build cost inline on every run.
+
+  The install carries the LLVM test utilities FileCheck and `not`
+  alongside clang / llvm-config / clang-repl, so a consumer's lit suite
+  finds them under the recipe install prefix the same way it would find
+  them in a from-source LLVM build tree.
+
+  A Debug LLVM is large and slow to build; that is exactly why it lives
+  as its own recipe/cell (built and cached once) rather than a
+  llvm-release flag or an inline per-run build.
+
+# Only fields read by build_manifest.py live here; the cmake invocation
+# and the installed-tool list are authoritative in build.py.
+source:
+  repo: https://github.com/llvm/llvm-project
+  branch_template: release/{version}.x


### PR DESCRIPTION
Downstream debug_build CI rows want an assertions-enabled LLVM/Clang built with CMAKE_BUILD_TYPE=Debug (-O0 -g) so crashes surface with usable stacks and debug info. Until now there was no recipe for that: consumers (clad's debug row) cloned llvm-project and built LLVM from source inline on every run, which is slow and uncached, and impossible to reproduce locally via bin/repro in reasonable time.

Add an llvm-debug recipe that mirrors llvm-release but passes build_type=Debug, and expose it through setup-llvm as flavor 'debug'. base_cmake_args grows a build_type parameter (default Release, so llvm-release is unchanged) rather than duplicating the shared flag set. The recipe copies the LLVM test utilities FileCheck and `not` into the install alongside clang/llvm-config/clang-repl, since a consumer's lit suite expects them under the install prefix the same way a from-source build tree provides them in build/bin.

Register an llvm-debug cell at the latest supported major (LLVM 22, Linux x86_64) so the cell is warmed and published once instead of rebuilt per consumer run.