### PR TITLE
bin/repro: do not fail --devshell when the recipe configure fails.

### DIFF
--- a/scripts/repro-config
+++ b/scripts/repro-config
@@ -188,8 +188,26 @@ PY
     # entirely. Leave it to the dev, who can see the manifest.
     echo "::warning title=devshell::manifest has no cmake_args; skipping the" \
          "cmake configure. Configure \$DEVSHELL_BUILD by hand."
-  else
-    eval cmake "$exec_cmake_args"
+  elif ! eval cmake "$exec_cmake_args"; then
+    # Not fatal. This configure is a convenience for devs who intend to
+    # rebuild the recipe's own source; the install tree, the ccache and
+    # the AI CLI are all in place without it, so failing here would cost
+    # the dev the whole shell over an optional step.
+    #
+    # It fails routinely for recipes with host dependencies beyond
+    # LLVM's. build.py apt-installs those itself before configuring, but
+    # that runs on the *producer*; the block at the top of this script
+    # installs only the LLVM set, so e.g. the biodynamo recipe stops at
+    # "We did not find any OpenMPI installation".
+    #
+    # Drop the half-written cache: cmake writes CMakeCache.txt even when
+    # it aborts, and leaving it would make every later session take the
+    # skip branch above and never retry the configure.
+    rm -rf "$build/CMakeCache.txt" "$build/CMakeFiles"
+    echo "::warning title=devshell::the recipe's cmake configure failed;" \
+         "the devshell is still usable. To rebuild \$DEVSHELL_SRC, apt-install" \
+         "the host packages the recipe's build.py installs, then re-run" \
+         "bin/repro --devshell."
   fi
 fi
 


### PR DESCRIPTION
repro-config replays the recipe's own cmake invocation so a dev who wants to rebuild the recipe's source finds a configured build tree. That convenience is currently fatal: the configure runs under `set -e`, so when it fails bin/repro aborts before the shell is ever handed over, and the dev loses an environment that is otherwise complete -- install tree, ccache and AI CLI all in place.

It fails routinely for any recipe whose host dependencies exceed LLVM's. build.py apt-installs those itself, but on the producer; repro-config installs only the LLVM set, so the biodynamo devshell stops at "We did not find any OpenMPI installation" and never opens. Warn and continue instead, and drop the CMakeCache.txt that cmake writes even when it aborts -- leaving it would make every later session skip the configure and never retry it once the dev has installed what was missing.