### PR TITLE
[llvm-release] Publish an LLVM 23 release-candidate cell.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -186,6 +186,13 @@ jobs:
         shell: bash
         working-directory: bin
         run: python3 -W error::ResourceWarning -m unittest discover -p 'test_*.py' -v
+      # Recipe build scripts are covered per directory, like the above:
+      # they are not packages and each is named build.py, so one
+      # discovery run over recipes/ would collide on the module name.
+      - name: recipes/llvm-release unit tests
+        shell: bash
+        working-directory: recipes/llvm-release
+        run: python3 -W error::ResourceWarning -m unittest discover -p 'test_*.py' -v
 
   # End-to-end dry-run of the real publish-recipe action against the
   # llvm-dry-run fixture recipe with cache-base: file:///... so no

--- a/actions/publish-recipe/build_manifest.py
+++ b/actions/publish-recipe/build_manifest.py
@@ -161,8 +161,14 @@ def build_manifest(recipe: str, version: str, os_: str, arch: str,
     build_script_name = bs.name if bs is not None else "unknown"
 
     repo = _grep_yaml_value(yaml_path, "repo") or "unknown"
-    branch_tpl = _grep_yaml_value(yaml_path, "branch_template") or ""
-    branch = branch_tpl.replace("{version}", version) if branch_tpl else "unknown"
+    # Prefer the ref the build script actually cloned. Substituting the
+    # version into branch_template only describes recipes where the two
+    # match: a tag-pinned llvm-release cell would read as the branch
+    # release/23.1.0-rc2.x.
+    branch = os.environ.get("SRC_REF", "")
+    if not branch:
+        branch_tpl = _grep_yaml_value(yaml_path, "branch_template") or ""
+        branch = branch_tpl.replace("{version}", version) if branch_tpl else "unknown"
 
     return {
         "key": key,

--- a/actions/publish-recipe/test_build_manifest.py
+++ b/actions/publish-recipe/test_build_manifest.py
@@ -125,6 +125,35 @@ class BuildManifestTests(unittest.TestCase):
             )
             self.assertEqual(m["source"]["branch"], "ROOT-llvm20-some-tag")
 
+    def test_src_ref_wins_over_branch_template(self):
+        """A recipe that resolves its own ref reports that ref.
+
+        llvm-release maps a bare major to release/N.x but a dotted
+        version to the llvmorg tag, so substituting the version into
+        branch_template would name a branch that does not exist.
+        """
+        with tempfile.TemporaryDirectory() as d, \
+             mock.patch.dict(os.environ,
+                             {"SRC_REF": "llvmorg-23.1.0-rc2"}, clear=True):
+            _make_recipe(Path(d), "r",
+                         branch_template="release/{version}.x")
+            m = build_manifest.build_manifest(
+                "r", "23.1.0-rc2", "ubuntu-24.04", "x86_64", "k",
+                recipe_root=d,
+            )
+            self.assertEqual(m["source"]["branch"], "llvmorg-23.1.0-rc2")
+
+    def test_empty_src_ref_falls_back_to_template(self):
+        with tempfile.TemporaryDirectory() as d, \
+             mock.patch.dict(os.environ, {"SRC_REF": ""}, clear=True):
+            _make_recipe(Path(d), "r",
+                         branch_template="release/{version}.x")
+            m = build_manifest.build_manifest(
+                "r", "22", "ubuntu-24.04", "x86_64", "k",
+                recipe_root=d,
+            )
+            self.assertEqual(m["source"]["branch"], "release/22.x")
+
     def test_build_py_recipe(self):
         with tempfile.TemporaryDirectory() as d, \
              mock.patch.dict(os.environ, {}, clear=True):

--- a/cells.yaml
+++ b/cells.yaml
@@ -20,6 +20,10 @@
 support_window:
   - 20
   - 22
+  # 23 is pre-release: release/23.x is cut and tagging candidates, no
+  # final yet. It is in the window because consumers test against it
+  # early; the cell that serves it is pinned to a tag, see below.
+  - 23
 
 caps:
   # Soft cap: prune-cache emits ::warning:: when total Release storage
@@ -78,6 +82,16 @@ cells:
   # bug) only surface on a 32-bit MSVC build.
   - { recipe: llvm-release, version: '22',         os: windows-2025,     arch: x86    }
   - { recipe: llvm-release, version: '22',         os: windows-11-arm,   arch: arm64  }
+  # Release candidate, so consumers meet an API break before the
+  # release rather than after: no package manager ships a major until
+  # it is final. Pinned to the tag rather than '23' -- release/23.x
+  # moves while the key does not, so a branch-tracking cell freezes
+  # silently under a name claiming the whole line. Bumping to rc3 is a
+  # one-line edit that moves the key and republishes. Consumers keep
+  # clang-runtime '23' and pass the tag as setup-llvm's flavor-version.
+  # Linux x86_64 only; every other platform is a full LLVM build, so
+  # add rows when a consumer needs one.
+  - { recipe: llvm-release, version: '23.1.0-rc2', os: ubuntu-24.04,     arch: x86_64 }
   # llvm-root: `version` doubles as a flavor selector and substitutes
   # into recipes/llvm-root/recipe.yaml's branch_template. Two flavors
   # track root-project/llvm-project's paired branches:

--- a/recipes/llvm-release/build.py
+++ b/recipes/llvm-release/build.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Builds a vanilla Clang/LLVM install tree from release/{version}.x.
+"""Builds a vanilla Clang/LLVM install tree from an upstream LLVM ref.
 
 Recipe-specific bits live here (source clone, cmake flags, ninja
 targets, post-install hooks). The shared install-tree publish flow
@@ -8,11 +8,13 @@ install-distribution, find_package smoke) lives in
 actions/lib/llvm_build.py.
 
 Inputs (env): see actions/lib/llvm_build.py docstring.
-  RECIPE_VERSION         major LLVM version (release/{version}.x).
+  RECIPE_VERSION         LLVM major ('22'), or a release tag suffix
+                         ('23.1.0-rc2'). See _source_ref.
   RECIPE_ARCH            optional cell arch slug for cross compilation
 
 Outputs (env, written to GITHUB_ENV when present):
   SRC_COMMIT             sha of llvm-project HEAD that was built
+  SRC_REF                the ref that sha was cloned from
 
 FIXME: dedup with recipes/llvm-asan/build.py.
 The compiler-rt OFF flags below and the _oop_targets() helper are
@@ -46,6 +48,34 @@ import llvm_build  # noqa: E402
 # LLVM test utilities a consumer's lit suite resolves under the recipe
 # install prefix ($LLVM/bin/FileCheck; a few RUN lines use count/not).
 _LIT_UTILS = ["FileCheck", "count", "not"]
+
+
+def _source_ref(version: str) -> str:
+    """Map the recipe version to a ref on llvm/llvm-project.
+
+    A bare major ('22') tracks release/22.x, which keeps moving as
+    point releases land; the key covers the version, not the commit,
+    so such a cell holds whatever HEAD it warmed on. Anything else is
+    an upstream tag ('23.1.0-rc2' -> llvmorg-23.1.0-rc2), immutable,
+    so the cell names exactly what it holds.
+    """
+    if re.fullmatch(r"\d+", version):
+        return f"release/{version}.x"
+    return f"llvmorg-{version}"
+
+
+def _record_src_ref(ref: str) -> None:
+    """Publish the cloned ref as SRC_REF for the manifest step.
+
+    build_manifest.py otherwise rebuilds source.branch from
+    recipe.yaml's branch_template, which describes the bare-major form
+    only.
+    """
+    github_env = os.environ.get("GITHUB_ENV", "")
+    if not github_env:
+        return
+    with open(github_env, "a") as f:
+        f.write(f"SRC_REF={ref}\n")
 
 
 def _oop_targets(build_dir: Path) -> list[str]:
@@ -83,22 +113,23 @@ def main() -> int:
     version = os.environ["RECIPE_VERSION"]
     ncpus = os.environ["NCPUS"]
 
-    # Parse + validate the LLVM major before any side effects.
+    # Parse + validate the LLVM major before any side effects; the
+    # prefix reads the same out of '22' and out of '23.1.0-rc2'.
     # The threshold (>= 22) governs the OOP-JIT compiler-rt branch;
     # the previous form silently fell back to need_oop=False on any
     # ValueError, which produced an artifact without the OOP runtime
     # when the caller passed a non-integer version (e.g. '22.1') —
     # exactly the consumers most likely to need OOP. Parse the major
-    # prefix and refuse anything that doesn't yield an integer; the
-    # recipe's source.branch_template also assumes integer-major
-    # releases (release/{version}.x), so erroring here surfaces the
-    # misuse before any git operation.
+    # prefix and refuse anything that doesn't yield an integer, so the
+    # misuse surfaces before any git operation rather than as a clone
+    # against a ref nobody publishes.
     try:
         major = int(version.split('.')[0])
     except ValueError:
         print(
-            f"::error::recipe llvm-release expects an integer-like "
-            f"version (e.g. '22' or '22.1'); got '{version}'",
+            f"::error::recipe llvm-release expects an LLVM major "
+            f"(e.g. '22') or a release tag suffix (e.g. '23.1.0-rc2'); "
+            f"got '{version}'",
             file=sys.stderr,
         )
         return 1
@@ -109,12 +140,15 @@ def main() -> int:
     need_oop = major >= 22 and not win32
 
     os.chdir(work_dir)
+    src_ref = _source_ref(version)
+    print(f"build.py: version={version}; cloning {src_ref}", flush=True)
     llvm_build.clone_shallow(
         "https://github.com/llvm/llvm-project.git",
-        f"release/{version}.x",
+        src_ref,
         work_dir / "llvm-project",
     )
     src_commit = llvm_build.record_src_commit(work_dir / "llvm-project")
+    _record_src_ref(src_ref)
 
     build_dir = work_dir / "llvm-project" / "build"
     build_dir.mkdir(exist_ok=True)

--- a/recipes/llvm-release/recipe.yaml
+++ b/recipes/llvm-release/recipe.yaml
@@ -19,6 +19,12 @@ description: |
   Windows cells (arch: x86) skip compiler-rt: orc_rt's COFF support
   is x86_64-only and the OOP-JIT is disabled on Windows consumers.
 
+# branch_template describes the bare-major form only. build.py owns the
+# mapping (_source_ref): '22' is release/22.x, anything else is the
+# upstream release tag, so '23.1.0-rc2' pins llvmorg-23.1.0-rc2 and a
+# release candidate can be published under its own name. The resolved
+# ref reaches the manifest as SRC_REF rather than through this template.
+#
 # Only fields read by build_manifest.py live here. The cmake invocation
 # and trim list are authoritative in build.py — having them duplicated
 # here as decorative metadata would silently drift. Add a field here

--- a/recipes/llvm-release/test_build.py
+++ b/recipes/llvm-release/test_build.py
@@ -1,0 +1,66 @@
+"""Unit tests for the llvm-release recipe's ref resolution.
+
+Loaded by path rather than imported: recipe directories are not
+packages ('llvm-release' is not an identifier), and every recipe's
+build script is called build.py, so a plain import would collide
+across recipes in sys.modules.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_SPEC = importlib.util.spec_from_file_location(
+    "llvm_release_build", Path(__file__).resolve().parent / "build.py")
+build = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(build)
+
+
+class SourceRefTests(unittest.TestCase):
+    """A cell's version selects between a moving branch and a fixed tag,
+    so getting the split wrong publishes an artifact under a name that
+    describes something else."""
+
+    def test_bare_major_tracks_the_release_branch(self):
+        self.assertEqual(build._source_ref("22"), "release/22.x")
+        self.assertEqual(build._source_ref("23"), "release/23.x")
+
+    def test_dotted_version_pins_the_llvmorg_tag(self):
+        self.assertEqual(build._source_ref("23.1.0-rc2"),
+                         "llvmorg-23.1.0-rc2")
+        self.assertEqual(build._source_ref("22.1.8"), "llvmorg-22.1.8")
+
+    def test_multi_digit_major_is_not_a_tag(self):
+        # '\d+' must match the whole string: a two-digit major is still
+        # a branch, and nothing but digits may take that path.
+        self.assertEqual(build._source_ref("100"), "release/100.x")
+        self.assertEqual(build._source_ref("23rc2"), "llvmorg-23rc2")
+
+
+class RecordSrcRefTests(unittest.TestCase):
+    def test_appends_to_github_env(self):
+        with tempfile.TemporaryDirectory() as d:
+            env_file = Path(d) / "env"
+            env_file.write_text("SRC_COMMIT=abc123\n")
+            with mock.patch.dict(os.environ,
+                                 {"GITHUB_ENV": str(env_file)}, clear=True):
+                build._record_src_ref("llvmorg-23.1.0-rc2")
+            self.assertEqual(
+                env_file.read_text(),
+                "SRC_COMMIT=abc123\nSRC_REF=llvmorg-23.1.0-rc2\n",
+            )
+
+    def test_no_github_env_is_a_noop(self):
+        # Local runs (bin/repro, a developer shell) have no GITHUB_ENV;
+        # the build must not fail for want of a place to record.
+        with mock.patch.dict(os.environ, {}, clear=True):
+            build._record_src_ref("release/22.x")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
No package manager ships an LLVM major until it is final, so a consumer cannot try a release candidate without building LLVM inline -- the cost this recipe's tier-2 fallback exists to avoid. Upstream cut release/23.x and is tagging candidates against it, and no cell serves them.

The recipe mapped every version to release/{version}.x, a branch that keeps moving while the cache key stays put, so a cell could not say which candidate it holds. Map a bare major to the branch as before and anything else to the upstream tag ('23.1.0-rc2' -> llvmorg-23.1.0-rc2): tags are immutable, so the cell holds exactly what it claims, and bumping to the next candidate moves the key and republishes on its own. Consumers keep clang-runtime '23' and pass the tag as setup-llvm's flavor-version. Linux x86_64 only, since every other platform is a full LLVM build; add rows when a consumer needs one.

branch_template cannot describe both forms, and the manifest rebuilt source.branch from it -- forensic metadata nothing parses, but it should not name a ref that was never cloned -- so the build script now records what it cloned as SRC_REF and the manifest prefers that. The mapping gets unit tests and verify.yml a per-recipe step to run them, having discovered test_*.py under actions/ and bin/ only.