### PR TITLE
Add a BioDynaMo recipe and setup-biodynamo action.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -197,6 +197,10 @@ jobs:
         shell: bash
         working-directory: recipes/llvm-release
         run: python3 -W error::ResourceWarning -m unittest discover -p 'test_*.py' -v
+      - name: recipes/biodynamo unit tests
+        shell: bash
+        working-directory: recipes/biodynamo
+        run: python3 -W error::ResourceWarning -m unittest discover -p 'test_*.py' -v
       - name: scripts/ unit tests
         shell: bash
         working-directory: scripts

--- a/actions/setup-biodynamo/action.yml
+++ b/actions/setup-biodynamo/action.yml
@@ -1,0 +1,204 @@
+name: 'Setup BioDynaMo'
+description: |
+  Resolves a BioDynaMo install for consumer CI via the `biodynamo` recipe and
+  exports the environment its build system expects, so a consumer's
+  find_package(BioDynaMo) resolves with no further plumbing.
+
+  The install lands at $GITHUB_WORKSPACE/biodynamo -- a dedicated prefix, so it
+  coexists with setup-llvm's $GITHUB_WORKSPACE/install -- and BDMSYS plus the
+  rest of thisbdm.sh's environment are exported via $GITHUB_ENV. Order relative
+  to setup-llvm does not matter: any pre-existing install/ is preserved across
+  the recipe step, which otherwise `rm -rf`s that path.
+
+  Unlike setup-kokkos, which only needs Kokkos_ROOT, BioDynaMo ships a
+  thisbdm.sh that sets a dozen variables (ROOTSYS, BDM_ROOT_DIR,
+  CMAKE_PREFIX_PATH, LD_LIBRARY_PATH, ROOT_INCLUDE_PATH, ...). A composite
+  action cannot leave a sourced shell behind, so this one sources the script
+  and marshals whatever it changed into $GITHUB_ENV.
+
+inputs:
+  version:
+    required: true
+    description: |
+      BioDynaMo tag to provision, e.g. "v1.05-cr-20260812-01". Interpolated
+      into the recipe source branch, so it must be a git ref on the source
+      repo -- clone_shallow passes it to `git clone -b` and a bare commit sha
+      will not resolve. See recipes/biodynamo/recipe.yaml for the tag naming
+      rules; BioDynaMo's own version generator parses `git describe`, so the
+      vX.YY prefix is required and not merely conventional.
+  os:
+    required: true
+    description: |
+      OS slug for the recipe cache key -- a runner-image name like
+      "ubuntu-24.04". Must match a cells.yaml entry warmed for this recipe.
+  arch:
+    required: false
+    default: ''
+    description: |
+      Architecture slug (x86_64 / arm64). Derived from the os slug when empty
+      (ubuntu-*-arm -> arm64, else x86_64).
+  build-on-miss:
+    required: false
+    default: 'false'
+    description: 'Forwarded to setup-recipe: build inline on a cache miss instead of failing fast.'
+  ref:
+    required: false
+    default: 'main'
+    description: 'ci-workflows ref for setup-recipe to read recipes/ from.'
+  cache-base:
+    required: false
+    default: ''
+    description: 'Forwarded to setup-recipe: override the recipe cache backend.'
+
+outputs:
+  bdmsys:
+    description: 'BioDynaMo install prefix ($GITHUB_WORKSPACE/biodynamo).'
+    value: ${{ steps.finalize.outputs.bdmsys }}
+  cache-hit:
+    description: '"true" when the recipe came from the cache, "false" when built inline.'
+    value: ${{ steps.recipe.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve arch
+      id: resolve
+      shell: bash
+      env:
+        OS: ${{ inputs.os }}
+        ARCH_IN: ${{ inputs.arch }}
+      run: |
+        set -euo pipefail
+        if [[ -n "${ARCH_IN}" ]]; then
+          arch="${ARCH_IN}"
+        else
+          case "${OS}" in
+            *-arm) arch=arm64 ;;
+            *)     arch=x86_64 ;;
+          esac
+        fi
+        echo "arch=${arch}" >> "$GITHUB_OUTPUT"
+
+    # The artifact is relocatable but not self-contained, so the consumer has to
+    # supply what it links against: UseBioDynaMo.cmake fails outright without
+    # MPI ("We did not find any OpenMPI installation") and requires OpenMP,
+    # libbiodynamo.so carries numa, blas/lapack and libgit2 symbols, and ROOT's
+    # cling shells out to the compiler ROOT was built with, so g++-11 must exist
+    # or any cppyy/JIT use dies inside libCling.
+    #
+    # cmake and make are here for a subtler reason: on a cache hit build.py
+    # never runs, so the toolchain its own apt list happened to install is
+    # absent and the consumer cannot build against what it just downloaded. The
+    # inline-build path masked that, because the recipe installed them itself.
+    - name: Install BioDynaMo's host dependencies
+      shell: bash
+      run: |
+        set -euo pipefail
+        # NEEDRESTART_MODE=l: list services needing a restart, do not restart
+        # them. Left to its default, needrestart bounces systemd-networkd and
+        # systemd-resolved partway through the job when a library upgrade pulls
+        # them in -- restarting the runner's network stack underneath a build
+        # that is about to fetch a few hundred MB.
+        sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=l \
+          apt-get update -qq
+        sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=l \
+          apt-get install -y --no-install-recommends \
+          cmake make git \
+          libopenmpi-dev libomp-dev libnuma-dev libblas-dev liblapack-dev \
+          libgit2-dev g++-11
+
+    # setup-recipe places the recipe at $GITHUB_WORKSPACE/install and `rm -rf`s
+    # that path first. Move any pre-existing install/ aside so this action is
+    # order-independent with respect to setup-llvm.
+    - name: Preserve existing install prefix
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -d "${GITHUB_WORKSPACE}/install" ]]; then
+          rm -rf "${GITHUB_WORKSPACE}/.install.pre-biodynamo"
+          mv "${GITHUB_WORKSPACE}/install" "${GITHUB_WORKSPACE}/.install.pre-biodynamo"
+        fi
+
+    - name: BioDynaMo recipe (cache or inline build)
+      id: recipe
+      uses: compiler-research/ci-workflows/actions/setup-recipe@main
+      with:
+        recipe:        biodynamo
+        version:       ${{ inputs.version }}
+        os:            ${{ inputs.os }}
+        arch:          ${{ steps.resolve.outputs.arch }}
+        build-on-miss: ${{ inputs.build-on-miss }}
+        ref:           ${{ inputs.ref }}
+        cache-base:    ${{ inputs.cache-base }}
+
+    - name: Relocate BioDynaMo and restore install prefix
+      shell: bash
+      run: |
+        set -euo pipefail
+        rm -rf "${GITHUB_WORKSPACE}/biodynamo"
+        mv "${GITHUB_WORKSPACE}/install" "${GITHUB_WORKSPACE}/biodynamo"
+        if [[ -d "${GITHUB_WORKSPACE}/.install.pre-biodynamo" ]]; then
+          mv "${GITHUB_WORKSPACE}/.install.pre-biodynamo" "${GITHUB_WORKSPACE}/install"
+        fi
+
+    - name: Export the thisbdm.sh environment
+      id: finalize
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        RECIPE_HIT: ${{ steps.recipe.outputs.cache-hit }}
+      run: |
+        set -euo pipefail
+        prefix="${GITHUB_WORKSPACE}/biodynamo"
+
+        # Diff the environment across the source rather than hand-listing the
+        # variables: thisbdm.sh sets a dozen and the set changes with the
+        # BioDynaMo version. Values are single-line paths, so plain
+        # NAME=value lines into $GITHUB_ENV are sufficient.
+        before="$(mktemp)"; after="$(mktemp)"; srclog="$(mktemp)"
+        env | sort > "$before"
+        # `set -u` has to come off across the source: thisbdm.sh reads
+        # BDM_THISBDM_LOGLEVEL without a default, so under -u it aborts partway
+        # and leaves the environment half-configured. Keep its output rather
+        # than discarding it -- the script reports real problems on stderr while
+        # still returning 0, so that text is the only diagnosis available when
+        # something goes wrong.
+        set +u
+        # shellcheck disable=SC1091
+        source "${prefix}/bin/thisbdm.sh" > "$srclog" 2>&1
+        set -u
+        # Returning 0 proves nothing; BDMSYS being set is the real signal.
+        if [[ -z "${BDMSYS:-}" ]]; then
+          echo "::error title=setup-biodynamo::sourcing ${prefix}/bin/thisbdm.sh did not set BDMSYS" >&2
+          cat "$srclog" >&2
+          exit 1
+        fi
+        env | sort > "$after"
+
+        comm -13 "$before" "$after" | while IFS= read -r line; do
+          # Only well-formed NAME=value assignments. `env` renders multi-line
+          # values (exported shell functions, notably) across several lines, and
+          # the continuation and blank lines are not assignments -- appending
+          # one makes the runner reject the whole file with "invalid format '',
+          # expected a line with '=' or '<<'".
+          [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]] || continue
+          name="${line%%=*}"
+          # Skip shell bookkeeping that must not leak into later steps.
+          case "$name" in
+            _|SHLVL|PWD|OLDPWD|BASH_*|PIPESTATUS) continue ;;
+          esac
+          printf '%s\n' "$line" >> "$GITHUB_ENV"
+        done
+        rm -f "$before" "$after" "$srclog"
+
+        echo "bdmsys=${prefix}" >> "$GITHUB_OUTPUT"
+
+        # Surface what the artifact actually carries. ROOT supplies the RNG
+        # BioDynaMo draws from, so its version is a scientific input, not just
+        # a build detail; build.py stamps it into the install tree.
+        prov="${prefix}/share/bdm-recipe-provenance.json"
+        if [[ -f "$prov" ]]; then
+          echo "::notice title=setup-biodynamo::$(tr -d '\n ' < "$prov")"
+        fi
+        src=$([[ "${RECIPE_HIT}" == "true" ]] && echo recipe-cache || echo inline-build)
+        echo "::notice title=setup-biodynamo::version=${VERSION} source=${src} BDMSYS=${prefix}"

--- a/cells.yaml
+++ b/cells.yaml
@@ -118,3 +118,21 @@ cells:
   # ubuntu-22.04 (x86_64), its arm row ubuntu-24.04-arm.
   - { recipe: kokkos,     version: '5.1.1',        os: ubuntu-22.04,     arch: x86_64 }
   - { recipe: kokkos,     version: '5.1.1',        os: ubuntu-24.04-arm, arch: arm64  }
+  # biodynamo: agent-based simulation framework consumed by CARTopiaX. The
+  # artifact bundles its own ROOT under third_party/root, so it is far larger
+  # than the other recipes here. build.py measures the install and records
+  # install_size_mib in share/bdm-recipe-provenance.json; check it against
+  # caps.soft_gb before adding rows.
+  #
+  # ubuntu-24.04 only for now. Both extra host packages the recipe needs are
+  # available there (g++-11 from noble's own repos, python3.9 from deadsnakes),
+  # and 22.04 would need deadsnakes just the same, so it buys nothing. No arm64
+  # row: BioDynaMo's external/ROOT.cmake has no aarch64 Linux tarball selected
+  # (that branch is commented out upstream), so there is no ROOT to download.
+  #
+  # `version` is a git tag on vgvassilev/biodynamo -- clone_shallow passes it to
+  # `git clone -b`, so it cannot be a bare sha. Like the llvm-release rc row
+  # above it pins a tag rather than a branch, so cutting the next serial moves
+  # the key and republishes; see recipes/biodynamo/recipe.yaml for the naming
+  # rules, which BioDynaMo's own version generator constrains.
+  - { recipe: biodynamo,  version: 'v1.05-cr-20260812-01', os: ubuntu-24.04,     arch: x86_64 }

--- a/recipes/biodynamo/build.py
+++ b/recipes/biodynamo/build.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Builds a relocatable BioDynaMo install tree.
+
+BioDynaMo installs into <prefix>/biodynamo-v<short-version>/ and pulls its own
+prebuilt ROOT into third_party/root, so the flattened result is self-contained:
+bin/thisbdm.sh derives BDMSYS from its own location and everything else hangs
+off that. See recipe.yaml for why python3.9, g++-11 and -DNOPYENV=YES are all
+load-bearing.
+
+Inputs (env): see actions/lib/llvm_build.py for the
+RECIPE_VERSION / WORK_DIR / OUT_DIR / NCPUS contract.
+
+Outputs (env, written to GITHUB_ENV when present):
+  SRC_COMMIT   sha of the BioDynaMo tag that was built.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / ".." / ".." / "actions" / "lib"))
+
+import llvm_build  # noqa: E402
+
+BDM_REPO = "https://github.com/vgvassilev/biodynamo.git"
+
+# BioDynaMo's own prerequisites, matching what its consumers' CI installs.
+APT_PACKAGES = [
+    "cmake", "make", "g++", "gcc", "git", "wget", "curl",
+    "libblas-dev", "liblapack-dev", "libnuma-dev", "libomp-dev",
+    "libopenmpi-dev", "libpthread-stubs0-dev", "zlib1g-dev",
+    "freeglut3-dev", "libbz2-dev", "libffi-dev", "liblzma-dev",
+    "libreadline-dev", "libsqlite3-dev", "libssl-dev", "tk-dev",
+    "xz-utils",
+    # Without it BioDynaMo's -Dlibgit2=ON silently degrades to
+    # "Libgit2 not found. GitTracking will not be available."
+    "libgit2-dev",
+    # See recipe.yaml: cling needs the compiler ROOT was built with.
+    "g++-11",
+]
+
+
+def _sudo() -> list[str]:
+    # geteuid is POSIX-only. This recipe has Linux cells exclusively (the ROOT
+    # tarballs BioDynaMo fetches are Linux/macOS), but bin/recipe-cache build
+    # can be invoked anywhere, so fail with a reason rather than an
+    # AttributeError from os.
+    if not hasattr(os, "geteuid"):
+        raise RuntimeError("recipes/biodynamo builds on POSIX hosts only")
+    return [] if os.geteuid() == 0 else ["sudo"]
+
+
+#: Prefixed to every apt invocation via `env`, not passed through
+#: subprocess(env=...): these run under sudo, which resets the environment, so
+#: an inherited variable never reaches apt.
+#:
+#: NEEDRESTART_MODE=l tells needrestart to list services needing a restart
+#: rather than restarting them. Left at its default it bounces
+#: systemd-networkd and systemd-resolved partway through the job when a library
+#: upgrade pulls them in -- restarting the runner's network stack underneath a
+#: build that then fetches a few hundred MB of ROOT.
+_APT_ENV = ("env", "DEBIAN_FRONTEND=noninteractive", "NEEDRESTART_MODE=l")
+
+
+def _apt(*packages: str) -> None:
+    subprocess.run([*_sudo(), *_APT_ENV, "apt-get", "install", "-y",
+                    "--no-install-recommends", *packages], check=True)
+
+
+def _install_deps() -> None:
+    """Host packages BioDynaMo's configure and ROOT's cling both need."""
+    subprocess.run([*_sudo(), *_APT_ENV, "apt-get", "update", "-qq"],
+                   check=True)
+    _apt(*APT_PACKAGES)
+    # python3.9 is not in any Ubuntu LTS; deadsnakes is the only apt source.
+    # Skipped when a 3.9 is already present so a re-run stays cheap.
+    if shutil.which("python3.9") is None:
+        _apt("software-properties-common")
+        subprocess.run([*_sudo(), *_APT_ENV, "add-apt-repository", "-y",
+                        "ppa:deadsnakes/ppa"], check=True)
+        subprocess.run([*_sudo(), *_APT_ENV, "apt-get", "update", "-qq"],
+                       check=True)
+    _apt("python3.9", "python3.9-dev")
+
+
+def _flatten_install(staging: Path, dest: Path) -> Path:
+    """Move <staging>/biodynamo-v<X>/ to `dest`.
+
+    setup-recipe expects the tarball root to be `install/`, while BioDynaMo
+    installs one level deeper under a version-stamped directory name.
+    """
+    entries = [p for p in staging.iterdir() if p.is_dir()]
+    if len(entries) != 1:
+        raise RuntimeError(
+            f"expected exactly one install dir under {staging}, got {entries}"
+        )
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.move(str(entries[0]), str(dest))
+    shutil.rmtree(staging, ignore_errors=True)
+    return dest
+
+
+def _record_root_provenance(prefix: Path) -> None:
+    """Stamp the bundled ROOT's version and Python ABI into the install tree.
+
+    ROOT supplies the random number generator BioDynaMo simulations draw from,
+    so which ROOT went into this artifact is a scientific input and not just a
+    build detail. The manifest has no field for it, so it travels with the
+    artifact instead.
+    """
+    root_config = prefix / "third_party" / "root" / "bin" / "root-config"
+    if not root_config.is_file():
+        print("build.py: no bundled root-config; skipping provenance stamp",
+              flush=True)
+        return
+
+    def _ask(flag: str) -> str:
+        r = subprocess.run([str(root_config), flag], capture_output=True,
+                           text=True)
+        return r.stdout.strip() if r.returncode == 0 else "unknown"
+
+    size_mib = sum(p.stat().st_size for p in prefix.rglob("*") if p.is_file())
+    size_mib = round(size_mib / 1048576)
+    provenance = {
+        "root_version": _ask("--version"),
+        "root_python_version": _ask("--python-version"),
+        # Measured rather than asserted: this artifact counts against
+        # cells.yaml's caps, and a stale figure in a comment is how a cache
+        # quietly outgrows them.
+        "install_size_mib": size_mib,
+    }
+    out = prefix / "share" / "bdm-recipe-provenance.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(provenance, indent=2) + "\n")
+    print(f"build.py: bundled ROOT {provenance['root_version']} "
+          f"(python {provenance['root_python_version']}), "
+          f"install {size_mib} MiB", flush=True)
+
+
+def _verify_relocated(prefix: Path, work_dir: Path, ncpus: str) -> None:
+    """Post-install smoke against a *moved* copy of the install tree.
+
+    Relocation is the failure mode that matters here: the consumer extracts to
+    a different absolute path than the producer built at, and ROOT bakes paths
+    into its PCH and dictionaries. Building at the original location proves
+    nothing, so drive the whole consumer path from a different one -- source
+    thisbdm.sh, configure and build BioDynaMo's own simulation-template, run
+    it, and import cppyy.
+
+    The tree is *moved* rather than copied, then moved back in `finally`. A
+    copy would double peak disk on a GB-scale artifact, and leaving the
+    original in place lets a stale absolute path resolve to it and pass a test
+    that would fail on a real consumer.
+    """
+    moved = work_dir / "relocated" / "install"
+    if moved.parent.exists():
+        shutil.rmtree(moved.parent)
+    moved.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(prefix), str(moved))
+    try:
+        _run_relocated_smoke(moved, work_dir, ncpus)
+    finally:
+        shutil.move(str(moved), str(prefix))
+        shutil.rmtree(moved.parent, ignore_errors=True)
+    print("build.py: relocated install smoke ok", flush=True)
+
+
+def _run_relocated_smoke(moved: Path, work_dir: Path, ncpus: str) -> None:
+    """Drive a consumer build against the install tree at `moved`."""
+    template = moved / "simulation-template"
+    if not template.is_dir():
+        raise RuntimeError(f"no simulation-template in install tree: {moved}")
+    sim = work_dir / "relocated" / "sim"
+    if sim.exists():
+        shutil.rmtree(sim)
+    shutil.copytree(template, sim, symlinks=True)
+
+    # thisbdm.sh reports failure on stderr but still exits 0, so assert on
+    # BDMSYS rather than on the exit status.
+    #
+    # The cppyy check runs under the interpreter ROOT's bindings were built
+    # for, not whatever `python3` resolves to: with -DNOPYENV=YES nothing puts
+    # that version first on PATH, and the system python is 3.12 on ubuntu-24.04
+    # while the bundled ROOT ships libcppyy3_9. Ask ROOT which one it wants,
+    # the same way BioDynaMo's own configure does.
+    script = textwrap.dedent(f"""
+        set -e
+        source "{moved}/bin/thisbdm.sh"
+        if [ -z "${{BDMSYS:-}}" ]; then
+          echo "thisbdm.sh did not set BDMSYS" >&2
+          exit 1
+        fi
+        echo "smoke: BDMSYS=$BDMSYS"
+        # Same compiler pin as the BioDynaMo build above, and for the same
+        # reason: this is a second cmake invocation, so it re-detects from the
+        # ambient CC/CXX (clang, in the publish workflow) while UseBioDynaMo
+        # swaps in mpicxx, which wraps gcc. Mismatched OpenMP flags then break
+        # the consumer build rather than BioDynaMo's own.
+        cmake -S "{sim}" -B "{sim}/build" -DCMAKE_BUILD_TYPE=Release \\
+              -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+        cmake --build "{sim}/build" -j {ncpus}
+        # Running it is the point: ROOT bakes absolute paths into its PCH and
+        # rootmap, and a relocated tree that compiles happily still fails at
+        # load. Only executing the binary exercises that.
+        cd "{sim}/build" && ./my-simulation
+        pyver=$("$BDMSYS/third_party/root/bin/root-config" --python-version \\
+                | cut -d. -f1,2)
+        "python${{pyver}}" -c 'import cppyy; print("smoke: import cppyy ok")'
+    """)
+    subprocess.run(["bash", "-c", script], check=True)
+
+
+def main() -> int:
+    llvm_build.setup_env()
+    work_dir = Path(os.environ["WORK_DIR"])
+    out_dir = Path(os.environ["OUT_DIR"])
+    version = os.environ["RECIPE_VERSION"]
+    ncpus = os.environ["NCPUS"]
+
+    _install_deps()
+
+    src = work_dir / "biodynamo"
+    llvm_build.clone_shallow(BDM_REPO, version, src)
+    llvm_build.record_src_commit(src)
+
+    staging = work_dir / "install-staging"
+    build = work_dir / "build"
+    cmake_args = [
+        "cmake", "-S", str(src), "-B", str(build),
+        "-DCMAKE_BUILD_TYPE=Release",
+        # See recipe.yaml: keeps pyenv out of the generated thisbdm.sh so the
+        # published tree is sourceable on a consumer that has no pyenv.
+        "-DNOPYENV=YES",
+        # A published artifact has to run wherever it is extracted, and a host
+        # with no NUMA topology -- any container on Docker for Mac or Windows,
+        # WSL, some CI runners -- reports zero nodes while claiming NUMA is
+        # available. A NUMA-aware build then allocates on a node that does not
+        # exist and dies inside Simulation's constructor. BioDynaMo's non-NUMA
+        # path is a thin shim (numa_alloc_onnode -> malloc, one node), and on
+        # the single-socket machines this cell targets a real NUMA build does
+        # the same thing anyway. Revisit if a consumer runs multi-socket, where
+        # the awareness actually pays.
+        "-Dnuma=OFF",
+        "-Dnotebooks=OFF",
+        "-Dparaview=OFF",
+        "-Dlibgit2=ON",
+        "-Dsbml=OFF",
+        f"-DCMAKE_INSTALL_PREFIX={staging}",
+        *llvm_build.cmake_extra(),
+        # Last, so nothing above can put it back: build with gcc whatever CC/CXX
+        # the workflow exported. install-build-deps sets clang for the LLVM
+        # recipes, but BioDynaMo replaces CMAKE_CXX_COMPILER with MPI's wrapper
+        # regardless, and mpicxx wraps gcc. The replacement happens *after* CMake
+        # has detected the compiler, so the flags stay clang-shaped --
+        # find_package(OpenMP) yields -fopenmp=libomp, g++ rejects it, and the
+        # build dies on the first agent. Pinning detection to what mpicxx
+        # actually runs keeps the two consistent, and matches the bundled ROOT,
+        # which is a gcc build.
+        "-DCMAKE_C_COMPILER=gcc",
+        "-DCMAKE_CXX_COMPILER=g++",
+    ]
+    # Persist for the manifest: repro-config replays this to configure a
+    # devshell against the same flags the producer used.
+    llvm_build.record_cmake_args(cmake_args)
+
+    print("build.py: " + " ".join(cmake_args), flush=True)
+    subprocess.run(cmake_args, check=True)
+    subprocess.run(["cmake", "--build", str(build), "-j", ncpus], check=True)
+    subprocess.run(["cmake", "--install", str(build)], check=True)
+
+    prefix = _flatten_install(staging, out_dir / "install")
+    _record_root_provenance(prefix)
+    _verify_relocated(prefix, work_dir, ncpus)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/recipes/biodynamo/recipe.yaml
+++ b/recipes/biodynamo/recipe.yaml
@@ -1,0 +1,53 @@
+recipe: biodynamo
+description: |
+  BioDynaMo built from a tagged release, installed as a relocatable tree that
+  carries its own ROOT under third_party/root. Consumers source
+  install/bin/thisbdm.sh (see actions/setup-biodynamo) and then
+  find_package(BioDynaMo) resolves with no further plumbing.
+
+  Why a recipe rather than an inline build: BioDynaMo is a ~30 minute build
+  that every downstream simulation repo (CARTopiaX and friends) would
+  otherwise repeat on every CI run, and it downloads a ~300 MB prebuilt ROOT
+  tarball from CERN while doing so. Publishing it once per cell turns that
+  into a cache fetch.
+
+  Two host packages are not optional and are installed by build.py:
+
+    python3.9  ROOT's PyROOT/cppyy are extension modules built against one
+               CPython minor (libcppyy3_9.so for the ROOT BioDynaMo bundles),
+               and BioDynaMo now requires that exact minor at configure time.
+               No Ubuntu LTS ships 3.9 -- 22.04 has 3.10, 24.04 has 3.12 --
+               so it comes from the deadsnakes PPA.
+    g++-11     cling shells out to the compiler ROOT was built with to locate
+               the standard library headers. When it is missing, `import
+               cppyy` dies inside libCling with a segmentation violation.
+
+  Built with -DNOPYENV=YES: without it the generated thisbdm.sh runs
+  `pyenv shell <version>` and cannot be sourced on a machine without pyenv,
+  which would make the published artifact unusable on any consumer that
+  doesn't replicate the producer's pyenv installation.
+
+# The version input is a git tag on the source repo below; clone_shallow passes
+# it to `git clone -b`, so a bare commit sha will not work.
+#
+# Tag shape is v<major>.<minor>-cr-<date>-<serial>, e.g.
+# v1.05-cr-20260810-01. Both halves are load-bearing:
+#
+#   v<major>.<minor>  required, not decorative. BioDynaMo's
+#                     util/version/generate_version_files.py derives its
+#                     version from `git describe` and matches it against
+#                     v([0-9]+)\.([0-9]+); anything else leaves the fallback
+#                     regex returning None and the build dies with an
+#                     AttributeError, then a missing bdm_version.h in
+#                     rootcling.
+#   -cr-<date>-<serial>  keeps the fork's tags out of upstream's namespace --
+#                     it carries commits upstream does not have -- and mirrors
+#                     the date-stamped ladder recipes/llvm-root uses.
+#
+# Cutting a new tag is also what moves the cache key: the key is a content hash
+# over this directory plus version/os/arch, so a new tag republishes the cell,
+# while a branch-tracking version would freeze the key as the branch advanced
+# and age the artifact silently.
+source:
+  repo: https://github.com/vgvassilev/biodynamo
+  branch_template: '{version}'

--- a/recipes/biodynamo/test_build.py
+++ b/recipes/biodynamo/test_build.py
@@ -1,0 +1,95 @@
+"""Unit tests for the biodynamo recipe's install-tree flattening.
+
+Loaded by path rather than imported: recipe directories are not packages
+('llvm-release' is not an identifier), and every recipe's build script is
+called build.py, so a plain import would collide across recipes in
+sys.modules. Mirrors recipes/llvm-release/test_build.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "biodynamo_build", Path(__file__).resolve().parent / "build.py")
+build = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(build)
+
+
+class FlattenInstallTests(unittest.TestCase):
+    """BioDynaMo installs into <prefix>/biodynamo-v<X>/ while setup-recipe
+    expects the tarball root to be `install/`. Getting this wrong publishes an
+    artifact whose layout no consumer can source, which only shows up on the
+    consumer side long after the cell is warm."""
+
+    def test_moves_the_single_versioned_dir_to_dest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            staging = Path(tmp) / "staging"
+            (staging / "biodynamo-v1.05" / "bin").mkdir(parents=True)
+            (staging / "biodynamo-v1.05" / "bin" / "thisbdm.sh").write_text("x")
+            dest = Path(tmp) / "install"
+
+            out = build._flatten_install(staging, dest)
+
+            self.assertEqual(out, dest)
+            self.assertTrue((dest / "bin" / "thisbdm.sh").is_file())
+            self.assertFalse(staging.exists())
+
+    def test_replaces_an_existing_dest(self):
+        """A re-run in a reused workspace must not merge into the old tree."""
+        with tempfile.TemporaryDirectory() as tmp:
+            staging = Path(tmp) / "staging"
+            (staging / "biodynamo-v1.05").mkdir(parents=True)
+            (staging / "biodynamo-v1.05" / "new").write_text("new")
+            dest = Path(tmp) / "install"
+            dest.mkdir()
+            (dest / "stale").write_text("stale")
+
+            build._flatten_install(staging, dest)
+
+            self.assertTrue((dest / "new").is_file())
+            self.assertFalse((dest / "stale").exists())
+
+    def test_rejects_more_than_one_candidate(self):
+        """Two directories means the install layout changed upstream; guessing
+        would silently publish half a tree."""
+        with tempfile.TemporaryDirectory() as tmp:
+            staging = Path(tmp) / "staging"
+            (staging / "biodynamo-v1.05").mkdir(parents=True)
+            (staging / "biodynamo-v1.06").mkdir(parents=True)
+            with self.assertRaises(RuntimeError):
+                build._flatten_install(staging, Path(tmp) / "install")
+
+    def test_rejects_an_empty_staging_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            staging = Path(tmp) / "staging"
+            staging.mkdir()
+            with self.assertRaises(RuntimeError):
+                build._flatten_install(staging, Path(tmp) / "install")
+
+
+class SudoGuardTests(unittest.TestCase):
+    """The recipe shells out to apt, so it is POSIX-only by construction; the
+    guard exists so a Windows invocation says that rather than dying inside os."""
+
+    def test_non_posix_host_gets_a_reason(self):
+        import os as _os
+        had = hasattr(_os, "geteuid")
+        if not had:
+            with self.assertRaises(RuntimeError):
+                build._sudo()
+            return
+        geteuid = _os.geteuid
+        del _os.geteuid
+        try:
+            with self.assertRaises(RuntimeError):
+                build._sudo()
+        finally:
+            _os.geteuid = geteuid
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every downstream simulation repo builds BioDynaMo inline on each CI run: a long build that also downloads a ~300 MB prebuilt ROOT tarball from CERN, and that needs a pyenv-managed interpreter set up beforehand. CARTopiaX carries a clone-cache-build dance plus its own pyenv step to do it.

Publishing it once per cell turns that into a cache fetch. The artifact is relocatable by construction: BioDynaMo installs its own ROOT under third_party/root, and bin/thisbdm.sh derives BDMSYS from its own location, so the tree works wherever setup-recipe extracts it. build.py proves that before publishing -- it moves the install to a different path and drives a full consumer build from there. setup-biodynamo then sources thisbdm.sh and marshals the resulting environment into $GITHUB_ENV, since a composite action cannot leave a sourced shell behind and the script sets a dozen variables.

Two host packages are not optional and are installed by the recipe. ROOT's PyROOT and cppyy are extension modules built against a single CPython minor, and no Ubuntu LTS ships the 3.9 the bundled ROOT wants, so it comes from deadsnakes; cling shells out to the compiler ROOT was built with to locate the standard library headers, so g++-11 has to be present or `import cppyy` dies inside libCling with a segmentation violation. The build passes -DNOPYENV=YES so the generated thisbdm.sh does not require pyenv on the consumer, which would otherwise make the published tree unsourceable.