### PR TITLE
Add a Kokkos recipe and setup-kokkos action.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ would collide with the workflow's `mkdir`, and drops you into a
 shell inside the post-run container. On shell exit you're prompted
 to dump any in-container edits as a patch on the host.
 
-Iterate on a `ci-workflows` action without pushing:
+Iterate on a `ci-workflows` action or recipe without pushing:
 
 ```bash
 ~/sources/ci-workflows/bin/repro \
@@ -127,8 +127,14 @@ Iterate on a `ci-workflows` action without pushing:
     <row-name>
 ```
 
-Stage / temp-workflow files are cleaned at exit; disk after the
-run is zero (image cache aside). See `bin/repro --help` and
+`--ci-workflows` stages the local recipes and actions into the consumer
+repo and rewrites every ci-workflows action `uses:` — both the
+workflow's top-level ones and those nested inside a staged composite
+action (e.g. `setup-kokkos` → `setup-recipe`) — to the staged copy;
+`setup-recipe` sources recipes from the stage instead of git-fetching.
+So an un-pushed action or recipe is exercised end-to-end. Stage /
+temp-workflow files are cleaned at exit; disk after the run is zero
+(image cache aside). See `bin/repro --help` and
 [docs/developer-guide.md](docs/developer-guide.md) for the rest.
 
 ## Iterating on LLVM with a warm ccache: `--devshell`
@@ -178,11 +184,12 @@ Linux container, with the platform-mismatch overhead under Rosetta.
 ```
 recipes/<name>/
   recipe.yaml          metadata fields the manifest reads
-  build.sh             imperative build invoked by setup-recipe and publish-recipe
+  build.py|build.sh    imperative build invoked by setup-recipe and publish-recipe
   patches/             optional, applied to the source tree
 
 actions/
   setup-recipe/        consumer-side: probe → download or build-on-miss
+  setup-kokkos/        consumer-side: setup-recipe wrapper that installs Kokkos and exports Kokkos_ROOT
   publish-recipe/      producer-side: build under ccache + tar/zstd + upload
   wake-on-lan/         send a magic packet to wake a self-hosted runner; no-op under act
   lib/cache-io.sh      scheme-aware probe/download/upload helpers; sourced by both actions and the CLI

--- a/actions/setup-kokkos/action.yml
+++ b/actions/setup-kokkos/action.yml
@@ -1,0 +1,135 @@
+name: 'Setup Kokkos'
+description: |
+  Resolves a Kokkos install for consumer CI via the `kokkos` recipe: a
+  pinned Serial/Release source build that ships a working CMake package
+  config. Use this instead of an apt Kokkos -- libtrilinos-kokkos-dev is
+  the ancient Trilinos-bundled 3.4 (no host Kokkos::sqrt(double), only the
+  complex overloads) and the standalone libkokkos-dev ships a broken CMake
+  package config, so find_package(Kokkos) can consume neither.
+
+  The install lands at $GITHUB_WORKSPACE/kokkos -- a dedicated prefix, so
+  it coexists with setup-llvm's $GITHUB_WORKSPACE/install -- and Kokkos_ROOT
+  is exported via $GITHUB_ENV so a consumer's find_package(Kokkos) resolves
+  it with no further plumbing. Order relative to setup-llvm does not matter:
+  any pre-existing install/ is preserved across the recipe step, which
+  otherwise `rm -rf`s that path.
+
+inputs:
+  version:
+    required: false
+    default: '5.1.1'
+    description: 'Kokkos release tag to provision (interpolated into the recipe source branch).'
+  os:
+    required: true
+    description: |
+      OS slug for the recipe cache key -- a runner-image name like
+      "ubuntu-22.04" or "ubuntu-24.04-arm". Must match a cells.yaml entry
+      warmed for the kokkos recipe.
+  arch:
+    required: false
+    default: ''
+    description: |
+      Architecture slug (x86_64 / arm64). Derived from the os slug when
+      empty (ubuntu-*-arm -> arm64, else x86_64); pass explicitly on hosts
+      whose os slug doesn't carry the architecture.
+  build-on-miss:
+    required: false
+    default: 'false'
+    description: 'Forwarded to setup-recipe: build inline on a cache miss instead of failing fast.'
+  ref:
+    required: false
+    default: 'main'
+    description: 'ci-workflows ref for setup-recipe to read recipes/ from.'
+  cache-base:
+    required: false
+    default: ''
+    description: 'Forwarded to setup-recipe: override the recipe cache backend.'
+
+outputs:
+  prefix:
+    description: 'Kokkos install prefix ($GITHUB_WORKSPACE/kokkos).'
+    value: ${{ steps.finalize.outputs.prefix }}
+  kokkos-dir:
+    description: 'KokkosConfig.cmake directory.'
+    value: ${{ steps.finalize.outputs.kokkos-dir }}
+  cache-hit:
+    description: '"true" when the recipe came from the cache, "false" when built inline.'
+    value: ${{ steps.recipe.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve arch
+      id: resolve
+      shell: bash
+      env:
+        OS: ${{ inputs.os }}
+        ARCH_IN: ${{ inputs.arch }}
+      run: |
+        set -euo pipefail
+        if [[ -n "${ARCH_IN}" ]]; then
+          arch="${ARCH_IN}"
+        else
+          case "${OS}" in
+            *-arm) arch=arm64 ;;
+            *)     arch=x86_64 ;;
+          esac
+        fi
+        echo "arch=${arch}" >> "$GITHUB_OUTPUT"
+
+    # setup-recipe places the recipe at $GITHUB_WORKSPACE/install and
+    # `rm -rf`s that path first. Move any pre-existing install/ (e.g.
+    # setup-llvm's) aside so setup-kokkos is order-independent.
+    - name: Preserve existing install prefix
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -d "${GITHUB_WORKSPACE}/install" ]]; then
+          rm -rf "${GITHUB_WORKSPACE}/.install.pre-kokkos"
+          mv "${GITHUB_WORKSPACE}/install" "${GITHUB_WORKSPACE}/.install.pre-kokkos"
+        fi
+
+    - name: Kokkos recipe (cache or inline build)
+      id: recipe
+      uses: compiler-research/ci-workflows/actions/setup-recipe@main
+      with:
+        recipe:        kokkos
+        version:       ${{ inputs.version }}
+        os:            ${{ inputs.os }}
+        arch:          ${{ steps.resolve.outputs.arch }}
+        build-on-miss: ${{ inputs.build-on-miss }}
+        ref:           ${{ inputs.ref }}
+        cache-base:    ${{ inputs.cache-base }}
+
+    # Relocate Kokkos to a dedicated prefix and restore the preserved
+    # install/, so Kokkos and setup-llvm's LLVM coexist.
+    - name: Relocate Kokkos and restore install prefix
+      shell: bash
+      run: |
+        set -euo pipefail
+        rm -rf "${GITHUB_WORKSPACE}/kokkos"
+        mv "${GITHUB_WORKSPACE}/install" "${GITHUB_WORKSPACE}/kokkos"
+        if [[ -d "${GITHUB_WORKSPACE}/.install.pre-kokkos" ]]; then
+          mv "${GITHUB_WORKSPACE}/.install.pre-kokkos" "${GITHUB_WORKSPACE}/install"
+        fi
+
+    - name: Finalize outputs
+      id: finalize
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        RECIPE_HIT: ${{ steps.recipe.outputs.cache-hit }}
+      run: |
+        set -euo pipefail
+        prefix="${GITHUB_WORKSPACE}/kokkos"
+        # lib vs lib64 varies by distro; Kokkos_ROOT lets find_package
+        # resolve either, and Kokkos_DIR points straight at the config.
+        kdir="$(dirname "$(find "${prefix}" -name KokkosConfig.cmake | head -1)")"
+        echo "prefix=${prefix}"       >> "$GITHUB_OUTPUT"
+        echo "kokkos-dir=${kdir}"     >> "$GITHUB_OUTPUT"
+        echo "Kokkos_ROOT=${prefix}"  >> "$GITHUB_ENV"
+        if [[ -n "${kdir}" ]]; then
+          echo "Kokkos_DIR=${kdir}"   >> "$GITHUB_ENV"
+        fi
+        src=$([[ "${RECIPE_HIT}" == "true" ]] && echo recipe-cache || echo inline-build)
+        echo "::notice title=setup-kokkos::version=${VERSION} source=${src} prefix=${prefix}"

--- a/actions/setup-recipe/action.yml
+++ b/actions/setup-recipe/action.yml
@@ -102,13 +102,27 @@ runs:
         # `git remote add origin` ("remote already exists") since
         # `git init` is the only idempotent half of the pair.
         rm -rf __ci_workflows__
-        git init __ci_workflows__
-        cd __ci_workflows__
-        git remote add origin https://github.com/compiler-research/ci-workflows.git
-        git sparse-checkout init --no-cone
-        git sparse-checkout set recipes actions
-        git fetch --depth=1 origin "$REF"
-        git checkout FETCH_HEAD
+        # Local-checkout override: bin/repro --ci-workflows stages the
+        # dev's local ci-workflows tree (recipes + actions) into the
+        # consumer repo and exports CI_WORKFLOWS_LOCAL. Copy from there
+        # instead of fetching, so un-pushed recipe/action changes are
+        # exercised end-to-end. A relative value is resolved against
+        # GITHUB_WORKSPACE. Unset -> the normal git path below.
+        if [[ -n "${CI_WORKFLOWS_LOCAL:-}" ]]; then
+          src="${CI_WORKFLOWS_LOCAL}"
+          [[ "$src" != /* ]] && src="${GITHUB_WORKSPACE}/${src}"
+          mkdir -p __ci_workflows__
+          cp -r "$src/recipes" "$src/actions" __ci_workflows__/
+          echo "::notice title=setup-recipe::using local ci-workflows at $src (CI_WORKFLOWS_LOCAL)"
+        else
+          git init __ci_workflows__
+          cd __ci_workflows__
+          git remote add origin https://github.com/compiler-research/ci-workflows.git
+          git sparse-checkout init --no-cone
+          git sparse-checkout set recipes actions
+          git fetch --depth=1 origin "$REF"
+          git checkout FETCH_HEAD
+        fi
 
     - name: Compute key
       id: compute-key

--- a/bin/repro
+++ b/bin/repro
@@ -726,6 +726,12 @@ def build_act_command(args: argparse.Namespace) -> List[str]:
     cmd = [_require("act"), "-j", args.job]
     if args.workflow:
         cmd += ["-W", args.workflow]
+    if args.ci_workflows:
+        # Point setup-recipe at the local ci-workflows tree that
+        # _localize_workflow_for_ci_workflows staged, so un-pushed
+        # recipes build inline instead of being git-fetched from
+        # github. Path is relative to GITHUB_WORKSPACE in the container.
+        cmd += ["--env", f"CI_WORKFLOWS_LOCAL=.github/{_STAGE_DIR_NAME}/.repo"]
     # Default -P fallbacks for slugs act doesn't ship a mapping
     # for. Skip the slug if `~/.actrc` already maps it -- that's
     # the user's preferred image and command-line -P would silently
@@ -1837,7 +1843,7 @@ _STAGE_DIR_NAME = "act-ci-workflows-stage"
 def _localize_workflow_for_ci_workflows(
         workflow_path: Path, ci_workflows: Path) -> Path:
     """Stage the local ci-workflows actions under
-    `.github/.act-ci-workflows-stage/<name>` as symlinks, rewrite
+    `.github/.act-ci-workflows-stage/<name>` as copies, rewrite
     every `uses: compiler-research/ci-workflows/actions/<name>@<ref>`
     in `workflow_path` to `uses: ./.github/.act-ci-workflows-stage/
     <name>` (act's local-action form), and return the path to a
@@ -1849,10 +1855,10 @@ def _localize_workflow_for_ci_workflows(
         no `~/.cache/act/` involvement.
       - `<path>` must be inside the consumer's repo (act resolves
         relative to cwd / the workflow's repo root), so we stage
-        symlinks under `.github/`.
-      - Each ci-workflows action becomes its own symlink target
-        rather than the whole repo, so consumers reading the temp
-        workflow see a clean stage layout.
+        under `.github/`.
+      - Each ci-workflows action is copied individually, not the
+        whole repo -- act does not follow directory symlinks for
+        local actions, and a per-action layout keeps the stage clean.
     """
     consumer = Path.cwd()
     stage = consumer / ".github" / _STAGE_DIR_NAME
@@ -1874,13 +1880,32 @@ def _localize_workflow_for_ci_workflows(
         # of symlinking. Each action is a few small files; fast.
         shutil.copytree(action_dir, stage / action_dir.name)
 
-    text = workflow_path.read_text()
     rel = f"./.github/{_STAGE_DIR_NAME}"
-    text = re.sub(
-        r"uses:\s*compiler-research/ci-workflows/actions/(\w[\w-]*)@\S+",
-        lambda m: f"uses: {rel}/{m.group(1)}",
-        text,
-    )
+    nested_re = re.compile(
+        r"uses:\s*compiler-research/ci-workflows/actions/(\w[\w-]*)@\S+")
+
+    # Rewrite nested `uses:` inside the staged actions too: a composite
+    # action that calls another ci-workflows action (e.g. setup-kokkos ->
+    # setup-recipe) must resolve to the local staged copy, else act fetches
+    # it from github and the local change under test is bypassed.
+    for staged in stage.iterdir():
+        ay = staged / "action.yml"
+        if ay.is_file():
+            ay.write_text(nested_re.sub(
+                lambda m: f"uses: {rel}/{m.group(1)}", ay.read_text()))
+
+    # Also stage a full recipes+actions tree under .repo/ so setup-recipe
+    # can source un-pushed recipes locally (it reads __ci_workflows__/
+    # {recipes,actions}) instead of git-fetching from github. The run
+    # flow exports CI_WORKFLOWS_LOCAL=.github/<stage>/.repo to point at it.
+    repo_stage = stage / ".repo"
+    for sub in ("recipes", "actions"):
+        src = ci_workflows / sub
+        if src.is_dir():
+            shutil.copytree(src, repo_stage / sub)
+
+    text = workflow_path.read_text()
+    text = nested_re.sub(lambda m: f"uses: {rel}/{m.group(1)}", text)
     fd, tmp = tempfile.mkstemp(
         prefix=f"act-{workflow_path.stem}-localized-",
         suffix=".yml", dir=str(workflow_path.parent),
@@ -1893,7 +1918,7 @@ def _localize_workflow_for_ci_workflows(
 
 
 def _cleanup_ci_workflows_overlay() -> None:
-    """Remove the .github/.act-ci-workflows-stage/ symlink tree and
+    """Remove the .github/.act-ci-workflows-stage/ staging tree and
     any act-*-localized-*.yml temp workflow we wrote. Idempotent;
     best-effort."""
     consumer = Path.cwd()

--- a/bin/test_repro.py
+++ b/bin/test_repro.py
@@ -39,7 +39,7 @@ repro = _load_repro()
 def _ns(**kw) -> argparse.Namespace:
     defaults = dict(list=False, job=None, workflow=None, matrix=[],
                     shell=True, save_temps=False, dry_run=False,
-                    passthrough=[])
+                    passthrough=[], ci_workflows=None)
     defaults.update(kw)
     return argparse.Namespace(**defaults)
 
@@ -67,6 +67,18 @@ class BuildActCommandTests(unittest.TestCase):
         cmd = repro.build_act_command(_ns(job="test", shell=False))
         self.assertEqual(cmd[:3], ["act", "-j", "test"])
         self.assertNotIn("--reuse", cmd)
+
+    def test_ci_workflows_exports_local_env(self):
+        # --ci-workflows must point setup-recipe at the staged tree via
+        # CI_WORKFLOWS_LOCAL; without it, no such --env is emitted.
+        with_cw = repro.build_act_command(
+            _ns(job="build", shell=False, ci_workflows=Path("x")))
+        self.assertIn(
+            f"CI_WORKFLOWS_LOCAL=.github/{repro._STAGE_DIR_NAME}/.repo",
+            with_cw)
+        without = repro.build_act_command(_ns(job="build", shell=False))
+        self.assertFalse(any(a.startswith("CI_WORKFLOWS_LOCAL=")
+                             for a in without))
 
     def test_workflow_passes_dash_W(self):
         cmd = repro.build_act_command(
@@ -1858,6 +1870,69 @@ class DevshellEnsureContainerArgvTests(unittest.TestCase):
         self.assertIn(
             "DEVSHELL_AI_REPO_ENCODED=-Users-v-work-CppInterOp2", argv)
         self.assertIn(f"HOME={self.repro.DEVSHELL_DEV_HOME}", argv)
+
+
+# ---------------------------------------------------------------------------
+# --ci-workflows local staging (_localize_workflow_for_ci_workflows)
+# ---------------------------------------------------------------------------
+
+class LocalizeWorkflowTests(unittest.TestCase):
+    """Staging must rewrite every ci-workflows action `uses:` -- top-level
+    and nested -- to the local copy, and stage a recipes+actions tree for
+    setup-recipe, so an un-pushed change is exercised instead of fetched."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        # A local ci-workflows checkout: a composite action that nests
+        # another ci-workflows action, plus a recipe.
+        self.ci = root / "ci-workflows"
+        (self.ci / "actions" / "setup-kokkos").mkdir(parents=True)
+        (self.ci / "actions" / "setup-recipe").mkdir(parents=True)
+        (self.ci / "recipes" / "kokkos").mkdir(parents=True)
+        (self.ci / "actions" / "setup-kokkos" / "action.yml").write_text(
+            "runs:\n  steps:\n    - uses: compiler-research/ci-workflows/"
+            "actions/setup-recipe@main\n")
+        (self.ci / "actions" / "setup-recipe" / "action.yml").write_text(
+            "runs:\n  using: composite\n")
+        (self.ci / "recipes" / "kokkos" / "recipe.yaml").write_text(
+            "name: kokkos\n")
+        # A consumer repo whose workflow uses the composite action.
+        self.consumer = root / "consumer"
+        wf_dir = self.consumer / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        self.workflow = wf_dir / "ci.yml"
+        self.workflow.write_text(
+            "jobs:\n  build:\n    steps:\n      - uses: compiler-research/"
+            "ci-workflows/actions/setup-kokkos@main\n")
+        # _localize reads Path.cwd() as the consumer repo root.
+        self._cwd = os.getcwd()
+        os.chdir(self.consumer)
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+        self._tmp.cleanup()
+
+    def test_stages_and_rewrites_local_tree(self):
+        localized = repro._localize_workflow_for_ci_workflows(
+            self.workflow, self.ci)
+        stage = self.consumer / ".github" / repro._STAGE_DIR_NAME
+        rel = f"./.github/{repro._STAGE_DIR_NAME}"
+
+        # The composite action is staged locally (copied, not fetched) and
+        # its nested ci-workflows `uses:` now resolves to the staged copy.
+        nested = (stage / "setup-kokkos" / "action.yml").read_text()
+        self.assertIn(f"uses: {rel}/setup-recipe", nested)
+        self.assertNotIn("compiler-research/ci-workflows", nested)
+        # A recipes+actions tree is staged under .repo/ for setup-recipe to
+        # source via CI_WORKFLOWS_LOCAL instead of git-fetching.
+        self.assertTrue((stage / ".repo" / "recipes" / "kokkos").is_dir())
+        self.assertTrue((stage / ".repo" / "actions" / "setup-recipe").is_dir())
+        # The top-level `uses:` is rewritten in the temp workflow, and the
+        # original workflow is left untouched.
+        self.assertIn(f"uses: {rel}/setup-kokkos", localized.read_text())
+        self.assertIn("compiler-research/ci-workflows",
+                      self.workflow.read_text())
 
 
 if __name__ == "__main__":

--- a/cells.yaml
+++ b/cells.yaml
@@ -92,3 +92,12 @@ cells:
   - { recipe: llvm-root, version: 'ROOT-llvm20',   os: macos-26,        arch: arm64  }
   - { recipe: llvm-root, version: 'ROOT-llvm20',   os: macos-26-intel,  arch: x86_64 }
   - { recipe: llvm-root, version: 'ROOT-llvm20',   os: windows-2025,    arch: x86_64 }
+  # kokkos: pinned Serial/Release Kokkos for clad's *-kokkos rows. The apt
+  # Kokkos is unusable -- libtrilinos-kokkos-dev is the ancient Trilinos-
+  # bundled 3.4 (no host Kokkos::sqrt(double), only the complex overloads),
+  # and standalone libkokkos-dev ships a broken CMake package config -- so
+  # those rows consume this recipe instead. Because it is a source build,
+  # the rows keep their existing runner images: clad's non-arm kokkos row is
+  # ubuntu-22.04 (x86_64), its arm row ubuntu-24.04-arm.
+  - { recipe: kokkos,     version: '5.1.1',        os: ubuntu-22.04,     arch: x86_64 }
+  - { recipe: kokkos,     version: '5.1.1',        os: ubuntu-24.04-arm, arch: arm64  }

--- a/recipes/kokkos/build.py
+++ b/recipes/kokkos/build.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Builds a Kokkos install tree from a tagged release (Serial, Release).
+
+The install ships Kokkos's CMake package config so consumers
+find_package(Kokkos) and link Kokkos::kokkos. See recipe.yaml for why this
+is a source build and not an apt package.
+
+Serial-only is deliberate: it keeps the build ~1 minute and avoids the
+OpenMP backend (Ubuntu's libkokkos-dev is OpenMP-enabled, which forces
+every consumer TU onto -fopenmp). Kokkos is built with the consumer's
+compiler when CXX is set in the environment -- clad's *-kokkos rows are
+all clang, and building Kokkos with the same compiler keeps its recorded
+compiler check happy.
+
+Inputs (env): see actions/lib/llvm_build.py docstring for the
+RECIPE_VERSION / WORK_DIR / OUT_DIR / NCPUS contract.
+
+Outputs (env, written to GITHUB_ENV when present):
+  SRC_COMMIT   sha of the Kokkos tag that was built.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / ".." / ".." / "actions" / "lib"))
+
+import llvm_build  # noqa: E402
+
+KOKKOS_REPO = "https://github.com/kokkos/kokkos.git"
+
+
+def _compiler_args() -> list[str]:
+    """Build Kokkos with the consumer's compiler when the environment names
+    one, so Kokkos's installed compiler check matches at find_package time."""
+    args = []
+    if os.environ.get("CXX"):
+        args.append(f"-DCMAKE_CXX_COMPILER={os.environ['CXX']}")
+    if os.environ.get("CC"):
+        args.append(f"-DCMAKE_C_COMPILER={os.environ['CC']}")
+    return args
+
+
+def _verify_find_package(prefix: Path, ncpus: str) -> None:
+    """Post-install smoke: a fresh project can find_package(Kokkos) and call
+    the host math (Kokkos::sqrt(double)) the apt packages can't provide.
+    Catches the broken-CMake-config failure mode the apt route hits, and a
+    compiler mismatch, before the cell is published."""
+    smoke = prefix.parent / "smoke"
+    smoke.mkdir(exist_ok=True)
+    (smoke / "m.cpp").write_text(textwrap.dedent("""\
+        #include <Kokkos_Core.hpp>
+        double f(double x, double y) {
+          return Kokkos::sqrt(x * x + 1.0) * Kokkos::cos(y) + Kokkos::sin(x * y);
+        }
+        int main() { return 0; }
+        """))
+    (smoke / "CMakeLists.txt").write_text(textwrap.dedent("""\
+        cmake_minimum_required(VERSION 3.20)
+        project(smoke CXX)
+        find_package(Kokkos REQUIRED)
+        add_executable(smoke m.cpp)
+        target_link_libraries(smoke Kokkos::kokkos)
+        """))
+    subprocess.run(
+        ["cmake", "-S", str(smoke), "-B", str(smoke / "b"),
+         f"-DKokkos_ROOT={prefix}", *_compiler_args()],
+        check=True,
+    )
+    subprocess.run(["cmake", "--build", str(smoke / "b"), "-j", ncpus],
+                   check=True)
+    print("build.py: find_package(Kokkos) + host-math smoke ok", flush=True)
+
+
+def main() -> int:
+    llvm_build.setup_env()
+    work_dir = Path(os.environ["WORK_DIR"])
+    out_dir = Path(os.environ["OUT_DIR"])
+    version = os.environ["RECIPE_VERSION"]
+    ncpus = os.environ["NCPUS"]
+
+    src = work_dir / "kokkos"
+    llvm_build.clone_shallow(KOKKOS_REPO, version, src)
+    llvm_build.record_src_commit(src)
+
+    prefix = out_dir / "install"
+    build = work_dir / "build"
+    cmake_args = [
+        "cmake", "-S", str(src), "-B", str(build),
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DKokkos_ENABLE_SERIAL=ON",
+        f"-DCMAKE_INSTALL_PREFIX={prefix}",
+        *_compiler_args(),
+    ]
+    print("build.py: " + " ".join(cmake_args), flush=True)
+    subprocess.run(cmake_args, check=True)
+    subprocess.run(
+        ["cmake", "--build", str(build), "--target", "install", "-j", ncpus],
+        check=True,
+    )
+    _verify_find_package(prefix, ncpus)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/recipes/kokkos/recipe.yaml
+++ b/recipes/kokkos/recipe.yaml
@@ -1,0 +1,26 @@
+recipe: kokkos
+description: |
+  Kokkos built from a tagged release (Serial backend, Release), installed
+  with its CMake package config so consumers find_package(Kokkos) and link
+  Kokkos::kokkos.
+
+  Why a source recipe rather than an apt package: Ubuntu's
+  libtrilinos-kokkos-dev is the Trilinos-bundled Kokkos 3.4, which predates
+  Kokkos's host MathematicalFunctions -- there is no Kokkos::sqrt(double),
+  only the Kokkos::complex overloads, so any host-math kernel fails to
+  compile. The standalone libkokkos-dev is newer (3.7 on Ubuntu 24.04, 5.x
+  on Debian sid) but ships a broken CMake package config (the imported
+  Kokkos::kokkos target references a non-existent include path on 24.04; a
+  KokkosTargets error on sid), so find_package(Kokkos) fails outright. A
+  pinned source build is the only reliable path to a modern,
+  find_package-able Kokkos in CI.
+
+  Serial-only keeps the build to ~1 minute and avoids the OpenMP-backend
+  requirement that Ubuntu's libkokkos-dev forces on every consumer TU.
+
+# Only fields read by build_manifest.py live here; the cmake invocation is
+# authoritative in build.py. Kokkos tags the release itself (no prefix), so
+# the version input is the tag, e.g. "5.1.1".
+source:
+  repo: https://github.com/kokkos/kokkos
+  branch_template: '{version}'


### PR DESCRIPTION
clad's *-kokkos CI rows install Kokkos from apt, but neither option is usable. libtrilinos-kokkos-dev is the Trilinos-bundled Kokkos 3.4, which predates the host MathematicalFunctions -- there is no Kokkos::sqrt(double), only the complex overloads, so any host-math kernel fails to compile. The standalone libkokkos-dev is newer but ships a broken CMake package config (a non-existent include path on Ubuntu 24.04, a KokkosTargets error on Debian sid), so find_package(Kokkos) fails outright.

Add a kokkos recipe that builds a pinned tag from source (Serial, Release) and installs a working CMake package config, plus a post-install find_package + Kokkos::sqrt(double) smoke so a broken cell never publishes. cells.yaml warms 5.1.1 for clad's two rows, ubuntu-22.04 (x86_64) and ubuntu-24.04-arm. A setup-kokkos composite action wraps setup-recipe, relocates Kokkos to a dedicated prefix (preserving any setup-llvm install/ so the two coexist), and exports Kokkos_ROOT via GITHUB_ENV so find_package(Kokkos) resolves it with no further plumbing.

Developing that recipe and action against a consumer's CI needs a way to test un-pushed changes. --ci-workflows already staged local actions and rewrote a workflow's top-level `uses:`, but setup-recipe still git-fetched recipes, and a composite action's nested `uses:` of another ci-workflows action (setup-kokkos -> setup-recipe) still resolved to github. Stage a full recipes+actions tree under .repo/ and export CI_WORKFLOWS_LOCAL so setup-recipe sources recipes locally, rewrite each nested ci-workflows action `uses:` in the staged actions, and cover the staging in bin/test_repro.py -- so a recipe or action change is exercised end-to-end before it is pushed.