### PR TITLE
[llvm-root] Track ROOT's move to LLVM 22.

### DIFF
--- a/.github/workflows/cppjit.yml
+++ b/.github/workflows/cppjit.yml
@@ -38,7 +38,7 @@ on:
       llvm-flavor-version:
         type: string
         default: ''
-        description: "setup-llvm flavor-version (e.g. 'cling-llvm20' for flavor:cling); empty otherwise."
+        description: "setup-llvm flavor-version (e.g. 'cling-llvm22' for flavor:cling); empty otherwise."
       python-version:
         type: string
         required: true

--- a/.github/workflows/publish-recipe.yml
+++ b/.github/workflows/publish-recipe.yml
@@ -31,7 +31,7 @@ on:
         type: string
         required: true
       version:
-        description: "Version/flavor as in cells.yaml (e.g. '22', 'ROOT-llvm20', 'cling-llvm20')."
+        description: "Version/flavor as in cells.yaml (e.g. '22', 'ROOT-llvm22', 'cling-llvm22')."
         type: string
         required: true
         default: '22'

--- a/actions/setup-llvm/action.yml
+++ b/actions/setup-llvm/action.yml
@@ -75,7 +75,7 @@ inputs:
     default: ''
     description: |
       Overrides the recipe `version` input for variant flavors. For
-      flavor=cling: 'cling-llvm20' or 'ROOT-llvm20' (selects branch on
+      flavor=cling: 'cling-llvm22' or 'ROOT-llvm22' (selects branch on
       root-project/llvm-project). Defaults to `version` when empty.
   build-on-miss:
     required: false

--- a/cells.yaml
+++ b/cells.yaml
@@ -81,17 +81,20 @@ cells:
   # llvm-root: `version` doubles as a flavor selector and substitutes
   # into recipes/llvm-root/recipe.yaml's branch_template. Two flavors
   # track root-project/llvm-project's paired branches:
-  #   cling-llvm20 = cling's patches alone (CppInterOp's cppyy/cling row).
+  #   cling-llvm22 = cling's patches alone (CppInterOp's cppyy/cling row).
   #                  Linux-only today; macOS / Windows cling rows still
-  #                  share the ROOT-llvm20 superset to keep one cell warm.
-  #   ROOT-llvm20  = cling + ROOT's extra clang patches. Built across
+  #                  share the ROOT-llvm22 superset to keep one cell warm.
+  #   ROOT-llvm22  = cling + ROOT's extra clang patches. Built across
   #                  the full CppInterOp matrix so every cling-using
   #                  consumer has a ready cell.
-  - { recipe: llvm-root, version: 'cling-llvm20',  os: ubuntu-24.04,    arch: x86_64 }
-  - { recipe: llvm-root, version: 'ROOT-llvm20',   os: ubuntu-24.04,    arch: x86_64 }
-  - { recipe: llvm-root, version: 'ROOT-llvm20',   os: macos-26,        arch: arm64  }
-  - { recipe: llvm-root, version: 'ROOT-llvm20',   os: macos-26-intel,  arch: x86_64 }
-  - { recipe: llvm-root, version: 'ROOT-llvm20',   os: windows-2025,    arch: x86_64 }
+  # The llvm20 pair is gone: ROOT moved to LLVM 22, cling's master
+  # followed, and recipe.yaml's branch_template carries one date stamp
+  # for both flavors -- so the two majors cannot be warm at once.
+  - { recipe: llvm-root, version: 'cling-llvm22',  os: ubuntu-24.04,    arch: x86_64 }
+  - { recipe: llvm-root, version: 'ROOT-llvm22',   os: ubuntu-24.04,    arch: x86_64 }
+  - { recipe: llvm-root, version: 'ROOT-llvm22',   os: macos-26,        arch: arm64  }
+  - { recipe: llvm-root, version: 'ROOT-llvm22',   os: macos-26-intel,  arch: x86_64 }
+  - { recipe: llvm-root, version: 'ROOT-llvm22',   os: windows-2025,    arch: x86_64 }
   # kokkos: pinned Serial/Release Kokkos for clad's *-kokkos rows. The apt
   # Kokkos is unusable -- libtrilinos-kokkos-dev is the ancient Trilinos-
   # bundled 3.4 (no host Kokkos::sqrt(double), only the complex overloads),

--- a/recipes/llvm-root/build.py
+++ b/recipes/llvm-root/build.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Builds an LLVM/Clang install tree against root-project/llvm-project's
-cling-llvm20 / ROOT-llvm20 branches. Source repo and branch template
+cling-llvm22 / ROOT-llvm22 branches. Source repo and branch template
 are read from recipe.yaml so a tag bump there is the single point of
 edit.
 
@@ -15,8 +15,8 @@ of this install. See recipe.yaml for the why.
 Inputs (env): see actions/lib/llvm_build.py docstring.
   RECIPE_VERSION         flavor selector. Substitutes into
                          recipe.yaml's source.branch_template
-                         ({version} → branch). Today: 'cling-llvm20'
-                         or 'ROOT-llvm20'. Factored into the cache
+                         ({version} → branch). Today: 'cling-llvm22'
+                         or 'ROOT-llvm22'. Factored into the cache
                          key so each flavor has its own asset.
 
 Outputs (env, written to GITHUB_ENV when present):

--- a/recipes/llvm-root/recipe.yaml
+++ b/recipes/llvm-root/recipe.yaml
@@ -1,11 +1,11 @@
 recipe: llvm-root
 description: |
-  LLVM/Clang built against root-project/llvm-project's cling-llvm20
-  (cling's patches alone) or ROOT-llvm20 (cling's patches + ROOT's
+  LLVM/Clang built against root-project/llvm-project's cling-llvm22
+  (cling's patches alone) or ROOT-llvm22 (cling's patches + ROOT's
   extra clang patches) branches. Consumed via setup-recipe by:
-    - CppInterOp's cppyy/cling rows (need cling-llvm20; build cling
+    - CppInterOp's cppyy/cling rows (need cling-llvm22; build cling
       themselves on top),
-    - CppInterOp's ROOT integration job (needs ROOT-llvm20; ROOT
+    - CppInterOp's ROOT integration job (needs ROOT-llvm22; ROOT
       builds its own bundled cling on top).
   Each flavor maps to a `version` value below; the cache key
   partitions on it, so the same recipe directory ships two distinct
@@ -23,9 +23,11 @@ description: |
 
 # `version` doubles as the flavor selector here — each value maps to a
 # branch on root-project/llvm-project under the same date-stamped
-# ladder (currently 20260408-01). When ROOT or cling cuts a new patch
+# ladder (currently 20260619-01). When ROOT or cling cuts a new patch
 # set, edit the date stamp here; the cache key moves and the new
-# asset republishes for both flavors.
+# asset republishes for both flavors. One stamp serves both flavors,
+# so they must move together — and the LLVM major moves with them,
+# since the ladder is per-major (…-llvm20-* vs …-llvm22-*).
 source:
   repo: https://github.com/root-project/llvm-project
-  branch_template: '{version}-20260408-01'
+  branch_template: '{version}-20260619-01'


### PR DESCRIPTION
ROOT and cling both moved to LLVM 22, and cling's master -- which setup-llvm's cling-on-top step clones by default -- expects it now, so the warm cells were serving an LLVM their consumers no longer build against. root-project/llvm-project carries the paired llvm22 branches under a single new stamp, 20260619-01.

Point the branch template at that stamp and move the five cells to cling-llvm22 / ROOT-llvm22. The llvm20 pair cannot stay warm alongside: recipe.yaml holds one stamp for both flavors and the ladder is per-major, so the two majors are mutually exclusive by construction.

Consumers naming the old flavors -- CppInterOp's cling, cppyy and ROOT rows pass flavor-version: 'cling-llvm20' / 'ROOT-llvm20' -- have to move to the llvm22 values in the same window. build-on-miss is off by default, so until they do they fail fast on an unwarmed cell rather than rebuilding LLVM inline.