### PR TITLE
bin/repro: make --devshell work for recipes other than LLVM.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,6 +13,10 @@ on:
       - 'recipes/**'
       - 'actions/**'
       - 'bin/**'
+      # scripts/ holds repro-config and the devshell cmake replay, which
+      # bin/repro executes inside the container. Without this entry a PR that
+      # touches only scripts/ runs no checks at all.
+      - 'scripts/**'
       - '.github/workflows/**'
 
 permissions:
@@ -192,6 +196,10 @@ jobs:
       - name: recipes/llvm-release unit tests
         shell: bash
         working-directory: recipes/llvm-release
+        run: python3 -W error::ResourceWarning -m unittest discover -p 'test_*.py' -v
+      - name: scripts/ unit tests
+        shell: bash
+        working-directory: scripts
         run: python3 -W error::ResourceWarning -m unittest discover -p 'test_*.py' -v
 
   # End-to-end dry-run of the real publish-recipe action against the

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ temp-workflow files are cleaned at exit; disk after the run is zero
 (image cache aside). See `bin/repro --help` and
 [docs/developer-guide.md](docs/developer-guide.md) for the rest.
 
-## Iterating on LLVM with a warm ccache: `--devshell`
+## Iterating on a recipe with a warm ccache: `--devshell`
 
 `bin/repro <cell> --devshell` skips the workflow and instead drops
 you into a long-lived container with the cell's published install,
@@ -175,6 +175,23 @@ invocation from `manifest.cmake_args`, and warns on dev-package
 version drift. A smoke compile of `lib/Support/Allocator.cpp.o`
 verifies that the producer cache actually reaches the consumer
 environment before handing off the shell.
+
+Works for any recipe, not only the LLVM ones: the source directory
+comes from the recipe's `source.repo` and the manifest's recorded cmake
+invocation is replayed with producer paths rewritten locally.
+
+`--devshell` reads from whatever cache base is set, so it also works
+against an artifact you built yourself rather than a published cell:
+
+```bash
+bin/recipe-cache pack <recipe> <version> <os> <arch> --from /path/to/install
+RECIPE_CACHE_BASE=file://$HOME/.cache/recipe-cache/ \
+  bin/repro <recipe>/<version>/<os>/<arch> --devshell
+```
+
+A packed entry has no sibling ccache and no cloneable source, so the
+devshell starts cold and without a checkout -- see
+[docs/developer-guide.md](docs/developer-guide.md).
 
 Linux-only for now (Ubuntu cells); macOS hosts work via the bundled
 Linux container, with the platform-mismatch overhead under Rosetta.

--- a/bin/repro
+++ b/bin/repro
@@ -984,8 +984,6 @@ DEVSHELL_HOST_CACHE_DEFAULT = (
 # the manifest value when present so ccache keys match the producer.
 DEVSHELL_RUNNER_WORKSPACE = "/home/runner/work/ci-workflows/ci-workflows"
 DEVSHELL_CCACHE_SUBDIR    = ".ccache"
-DEVSHELL_SRC_SUBDIR       = "_recipe_work/llvm-project"
-DEVSHELL_BUILD_SUBDIR     = "_recipe_work/llvm-project/build"
 DEVSHELL_INSTALL_SUBDIR   = "_recipe_out/install"
 
 DEVSHELL_PATCHES_MOUNT = "/patches"
@@ -1112,6 +1110,7 @@ def _devshell_fetch(base: str, key: str, work: Path,
     sys.path.insert(0, str(REPO_ROOT / "actions" / "lib"))
     import cache_io  # noqa: E402
     import json
+    import urllib.error
     import urllib.request
 
     # Layout under `work` (host) mirrors publish-recipe's runner
@@ -1134,19 +1133,33 @@ def _devshell_fetch(base: str, key: str, work: Path,
 
     # Sibling ccache: archive's top-level dir is `.ccache/`, extracting
     # to `<work>/` lands the ccache at `<work>/.ccache/`.
+    #
+    # Optional, because only publish-recipe emits this asset. An entry created
+    # by `bin/recipe-cache pack` -- the documented way to mock up a cache from
+    # an existing build -- has an install tree and a manifest but no ccache, and
+    # a hard failure there makes the whole local `file://` workflow unusable for
+    # the case it exists to serve. A cold cache is a slow devshell, not a broken
+    # one.
     ccache_dir = ccache_root / DEVSHELL_CCACHE_SUBDIR
     if refetch or not ccache_dir.is_dir():
         if ccache_dir.is_dir():
             shutil.rmtree(ccache_dir)
         asset = f"{key}.ccache.tar.zst"
         _log(f"repro: fetching ccache ({asset})...")
-        if base.startswith("file://"):
-            with (Path(base[len("file://"):]) / asset).open("rb") as f:
-                cache_io._zstd_decode_into_tar(f, ccache_root)
-        else:
-            with urllib.request.urlopen(
-                    f"{base.rstrip('/')}/{asset}", timeout=300) as r:
-                cache_io._zstd_decode_into_tar(r, ccache_root)
+        try:
+            if base.startswith("file://"):
+                with (Path(base[len("file://"):]) / asset).open("rb") as f:
+                    cache_io._zstd_decode_into_tar(f, ccache_root)
+            else:
+                with urllib.request.urlopen(
+                        f"{base.rstrip('/')}/{asset}", timeout=300) as r:
+                    cache_io._zstd_decode_into_tar(r, ccache_root)
+        except (OSError, urllib.error.URLError) as e:
+            # The directory still has to exist: CCACHE_LOGFILE points inside it
+            # and ccache fails outright if it cannot open the log.
+            ccache_dir.mkdir(parents=True, exist_ok=True)
+            _log(f"repro: no sibling ccache for this cell ({e}); "
+                 f"the devshell will start with a cold cache")
 
     # Manifest: plain JSON, no zstd/tar.
     if refetch or not manifest.is_file():
@@ -1162,8 +1175,8 @@ def _devshell_fetch(base: str, key: str, work: Path,
     return json.loads(manifest.read_text())
 
 
-def _devshell_source(work: Path, manifest: Dict) -> Path:
-    """Shallow-clone llvm-project at the manifest's SRC_COMMIT.
+def _devshell_source(work: Path, manifest: Dict) -> Optional[Path]:
+    """Shallow-clone the recipe's source at the manifest's SRC_COMMIT.
 
     `git init` + `git fetch --depth=1 origin <commit>` instead of a
     full-history clone: llvm-project's full history is ~3 GB and
@@ -1179,10 +1192,19 @@ def _devshell_source(work: Path, manifest: Dict) -> Path:
     src = manifest.get("source") or {}
     repo = src.get("repo")
     commit = src.get("commit")
+    # `bin/recipe-cache pack` mocks up a cache entry from an existing build and
+    # stamps a placeholder source it cannot know. There is nothing to clone, but
+    # the install tree is real, so hand back a devshell without a source tree
+    # rather than refusing: inspecting or running a packed artifact is the case
+    # pack exists to serve.
+    if manifest.get("kind") == "mockup" or repo == "mockup://":
+        _log("repro: mockup manifest (packed from an existing build); "
+             "no source tree to fetch")
+        return None
     if not repo or not commit or commit == "unknown":
         sys.exit(f"error: manifest missing source.{{repo,commit}}; "
                  f"cannot reproduce")
-    src_dir = work / DEVSHELL_SRC_SUBDIR
+    src_dir = work / _devshell_src_subdir(manifest)
     if not (src_dir / ".git").is_dir():
         _log(f"repro: shallow-fetching {repo} @ {commit[:12]} "
              f"(use `git fetch --unshallow` inside the container "
@@ -1199,6 +1221,27 @@ def _devshell_source(work: Path, manifest: Dict) -> Path:
     subprocess.run(["git", "-C", str(src_dir),
                     "checkout", "--detach", commit], check=True)
     return src_dir
+
+
+def _devshell_src_subdir(manifest: Dict) -> str:
+    """Workspace-relative source directory, derived from the recipe's source.
+
+    Every recipe clones into WORK_DIR/<basename of source.repo>, so deriving it
+    here reproduces the producer's layout without a new manifest field. That
+    matters beyond tidiness: CCACHE_BASEDIR rewrites paths relative to the
+    workspace, so a source directory that doesn't match the producer's turns
+    every lookup into a miss. The llvm-* recipes all resolve to `llvm-project`,
+    which is what this was hardcoded to before it needed to serve others.
+    """
+    repo = ((manifest.get("source") or {}).get("repo") or "")
+    name = repo.rstrip("/").rsplit("/", 1)[-1]
+    if name.endswith(".git"):
+        name = name[:-len(".git")]
+    return f"_recipe_work/{name or 'source'}"
+
+
+def _devshell_build_subdir(manifest: Dict) -> str:
+    return f"{_devshell_src_subdir(manifest)}/build"
 
 
 def _devshell_ccache_cfg(manifest: Dict) -> Dict[str, str]:
@@ -1471,9 +1514,14 @@ def _devshell_ensure_container(args: argparse.Namespace, name: str,
           if cfg.get("hash_dir") == "false" else []),
         "-e", "CMAKE_C_COMPILER_LAUNCHER=ccache",
         "-e", "CMAKE_CXX_COMPILER_LAUNCHER=ccache",
+        "-e", f"DEVSHELL_INSTALL={ws}/{DEVSHELL_INSTALL_SUBDIR}",
+        # LLVM_PREFIX is the old name for DEVSHELL_INSTALL, kept because muscle
+        # memory and out-of-tree scripts still reach for it. Deprecated: drop
+        # once nothing in-tree references it and the old name has been out of
+        # the docs long enough that nobody is following a stale README.
         "-e", f"LLVM_PREFIX={ws}/{DEVSHELL_INSTALL_SUBDIR}",
-        "-e", f"DEVSHELL_SRC={ws}/{DEVSHELL_SRC_SUBDIR}",
-        "-e", f"DEVSHELL_BUILD={ws}/{DEVSHELL_BUILD_SUBDIR}",
+        "-e", f"DEVSHELL_SRC={ws}/{_devshell_src_subdir(manifest)}",
+        "-e", f"DEVSHELL_BUILD={ws}/{_devshell_build_subdir(manifest)}",
         "-e", f"DEVSHELL_MANIFEST={ws}/manifest.json",
         "-e", f"CCACHE_LOGFILE={ws}/{DEVSHELL_CCACHE_SUBDIR}/ccache.log",
         "-e", f"HOME={DEVSHELL_DEV_HOME}",

--- a/bin/test_repro.py
+++ b/bin/test_repro.py
@@ -1937,3 +1937,63 @@ class LocalizeWorkflowTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class DevshellSrcSubdirTests(unittest.TestCase):
+    """The devshell source directory has to match the one the producer built
+    in: CCACHE_BASEDIR rewrites paths relative to the workspace, so a mismatch
+    turns every ccache lookup into a miss and silently costs the dev the warm
+    cache the devshell exists to provide."""
+
+    def _for(self, repo):
+        return repro._devshell_src_subdir({"source": {"repo": repo}})
+
+    def test_llvm_recipes_keep_their_existing_path(self):
+        """Regression guard: this was hardcoded to llvm-project, and every
+        llvm-* recipe must still resolve to exactly that."""
+        for repo in ("https://github.com/llvm/llvm-project",
+                     "https://github.com/root-project/llvm-project",
+                     "https://github.com/llvm/llvm-project.git"):
+            self.assertEqual(self._for(repo), "_recipe_work/llvm-project", repo)
+
+    def test_non_llvm_recipes_get_their_own_directory(self):
+        self.assertEqual(self._for("https://github.com/kokkos/kokkos"),
+                         "_recipe_work/kokkos")
+        self.assertEqual(
+            self._for("https://github.com/vgvassilev/biodynamo.git"),
+            "_recipe_work/biodynamo")
+
+    def test_trailing_slash_does_not_produce_an_empty_name(self):
+        self.assertEqual(self._for("https://github.com/kokkos/kokkos/"),
+                         "_recipe_work/kokkos")
+
+    def test_missing_source_falls_back_rather_than_yielding_the_workdir(self):
+        """A manifest with no source must not resolve to _recipe_work/ itself,
+        which would drop the checkout on top of the build tree."""
+        self.assertEqual(repro._devshell_src_subdir({}), "_recipe_work/source")
+
+    def test_build_subdir_hangs_off_the_source_subdir(self):
+        m = {"source": {"repo": "https://github.com/kokkos/kokkos"}}
+        self.assertEqual(repro._devshell_build_subdir(m),
+                         "_recipe_work/kokkos/build")
+
+
+class DevshellMockupSourceTests(unittest.TestCase):
+    """`bin/recipe-cache pack` stamps a placeholder source it cannot know, so
+    the devshell has to tolerate an entry it can't clone. Without this the
+    documented pack + file:// route dies in git rather than handing over a
+    shell with the packed install."""
+
+    def test_mockup_manifest_skips_the_clone(self):
+        m = {"kind": "mockup",
+             "source": {"repo": "mockup://", "commit": "n/a"}}
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(subprocess, "run") as run:
+                self.assertIsNone(repro._devshell_source(Path(tmp), m))
+            run.assert_not_called()
+
+    def test_a_real_manifest_still_refuses_when_source_is_unknown(self):
+        m = {"source": {"repo": "https://example.invalid/x", "commit": "unknown"}}
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(SystemExit):
+                repro._devshell_source(Path(tmp), m)

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -367,24 +367,60 @@ bin/repro consumes via `--ci-workflows <path>`.
   `.github/act-ci-workflows-stage/` and
   `.github/workflows/act-*-localized-*.yml` by hand.
 
-## Iterating on LLVM with `--devshell`
+## Iterating on a recipe with `--devshell`
 
 `bin/repro <cell> --devshell` is a different mode: it doesn't run
-a workflow. It downloads the cell's published install +
-sibling-ccache + manifest, shallow-clones llvm-project at the
-manifest's pinned `SRC_COMMIT`, and drops you into a long-lived
-container ready for incremental rebuilds against the producer's
-ccache.
+a workflow. It downloads the cell's install + sibling-ccache +
+manifest, shallow-clones the recipe's source at the manifest's
+pinned `SRC_COMMIT`, and drops you into a long-lived container
+ready for incremental rebuilds against the producer's ccache.
+
+This works for **any** recipe, not only the LLVM ones. The source
+directory is derived from the recipe's `source.repo` (so
+`llvm-*` land in `_recipe_work/llvm-project`, `kokkos` in
+`_recipe_work/kokkos`, `biodynamo` in `_recipe_work/biodynamo`),
+and the cmake invocation recorded in the manifest is replayed with
+its producer-side paths rewritten to local ones — see
+`actions/lib/devshell_cmake.py`.
 
 Use it when:
 
-- A workflow ran clean in CI but you want to edit something *in
-  LLVM itself* and rebuild fast (the `bin/repro <row>` shell only
-  reproduces the row's own build, which doesn't iterate well).
+- A workflow ran clean in CI but you want to edit something *in the
+  recipe's own source* and rebuild fast (the `bin/repro <row>` shell
+  only reproduces the row's own build, which doesn't iterate well).
 - You're triaging a cppyy / CppInterOp issue that needs a
   patched LLVM.
 - You want to verify a recipe's published install actually compiles
-  the next dependent layer (CppInterOp, cling) before relying on it.
+  the next dependent layer (CppInterOp, cling, a simulation built
+  against BioDynaMo) before relying on it.
+- You want to debug an artifact that is *not published yet* — see
+  "Devshell against a local build" below.
+
+### Devshell against a local build
+
+`--devshell` reads from whatever cache base is configured, so it
+does not require a published cell. To debug an artifact you built
+yourself:
+
+```bash
+# 1. Pack an existing install tree into the local cache.
+bin/recipe-cache pack <recipe> <version> <os> <arch> --from /path/to/install
+
+# 2. Point the devshell at it.
+RECIPE_CACHE_BASE=file://$HOME/.cache/recipe-cache/ \
+  bin/repro <recipe>/<version>/<os>/<arch> --devshell
+```
+
+Two things are deliberately tolerated on this path, because a
+packed entry is not a published one:
+
+- **No sibling ccache.** `publish-recipe` emits `<key>.ccache.tar.zst`;
+  `recipe-cache pack` does not. The fetch logs that it is missing and
+  continues, so the devshell starts cold rather than failing.
+- **No source tree.** `pack` stamps a placeholder `source.repo` of
+  `mockup://` that cannot be cloned, so the clone is skipped and you
+  get a container with the install and no checkout. That is the point
+  of the mode: inspecting or *running* a packed artifact.
 
 ### Cell argument
 

--- a/scripts/devshell_cmake.py
+++ b/scripts/devshell_cmake.py
@@ -1,0 +1,69 @@
+"""Rewrite a recipe's recorded cmake invocation for replay in a devshell.
+
+The manifest stores the exact cmake command the producer ran (see
+llvm_build.record_cmake_args). Replaying it verbatim is what keeps a devshell's
+compile commands identical to the producer's, which is the whole basis of the
+sibling-ccache pre-warm -- ccache hashes the full command line, so any drift
+turns hits into misses.
+
+Three arguments are producer-specific and have to be rewritten: the install
+prefix and the source and build directories, all of which name paths on a
+filesystem the consumer does not have.
+
+Recipes record two different shapes. LLVM's build.py runs cmake from inside the
+build directory and passes a relative `../llvm`, because its CMakeLists lives in
+an llvm/ subdirectory rather than at the tree root. Every other recipe passes an
+absolute `-S <dir> -B <dir>`. Handling only the first is how the devshell came
+to work exclusively for LLVM.
+"""
+
+from __future__ import annotations
+
+import posixpath
+from typing import List, Sequence
+
+#: cmake flags whose value is a producer path we must replace. Each accepts the
+#: value either as the next argument (`-S dir`) or joined (`-Sdir`).
+_PATH_FLAGS = ("-S", "-B")
+
+
+def rewrite(args: Sequence[str], *, prefix: str, src: str,
+            build: str) -> List[str]:
+    """Return `args` with producer paths replaced by the local ones.
+
+    `args` is the manifest's cmake_args, including the leading "cmake".
+    `src` is the source tree root; LLVM's `../llvm` resolves to `src/llvm`.
+    """
+    replacement = {"-S": src, "-B": build}
+    # LLVM keeps its CMakeLists one level down; other projects are at the root.
+    #
+    # posixpath, not os.path: every path here is a path *inside the devshell
+    # container*, which is always Linux. os.path would join with whatever
+    # separator the host running this module happens to use, producing
+    # "/local/src\llvm" when the unit tests run on a Windows CI leg.
+    llvm_src = posixpath.join(src, "llvm")
+
+    out: List[str] = []
+    pending: str | None = None
+    for arg in args:
+        if pending is not None:
+            out.append(pending)
+            pending = None
+            continue
+        if arg == "cmake":
+            continue
+        if arg.startswith("-DCMAKE_INSTALL_PREFIX="):
+            out.append(f"-DCMAKE_INSTALL_PREFIX={prefix}")
+            continue
+        if arg in _PATH_FLAGS:
+            out.append(arg)
+            pending = replacement[arg]
+            continue
+        if arg[:2] in _PATH_FLAGS and len(arg) > 2:
+            out.append(f"{arg[:2]}{replacement[arg[:2]]}")
+            continue
+        if arg == "../llvm":
+            out.append(llvm_src)
+            continue
+        out.append(arg)
+    return out

--- a/scripts/repro-config
+++ b/scripts/repro-config
@@ -145,49 +145,52 @@ else
 fi
 
 build="${DEVSHELL_BUILD:?env not set; bin/repro --devshell exports it}"
-src="${DEVSHELL_SRC:?env not set; bin/repro --devshell exports it}/llvm"
-prefix="${LLVM_PREFIX:?env not set; bin/repro --devshell exports it}"
+src="${DEVSHELL_SRC:?env not set; bin/repro --devshell exports it}"
+prefix="${DEVSHELL_INSTALL:-${LLVM_PREFIX:?env not set; bin/repro --devshell exports it}}"
 manifest="${DEVSHELL_MANIFEST:?env not set; bin/repro --devshell exports it}"
 
 if [[ ! -f "$build/CMakeCache.txt" ]]; then
   mkdir -p "$build"
   cd "$build"
-  # Replay the recipe's own cmake invocation from the manifest's
-  # cmake_args field (post-#53). Substitute CMAKE_INSTALL_PREFIX with
-  # the consumer's local LLVM_PREFIX and resolve the source path
-  # relative to the build dir. ccache hashes the full compile command,
-  # so any drift here defeats the sibling-cache pre-warm. The fallback
-  # path (no cmake_args in manifest) computes flags via llvm_build for
-  # backwards compatibility with pre-#53 publishes.
+  # Replay the recipe's own cmake invocation from the manifest's cmake_args
+  # field (post-#53), rewriting the two things that are producer-specific: the
+  # install prefix and the source path. ccache hashes the full compile command,
+  # so any drift here defeats the sibling-cache pre-warm.
+  #
+  # The source rewrite has to cover both shapes recipes use. LLVM's build.py
+  # runs cmake from a build directory and passes the relative `../llvm`, since
+  # its CMakeLists lives in an llvm/ subdirectory. Every other recipe passes an
+  # absolute `-S <work_dir>/<name>` -- which points at the *producer's*
+  # filesystem and does not exist here, so passing it through unchanged
+  # configures against nothing.
   exec_cmake_args=$(python3 - <<'PY'
 import json, os, shlex, sys
+sys.path.insert(0, "/ci-workflows/scripts")
+import devshell_cmake
+
 manifest = json.load(open(os.environ["DEVSHELL_MANIFEST"]))
 args = manifest.get("cmake_args") or []
-prefix = os.environ["LLVM_PREFIX"]
-src = os.environ["DEVSHELL_SRC"] + "/llvm"
-if args:
-    out = []
-    for a in args:
-        if a == "cmake":
-            continue
-        if a.startswith("-DCMAKE_INSTALL_PREFIX="):
-            out.append(f"-DCMAKE_INSTALL_PREFIX={prefix}")
-            continue
-        if a == "../llvm":
-            out.append(src)
-            continue
-        out.append(a)
-else:
-    sys.path.insert(0, "/ci-workflows/actions/lib")
-    import llvm_build
-    out = (llvm_build.base_cmake_args(prefix)
-           + ["-DLLVM_ENABLE_PROJECTS=clang"]
-           + llvm_build.cmake_extra()
-           + [src])
+if not args:
+    sys.exit(0)
+out = devshell_cmake.rewrite(
+    args,
+    prefix=os.environ.get("DEVSHELL_INSTALL") or os.environ["LLVM_PREFIX"],
+    src=os.environ["DEVSHELL_SRC"],
+    build=os.environ["DEVSHELL_BUILD"],
+)
 print(" ".join(shlex.quote(x) for x in out))
 PY
 )
-  eval cmake "$exec_cmake_args"
+  if [[ -z "$exec_cmake_args" ]]; then
+    # Pre-#53 publishes carry no cmake_args. Guessing the flags is only
+    # possible for LLVM, and a wrong guess is worse than no configure: it
+    # produces a build tree whose compile commands miss the producer's ccache
+    # entirely. Leave it to the dev, who can see the manifest.
+    echo "::warning title=devshell::manifest has no cmake_args; skipping the" \
+         "cmake configure. Configure \$DEVSHELL_BUILD by hand."
+  else
+    eval cmake "$exec_cmake_args"
+  fi
 fi
 
 # Sanity check: smoke-compile one TU every LLVM build has

--- a/scripts/test_devshell_cmake.py
+++ b/scripts/test_devshell_cmake.py
@@ -1,0 +1,79 @@
+"""Unit tests for the devshell cmake-argument replay.
+
+The rewrite is what keeps a devshell's compile commands identical to the
+producer's, so a regression here does not fail loudly -- it silently turns every
+ccache hit into a miss, or configures against a path that does not exist.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import devshell_cmake
+
+LOCAL = {"prefix": "/local/install", "src": "/local/src",
+         "build": "/local/build"}
+
+
+class LlvmShapeTests(unittest.TestCase):
+    """LLVM runs cmake from the build directory and passes a relative
+    ../llvm. This is the shape the devshell supported before it had to serve
+    anything else, so it must come through unchanged."""
+
+    def test_relative_llvm_source_resolves_under_the_local_tree(self):
+        out = devshell_cmake.rewrite(
+            ["cmake", "-DCMAKE_INSTALL_PREFIX=/prod/out",
+             "-DLLVM_ENABLE_PROJECTS=clang", "../llvm"], **LOCAL)
+        self.assertEqual(out, ["-DCMAKE_INSTALL_PREFIX=/local/install",
+                               "-DLLVM_ENABLE_PROJECTS=clang",
+                               "/local/src/llvm"])
+
+    def test_leading_cmake_is_dropped(self):
+        self.assertNotIn("cmake", devshell_cmake.rewrite(["cmake"], **LOCAL))
+
+
+class SeparateSourceBuildShapeTests(unittest.TestCase):
+    """Every non-LLVM recipe passes absolute -S/-B naming the producer's
+    filesystem. Passing those through unchanged configures against nothing --
+    the bug this rewrite exists to fix."""
+
+    def test_separate_form_is_rewritten(self):
+        out = devshell_cmake.rewrite(
+            ["cmake", "-S", "/prod/work/biodynamo", "-B", "/prod/work/build",
+             "-DNOPYENV=YES", "-DCMAKE_INSTALL_PREFIX=/prod/staging"], **LOCAL)
+        self.assertEqual(out, ["-S", "/local/src", "-B", "/local/build",
+                               "-DNOPYENV=YES",
+                               "-DCMAKE_INSTALL_PREFIX=/local/install"])
+
+    def test_joined_form_is_rewritten(self):
+        out = devshell_cmake.rewrite(
+            ["cmake", "-S/prod/src", "-B/prod/build"], **LOCAL)
+        self.assertEqual(out, ["-S/local/src", "-B/local/build"])
+
+    def test_producer_paths_never_survive(self):
+        """The point of the rewrite: no /prod path may reach the output."""
+        out = devshell_cmake.rewrite(
+            ["cmake", "-S", "/prod/src", "-B", "/prod/build",
+             "-DCMAKE_INSTALL_PREFIX=/prod/install"], **LOCAL)
+        self.assertFalse([a for a in out if "/prod" in a], out)
+
+
+class PassthroughTests(unittest.TestCase):
+    def test_unrelated_flags_are_untouched(self):
+        flags = ["-DCMAKE_BUILD_TYPE=Release", "-GNinja",
+                 "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"]
+        self.assertEqual(devshell_cmake.rewrite(["cmake", *flags], **LOCAL),
+                         flags)
+
+    def test_a_flag_whose_value_merely_starts_with_dash_s_is_not_a_path(self):
+        """-Sfoo is a source dir, but -DSOMETHING is not -- guard the prefix
+        match against eating ordinary defines."""
+        out = devshell_cmake.rewrite(["cmake", "-DSANITIZE=address"], **LOCAL)
+        self.assertEqual(out, ["-DSANITIZE=address"])
+
+    def test_empty_args_yield_empty_output(self):
+        self.assertEqual(devshell_cmake.rewrite([], **LOCAL), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
--devshell was written when every cell was an LLVM one, and it still assumes that in three places: the source directory is hardcoded to _recipe_work/llvm-project, the install prefix is exported only as LLVM_PREFIX, and repro-config appends /llvm to the source path because LLVM keeps its CMakeLists one level down. A kokkos or biodynamo cell therefore drops the dev into a container whose source tree is missing and whose build directory was never configured.

The cmake replay is the substantive part. It rewrote only the literal `../llvm` argument, but every non-LLVM recipe passes an absolute `-S <dir> -B <dir>` naming the *producer's* filesystem, which the replay handed to cmake unchanged -- configuring against a path that does not exist here. Both shapes are now rewritten to local paths, and the logic moved to scripts/devshell_cmake.py so it can be tested rather than only read; it lives under scripts/ rather than actions/lib/ because compute_key.py hashes actions/lib/**.py into every recipe's cache key, and a devshell-only helper has no business invalidating published cells.

The source directory is derived from the recipe's own source.repo, which resolves to llvm-project for every llvm-* recipe and so leaves existing cells byte-identical. That matters beyond tidiness: CCACHE_BASEDIR rewrites paths relative to the workspace, so a source directory that does not match the producer's turns every ccache lookup into a miss.

Three smaller fixes make a locally packed cell usable, which is what turns --devshell into a debugging tool for an artifact that is not published yet. The sibling ccache is now optional, since only publish-recipe emits it and `recipe-cache pack` does not -- the directory is still created because CCACHE_LOGFILE lives inside it. A mockup manifest's placeholder source is recognised and the clone skipped, instead of git-fetching 'n/a' from 'mockup://'.

scripts/ gains a unit-test step in verify.yml and joins its path filter: the replay logic is the substantive part of this change, and a test no job runs is decoration.