### PR TITLE
Add bin/start, a guided entry point for new contributors.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -136,6 +136,33 @@ jobs:
             fi
           done
           exit $fail
+      - name: projects.yaml entries name a real cell
+        # bin/start renders this catalog before anything is cloned, so a
+        # coord here that no cell serves shows a student a project they
+        # cannot actually enter. Membership in cells.yaml is the right
+        # test rather than a backend probe: it is what makes a cell
+        # warmed and kept, and it keeps this check offline.
+        run: |
+          set -euo pipefail
+          fail=0
+          count=$(yq '.projects | length' projects.yaml)
+          for i in $(seq 0 $((count - 1))); do
+            name=$(yq -r ".projects[$i].name" projects.yaml)
+            for f in name description repo workflow row recipe version os arch; do
+              v=$(yq -r ".projects[$i].$f // \"\"" projects.yaml)
+              if [ -z "$v" ]; then
+                echo "::error file=projects.yaml::$name missing field: $f"
+                fail=1
+              fi
+            done
+            coord=$(yq -r ".projects[$i] | [.recipe, .version, .os, .arch] | @tsv" projects.yaml)
+            if ! yq -r '.cells[] | [.recipe, .version, .os, .arch] | @tsv' cells.yaml \
+                 | grep -qxF "$coord"; then
+              echo "::error file=projects.yaml::$name names a cell absent from cells.yaml: $coord"
+              fail=1
+            fi
+          done
+          exit $fail
       - name: No orphan recipe directories
         # Catches recipes/ subdirs that aren't referenced by cells.yaml.
         # An orphan recipe directory is dead weight — it's never built,

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -186,6 +186,83 @@ jobs:
             exit 1
           fi
 
+  # The only job that actually provisions a devshell. The unit tests
+  # cover the Python deciding *what* to provision and publish-dryrun
+  # covers the recipe pipeline, but the chain that hands a developer a
+  # working container -- fetch, repro-config, the recipe's
+  # devshell-setup.sh, the cmake replay -- was previously proven only by
+  # someone running it on a laptop. That is how the biodynamo devshell
+  # shipped unable to configure anything.
+  #
+  # biodynamo rather than a cheaper cell on purpose: it is the only
+  # recipe shipping a devshell-setup.sh, and an LLVM cell cannot regress
+  # that hook because repro-config installs LLVM's dependencies anyway.
+  # The coord comes from projects.yaml so a version bump does not leave
+  # this job testing a cell nobody offers.
+  #
+  # Costs a ~1 GB act-image pull plus the cell download on every PR that
+  # touches bin/, scripts/ or recipes/.
+  devshell-smoke:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve the biodynamo cell from projects.yaml
+        id: cell
+        run: |
+          set -euo pipefail
+          coord=$(yq -r '.projects[] | select(.recipe == "biodynamo")
+            | .recipe + "/" + .version + "/" + .os + "/" + .arch' \
+            projects.yaml | head -1)
+          if [ -z "$coord" ]; then
+            echo "::error file=projects.yaml::no biodynamo project to smoke"
+            exit 1
+          fi
+          echo "coord=$coord" >> "$GITHUB_OUTPUT"
+
+      - name: bin/start lists the catalog
+        run: |
+          set -euo pipefail
+          ./bin/start --list | tee listing
+          # An empty catalog still exits 0, so assert on content.
+          grep -q 'CARTopiaX' listing
+
+      - name: Provision a devshell and assert it is usable
+        env:
+          COORD: ${{ steps.cell.outputs.coord }}
+        run: |
+          set -euo pipefail
+          cat > "$RUNNER_TEMP/smoke.sh" <<'SH'
+          set -eo pipefail
+          fail=0
+          check() {
+            if eval "$2" >/dev/null 2>&1; then
+              echo "  ok    $1"
+            else
+              echo "  FAIL  $1"; fail=1
+            fi
+          }
+          # The recipe's host dependencies, i.e. devshell-setup.sh ran.
+          # Without it the configure below dies on missing OpenMPI.
+          check "mpicxx present"        "command -v mpicxx"
+          check "python3.9 present"     "command -v python3.9"
+          # The artifact, and the environment a consumer build needs.
+          check "thisbdm.sh sets BDMSYS" \
+            'set +u; . "$DEVSHELL_INSTALL/bin/thisbdm.sh" >/dev/null 2>&1; [ -n "$BDMSYS" ]'
+          # The cmake replay reached the end. This is the assertion that
+          # would have caught the original breakage.
+          check "recipe build tree configured" \
+            '[ -f "$DEVSHELL_BUILD/CMakeCache.txt" ]'
+          # The "claude-ready" half of the promise.
+          check "claude on PATH"        "command -v claude"
+          exit $fail
+          SH
+          ./bin/repro --devshell \
+              --devshell-host-cache-dir "$RUNNER_TEMP/devshell-cache" \
+              --devshell-script "$RUNNER_TEMP/smoke.sh" \
+              "$COORD"
+
   # Cross-OS unit tests for every Python module in the recipe pipeline.
   # Each function has minimal-effective tests (happy path + targeted
   # edge cases) — the publish-dryrun matrix is the broader integration

--- a/README.md
+++ b/README.md
@@ -11,6 +11,31 @@ eventually MSan stacks and sanitizer-CPython).
 > and the trade-offs you're accepting. The rest of this README is a
 > quick reference.
 
+## Just want to start working on a project? `bin/start`
+
+You need Docker, git and a Python 3. Not `act`, and not a toolchain --
+that gets downloaded.
+
+```bash
+git clone https://github.com/compiler-research/ci-workflows
+cd ci-workflows && ./bin/start
+```
+
+It lists the projects in [`projects.yaml`](projects.yaml) with the
+toolchain each develops against, clones the one you pick, and opens a
+container holding that exact toolchain -- the same artifact the
+project's CI uses -- with its host dependencies installed and Claude
+Code ready. Run it from inside a checkout you already have and it skips
+the menu.
+
+Your checkout is bind-mounted, not copied, so edits show up on the host
+immediately and you commit, push and open pull requests from there.
+No credentials are copied into the container.
+
+`./bin/start --list` prints the catalog without prompting. See
+[Onboarding a contributor](docs/developer-guide.md#onboarding-a-contributor-binstart)
+for what it sets up and how to add a project to the list.
+
 ## Consumer side: `setup-recipe`
 
 In a downstream workflow:

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+"""Newcomer entry point: pick a project, land in a container ready to work in.
+
+    git clone https://github.com/compiler-research/ci-workflows
+    cd ci-workflows && ./bin/start
+
+Prints the projects in projects.yaml with the toolchain each one
+develops against, takes a number, clones the project if it isn't on
+disk yet, and hands the whole thing to `bin/repro --devshell` -- which
+downloads that toolchain from the recipe cache, installs the recipe's
+host dependencies, and opens a shell with Claude Code in it.
+
+Why a second entry point rather than a `bin/repro` flag: repro's
+audience already knows what a matrix row is and why they want to
+reproduce one. This one's audience has been handed a link by a
+supervisor. Nothing here is new machinery -- the module is loaded and
+`cmd_devshell` called directly, so provisioning, container naming,
+ccache wiring and the AI setup all stay in one place. What this file
+owns is the catalog, the prompts, and the decision of what to hand
+`cmd_devshell`.
+
+Deliberately stdlib-only, like bin/repro: a student running this has
+Docker and a Python, and that has to be enough. That is also why
+projects.yaml is parsed here by hand instead of with PyYAML.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.machinery
+import importlib.util
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROJECTS_YAML = REPO_ROOT / "projects.yaml"
+#: Where a project gets cloned when the user accepts the default.
+DEFAULT_SRC_PARENT = Path.home() / "src"
+#: Mirrors bin/repro's DEVSHELL_HOST_CACHE_DEFAULT, which is what
+#: --devshell-host-cache resolves to and where the cell is unpacked.
+DEVSHELL_HOST_CACHE = Path.home() / ".cache" / "ci-workflows" / "devshell-cache"
+#: Free space below which we say so. Advisory, not a floor: preflight
+#: runs before a project is picked, and cells differ by an order of
+#: magnitude -- biodynamo unpacks to ~800 MB, an LLVM cell to ~4 GB --
+#: so any single number would either block a small project needlessly
+#: or wave a big one through.
+WARN_FREE_GIB = 10
+
+_COORD_KEYS = ("recipe", "version", "os", "arch")
+_REQUIRED = ("name", "description", "repo", "workflow", "row") + _COORD_KEYS
+
+
+def _load_repro():
+    """Import the extensionless bin/repro as a module.
+
+    Same SourceFileLoader dance bin/test_repro.py uses; repro is
+    import-safe (everything is behind functions and a main() guard).
+    """
+    path = REPO_ROOT / "bin" / "repro"
+    loader = importlib.machinery.SourceFileLoader("repro", str(path))
+    spec = importlib.util.spec_from_loader("repro", loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------- catalog
+
+
+def load_projects(path: Optional[Path] = None) -> List[Dict[str, str]]:
+    """Parse projects.yaml's `projects:` list.
+
+    Hand-rolled for the same reason published_cells() is -- no PyYAML
+    on a student's machine. The accepted shape is deliberately narrow:
+    a `- name: value` line opens an entry and further indented
+    `key: value` lines extend it. Only the first colon splits, so a
+    description may contain them.
+
+    Entries missing a required field are dropped rather than raised
+    on: a malformed row should cost the student that one project, not
+    the whole menu. verify.yml is what makes malformed rows loud.
+    """
+    if path is None:
+        path = PROJECTS_YAML
+    if not path.is_file():
+        return []
+    out: List[Dict[str, str]] = []
+    cur: Optional[Dict[str, str]] = None
+    in_projects = False
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if line.startswith("projects:"):
+            in_projects = True
+            continue
+        if not in_projects:
+            continue
+        # Any new top-level key ends the projects: block.
+        if line and not line[0].isspace() and not line.startswith("#"):
+            break
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- "):
+            if cur:
+                out.append(cur)
+            cur = {}
+            stripped = stripped[2:].strip()
+        if cur is None or ":" not in stripped:
+            continue
+        key, _, value = stripped.partition(":")
+        cur[key.strip()] = value.strip().strip("'").strip('"')
+    if cur:
+        out.append(cur)
+    return [p for p in out if all(k in p and p[k] for k in _REQUIRED)]
+
+
+def coord_of(project: Dict[str, str]) -> Dict[str, str]:
+    """The (recipe, version, os, arch) tuple a project develops against."""
+    return {k: project[k] for k in _COORD_KEYS}
+
+
+def coord_str(coord: Dict[str, str]) -> str:
+    return "/".join(coord[k] for k in _COORD_KEYS)
+
+
+# -------------------------------------------------------------- preflight
+
+
+def _docker_status() -> Tuple[bool, str]:
+    """Return (ok, detail) for the docker daemon.
+
+    Client version and daemon reachability are separate failures with
+    separate fixes, so they get separate messages: an installed client
+    that can't reach a daemon means "start Docker Desktop", a missing
+    binary means "install it".
+    """
+    if shutil.which("docker") is None:
+        return False, "not installed -- see https://docs.docker.com/get-docker/"
+    try:
+        version = subprocess.run(
+            ["docker", "version", "--format", "{{.Client.Version}}"],
+            capture_output=True, text=True, timeout=30,
+        ).stdout.strip()
+        info = subprocess.run(
+            ["docker", "info", "--format", "{{.ServerVersion}}"],
+            capture_output=True, text=True, timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        return False, f"could not be queried ({e})"
+    if info.returncode != 0:
+        return False, (f"{version or 'installed'}, but the daemon is not "
+                       f"running -- start Docker and try again")
+    return True, f"{version or info.stdout.strip()}, daemon up"
+
+
+def _disk_status() -> Tuple[bool, str]:
+    """Free space where the unpacked cell will land.
+
+    Measured at the cache location rather than $PWD, which on a laptop
+    is often a different volume. Never blocks: see WARN_FREE_GIB.
+    """
+    probe = DEVSHELL_HOST_CACHE
+    while not probe.exists() and probe != probe.parent:
+        probe = probe.parent
+    try:
+        free_gib = shutil.disk_usage(probe).free / (1024 ** 3)
+    except OSError as e:
+        return True, f"could not be determined ({e})"
+    detail = f"{free_gib:.0f} GB free at {probe}"
+    if free_gib < WARN_FREE_GIB:
+        detail += " -- tight for the larger cells"
+    return True, detail
+
+
+def _host_machine() -> str:
+    """The machine's architecture, not the interpreter's.
+
+    platform.machine() reports the *process* arch, so an x86_64 Python
+    under Rosetta calls an Apple Silicon Mac "x86_64" -- and then we
+    would fail to warn about exactly the machine that needs the
+    warning. sysctl.proc_translated is macOS's answer to "am I being
+    translated"; it is absent on a native process.
+    """
+    import platform as _platform
+    machine = _platform.machine().lower()
+    if _platform.system().lower() != "darwin" or machine != "x86_64":
+        return machine
+    try:
+        out = subprocess.run(["sysctl", "-n", "sysctl.proc_translated"],
+                             capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return machine
+    return "arm64" if out.stdout.strip() == "1" else machine
+
+
+def _platform_status() -> Tuple[bool, str]:
+    """Note x86_64-on-arm64 translation rather than failing on it.
+
+    A translated container is fine for developing and wrong for
+    timing, so this is information the user needs and not a reason to
+    stop.
+    """
+    import platform as _platform
+    system = _platform.system().lower()
+    machine = _host_machine()
+    if machine in ("arm64", "aarch64"):
+        return True, (f"{system}/{machine} -- x86_64 containers run "
+                      f"translated (fine to develop in, not to time)")
+    return True, f"{system}/{machine}"
+
+
+def preflight() -> bool:
+    """Print the environment checks; return False if any blocks."""
+    checks = [
+        ("docker", _docker_status()),
+        ("disk", _disk_status()),
+        ("platform", _platform_status()),
+    ]
+    print("  checking prerequisites")
+    ok = True
+    for label, (passed, detail) in checks:
+        prefix = "    " if passed else "  ! "
+        print(f"{prefix}{label:<18}{detail}")
+        ok = ok and passed
+    print()
+    return ok
+
+
+# ------------------------------------------------------------ cell status
+
+
+def _asset_size(base: str, key: str) -> Optional[int]:
+    """Content-Length of the cell's install asset, or None.
+
+    A HEAD rather than cache_io.cache_probe(), which throws the size
+    away -- the download size is the single most useful number to show
+    someone about to wait for it. Kept here rather than added to
+    cache_io for the reason in the module docstring: that directory
+    feeds the cache key.
+    """
+    asset = f"{key}.tar.zst"
+    if base.startswith("file://"):
+        p = Path(base[len("file://"):]) / asset
+        return p.stat().st_size if p.is_file() else None
+    if not base.startswith(("http://", "https://")):
+        return None
+    req = urllib.request.Request(f"{base.rstrip('/')}/{asset}", method="HEAD")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            if not 200 <= resp.status < 400:
+                return None
+            length = resp.headers.get("Content-Length")
+            return int(length) if length else None
+    except (urllib.error.HTTPError, urllib.error.URLError,
+            ValueError, OSError):
+        return None
+
+
+def cell_status(repro, base: str, project: Dict[str, str],
+                cells: List[Dict[str, str]]) -> str:
+    """One line describing whether this project's cell is usable.
+
+    Two failures are worth distinguishing. Not in cells.yaml means the
+    catalog is stale and no amount of waiting helps. In cells.yaml but
+    not on the backend means the cell simply hasn't been warmed yet,
+    which fixes itself on the next publish.
+    """
+    coord = coord_of(project)
+    if not any(all(coord[k] == c[k] for k in _COORD_KEYS) for c in cells):
+        return "unknown cell -- not in cells.yaml, this entry is stale"
+    try:
+        key = repro._devshell_compute_key(coord)
+    except (subprocess.CalledProcessError, SystemExit):
+        return "cell key could not be computed"
+    size = _asset_size(base, key)
+    if size is None:
+        return "not published yet -- pick another, or warm this cell first"
+    return f"published -- {size / (1024 ** 2):.0f} MB download"
+
+
+# ------------------------------------------------------------------ menu
+
+
+def render(projects: List[Dict[str, str]], statuses: List[str]) -> None:
+    print("  ci-workflows projects")
+    print()
+    for i, (p, status) in enumerate(zip(projects, statuses), start=1):
+        coord = coord_of(p)
+        print(f"  {i:>2}  {p['name']:<14} {p['description']}")
+        print(f"      {'':<14} {coord['recipe']} {coord['version']} "
+              f"- {coord['os']}/{coord['arch']}")
+        print(f"      {'':<14} {status}")
+        print()
+
+
+def select(count: int) -> Optional[int]:
+    """Prompt until a valid index or a quit. Returns a 0-based index.
+
+    EOF counts as quit so a piped or non-interactive run exits cleanly
+    instead of looping on an empty read.
+    """
+    while True:
+        try:
+            raw = input(f"  select a project [1-{count}], or q to quit: ")
+        except EOFError:
+            print()
+            return None
+        raw = raw.strip().lower()
+        if raw in ("q", "quit", "exit"):
+            return None
+        if raw.isdigit() and 1 <= int(raw) <= count:
+            return int(raw) - 1
+        print(f"  not a choice: {raw!r}")
+
+
+def _confirm(prompt: str, default: bool = True) -> bool:
+    suffix = "[Y/n]" if default else "[y/N]"
+    try:
+        raw = input(f"  {prompt} {suffix} ").strip().lower()
+    except EOFError:
+        print()
+        return False
+    if not raw:
+        return default
+    return raw in ("y", "yes")
+
+
+# -------------------------------------------------------------- checkout
+
+
+def resolve_checkout(project: Dict[str, str]) -> Optional[Path]:
+    """Find or create the project's checkout; return its path.
+
+    An existing directory is reused as-is and never touched -- it is
+    the user's working copy, and this tool has no business pulling or
+    resetting it.
+    """
+    default = DEFAULT_SRC_PARENT / project["name"]
+    print()
+    print(f"  {project['name']}")
+    print(f"    clone to    {default}            [enter to accept]")
+    print(f"    toolchain   {project['recipe']} {project['version']}")
+    print()
+    try:
+        raw = input(f"  path [{default}]: ").strip()
+    except EOFError:
+        print()
+        return None
+    dest = Path(raw).expanduser().resolve() if raw else default
+
+    if dest.is_dir():
+        if not (dest / ".git").is_dir():
+            print(f"  {dest} exists but is not a git checkout; "
+                  f"pick another path.")
+            return None
+        print(f"  using the checkout already at {dest}")
+        return dest
+
+    if not _confirm(f"clone {project['repo']} to {dest}?"):
+        return None
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    r = subprocess.run(["git", "clone", project["repo"], str(dest)])
+    if r.returncode != 0:
+        print(f"  git clone failed (exit {r.returncode})")
+        return None
+    return dest
+
+
+def _value_after(line: str, key: str) -> Optional[str]:
+    """Pull `key: value` out of one line, inline-flow or block.
+
+    Stops at a comma or a closing brace so an inline row like
+    `{ name: r, recipe-version: v1, arch: x86_64 }` yields just `v1`.
+    """
+    _, _, rest = line.partition(key)
+    rest = rest.lstrip().lstrip(":").strip()
+    value = rest.split(",")[0].split("}")[0].strip().strip("'\"")
+    return value or None
+
+
+#: Matrix keys that name a recipe version, most specific first. The
+#: same pair `_devshell_cell` maps from, because consumers disagree:
+#: CARTopiaX says `recipe-version`, CppInterOp says `clang-runtime`.
+_VERSION_KEYS = ("recipe-version", "clang-runtime")
+
+#: `name:` as a mapping key: opening a block item, or after `{` / `,`
+#: inline. Anchored at both ends because a substring test matches the
+#: wrong row -- `ubu24-x86-gcc12-llvm22` against the line for
+#: `ubu24-x86-gcc12-llvm22-cppyy` -- and matches `flavor-name:` too.
+_NAME_RE = re.compile(r"(?:[{,]|^\s*-)\s*name:\s*([^,}\s]+)")
+
+
+def _row_name(line: str) -> Optional[str]:
+    """The row this line opens, or None if it opens no row."""
+    m = _NAME_RE.search(line)
+    return m.group(1).strip("'\"") if m else None
+
+
+def _collect_versions(line: str, into: Dict[str, str]) -> None:
+    """Record any version keys on `line`; first occurrence wins."""
+    for key in _VERSION_KEYS:
+        if key in line and key not in into:
+            value = _value_after(line, key)
+            if value:
+                into[key] = value
+
+
+def repo_pinned_version(checkout: Path,
+                        project: Dict[str, str]) -> Optional[str]:
+    """Read the version the project itself pins for its recorded row.
+
+    The catalog makes the menu renderable before anything is cloned,
+    but the project is the authority on what it builds against, so a
+    bumped pin must not strand a contributor on last month's
+    toolchain. This is a targeted scan of one row, not a workflow
+    parser: it handles the inline and block matrix shapes because
+    consumers use both, and returns None the moment the answer is not
+    unambiguous. Being a little stale beats guessing.
+
+    Only the version is recovered. A project that changes its recipe,
+    os or arch outruns this check and needs the projects.yaml row
+    updated by hand; verify.yml is what catches the result.
+    """
+    wf = checkout / project["workflow"]
+    if not wf.is_file():
+        return None
+    lines = wf.read_text().splitlines()
+    for i, line in enumerate(lines):
+        if _row_name(line) != project["row"]:
+            continue
+        # Collect the whole row before choosing, so precedence is by
+        # key and not by which line happened to come first.
+        found: Dict[str, str] = {}
+        _collect_versions(line, found)
+        # A block item carries its remaining keys indented past the
+        # `-`; an inline one ends here and the walk stops immediately.
+        indent = len(line) - len(line.lstrip())
+        for nxt in lines[i + 1:]:
+            if not nxt.strip() or nxt.lstrip().startswith("#"):
+                continue
+            if len(nxt) - len(nxt.lstrip()) <= indent:
+                break
+            _collect_versions(nxt, found)
+        for key in _VERSION_KEYS:
+            if key in found:
+                return found[key]
+        return None
+    return None
+
+
+# ------------------------------------------------------------------ main
+
+
+def launch(repro, project: Dict[str, str], checkout: Path,
+           coord: Dict[str, str]) -> int:
+    """Hand off to bin/repro's devshell.
+
+    The Namespace is the full set cmd_devshell and its helpers read.
+    Host-cache mode is on because a newcomer wants the download to
+    survive `docker volume rm` and a machine move; the coordinate goes
+    through `matrix` because _devshell_cell takes a direct coord there
+    and skips act entirely.
+    """
+    # Say where the work lives before the shell opens, because the
+    # question it answers ("how do I get my changes out?") otherwise
+    # gets asked after the fact. There is no export step: /patches is
+    # the checkout, so git runs on the host, where the credentials
+    # are -- and deliberately nowhere near a container running an AI
+    # agent. The container has no git identity for the same reason.
+    print()
+    print(f"  {checkout} is mounted at /patches inside the container.")
+    print("  Edits appear there immediately; commit, push and open "
+          "pull requests")
+    print("  from the host as usual -- no credentials are copied "
+          "into the container.")
+    print()
+    args = argparse.Namespace(
+        matrix=[f"name:{coord_str(coord)}"],
+        devshell_host_cache=True,
+        devshell_host_cache_dir=None,
+        devshell_patches_out=str(checkout),
+        devshell_image=None,
+        devshell_refetch=False,
+        devshell_rm=False,
+        devshell_script=None,
+        devshell_as_root=False,
+    )
+    return repro.cmd_devshell(args)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="bin/start",
+        description="Pick a ci-workflows project and open a dev container "
+                    "for it.",
+    )
+    parser.add_argument(
+        "--list", action="store_true",
+        help="print the catalog with cell status and exit (no prompts)",
+    )
+    args = parser.parse_args(argv)
+
+    projects = load_projects()
+    if not projects:
+        print(f"error: no usable entries in {PROJECTS_YAML}", file=sys.stderr)
+        return 1
+
+    if args.list:
+        repro = _load_repro()
+        sys.path.insert(0, str(REPO_ROOT / "actions" / "lib"))
+        import cache_io  # noqa: E402
+        base = cache_io.resolve_cache_base()
+        cells = repro.published_cells()
+        print()
+        render(projects, [cell_status(repro, base, p, cells)
+                          for p in projects])
+        return 0
+
+    print()
+    if not preflight():
+        print("  fix the flagged items above, then run ./bin/start again.")
+        return 1
+
+    repro = _load_repro()
+    sys.path.insert(0, str(REPO_ROOT / "actions" / "lib"))
+    import cache_io  # noqa: E402
+
+    base = cache_io.resolve_cache_base()
+    cells = repro.published_cells()
+
+    statuses = [cell_status(repro, base, p, cells) for p in projects]
+    render(projects, statuses)
+    index = select(len(projects))
+    if index is None:
+        return 0
+    project = projects[index]
+
+    checkout = resolve_checkout(project)
+    if checkout is None:
+        return 1
+
+    coord = coord_of(project)
+    pinned = repo_pinned_version(checkout, project)
+    if pinned and pinned != coord["version"]:
+        print(f"  note: {project['name']} pins {pinned}, projects.yaml "
+              f"records {coord['version']}; using the repo's.")
+        coord["version"] = pinned
+
+    return launch(repro, project, checkout, coord)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/start
+++ b/bin/start
@@ -384,6 +384,45 @@ def _value_after(line: str, key: str) -> Optional[str]:
     return value or None
 
 
+def _repo_slug(url: str) -> str:
+    """owner/repo out of a clone URL, for comparing catalog to remote."""
+    trimmed = url.rstrip("/")
+    if trimmed.endswith(".git"):
+        trimmed = trimmed[:-len(".git")]
+    parts = trimmed.replace(":", "/").split("/")
+    return "/".join(parts[-2:]).lower() if len(parts) >= 2 else trimmed.lower()
+
+
+def detect_project(repro, projects: List[Dict[str, str]]
+                   ) -> Optional[Tuple[Dict[str, str], Path]]:
+    """If the cwd is a checkout of a catalogued project, return it.
+
+    Two entry paths, one command. Someone starting from nothing runs
+    this from the ci-workflows clone and picks off the menu; someone
+    already sitting in their checkout should not be asked which
+    project they are in, nor where to put it. Matching is on the
+    origin remote rather than the directory name, so a fork or a
+    renamed directory still resolves.
+    """
+    slug = repro._origin_repo_slug()
+    if not slug:
+        return None
+    for p in projects:
+        if _repo_slug(p["repo"]) != slug.lower():
+            continue
+        try:
+            top = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True, text=True, timeout=30,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if top.returncode != 0 or not top.stdout.strip():
+            return None
+        return p, Path(top.stdout.strip())
+    return None
+
+
 #: Matrix keys that name a recipe version, most specific first. The
 #: same pair `_devshell_cell` maps from, because consumers disagree:
 #: CARTopiaX says `recipe-version`, CppInterOp says `clang-runtime`.
@@ -534,16 +573,27 @@ def main(argv: Optional[List[str]] = None) -> int:
     base = cache_io.resolve_cache_base()
     cells = repro.published_cells()
 
-    statuses = [cell_status(repro, base, p, cells) for p in projects]
-    render(projects, statuses)
-    index = select(len(projects))
-    if index is None:
-        return 0
-    project = projects[index]
-
-    checkout = resolve_checkout(project)
-    if checkout is None:
-        return 1
+    detected = detect_project(repro, projects)
+    if detected is not None:
+        # Announce, don't ask. cd'ing into the checkout and running this
+        # is already the answer to both questions the menu path asks,
+        # and nothing here writes to the checkout -- it is bind-mounted,
+        # not modified. The line below is the disclosure.
+        project, checkout = detected
+        print(f"  in a {project['name']} checkout ({checkout});"
+              f" skipping the menu.")
+        print(f"    {cell_status(repro, base, project, cells)}")
+    else:
+        statuses = [cell_status(repro, base, p, cells) for p in projects]
+        render(projects, statuses)
+        index = select(len(projects))
+        if index is None:
+            return 0
+        project = projects[index]
+        maybe_checkout = resolve_checkout(project)
+        if maybe_checkout is None:
+            return 1
+        checkout = maybe_checkout
 
     coord = coord_of(project)
     pinned = repo_pinned_version(checkout, project)

--- a/bin/test_start.py
+++ b/bin/test_start.py
@@ -1,0 +1,432 @@
+"""Unit tests for bin/start (the newcomer project picker).
+
+Pins the parts that decide what a student ends up in: which entries
+projects.yaml yields, which cell each names, how a project's own pin
+overrides a stale catalog row, and what the menu says about a cell that
+cannot be used.
+
+The provisioning itself is bin/repro's and is tested in test_repro.py;
+what is checked here is that start hands it a well-formed Namespace.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+START_PATH = Path(__file__).resolve().parent / "start"
+
+
+def _load_start():
+    loader = importlib.machinery.SourceFileLoader("start", str(START_PATH))
+    spec = importlib.util.spec_from_loader("start", loader)
+    m = importlib.util.module_from_spec(spec)
+    loader.exec_module(m)
+    return m
+
+
+start = _load_start()
+
+
+def _write(text: str) -> Path:
+    tmp = Path(tempfile.mkdtemp()) / "projects.yaml"
+    tmp.write_text(text, encoding="utf-8")
+    return tmp
+
+
+WELL_FORMED = """\
+# leading comment
+projects:
+  - name: CARTopiaX
+    description: CAR T-cell model, built on BioDynaMo
+    repo: https://github.com/compiler-research/CARTopiaX
+    workflow: .github/workflows/ci.yml
+    row: ubu24-gcc
+    recipe: biodynamo
+    version: v1.05-cr-20260812-01
+    os: ubuntu-24.04
+    arch: x86_64
+
+  - name: CppInterOp
+    description: C++ interop layer
+    repo: https://github.com/compiler-research/CppInterOp
+    workflow: .github/workflows/main.yml
+    row: ubu24-x86-gcc12-llvm22
+    recipe: llvm-release
+    version: '22'
+    os: ubuntu-24.04
+    arch: x86_64
+"""
+
+
+class LoadProjectsTest(unittest.TestCase):
+    def test_parses_every_entry_and_field(self):
+        got = start.load_projects(_write(WELL_FORMED))
+        self.assertEqual([p["name"] for p in got],
+                         ["CARTopiaX", "CppInterOp"])
+        self.assertEqual(got[0]["row"], "ubu24-gcc")
+        # Quotes are stripped so '22' compares equal to the cells.yaml
+        # value and to what compute_key.py is handed.
+        self.assertEqual(got[1]["version"], "22")
+
+    def test_description_may_contain_commas_and_colons(self):
+        text = WELL_FORMED.replace(
+            "description: C++ interop layer",
+            "description: C++ interop: bindings, cppyy, and friends")
+        got = start.load_projects(_write(text))
+        self.assertEqual(got[1]["description"],
+                         "C++ interop: bindings, cppyy, and friends")
+
+    def test_entry_missing_a_required_field_is_dropped_not_raised(self):
+        # A half-written row must cost the student that project only --
+        # the rest of the menu still has to render.
+        text = WELL_FORMED.replace("    arch: x86_64\n\n", "\n", 1)
+        got = start.load_projects(_write(text))
+        self.assertEqual([p["name"] for p in got], ["CppInterOp"])
+
+    def test_missing_file_yields_empty_list(self):
+        self.assertEqual(
+            start.load_projects(Path(tempfile.mkdtemp()) / "nope.yaml"), [])
+
+    def test_trailing_top_level_key_ends_the_block(self):
+        got = start.load_projects(_write(WELL_FORMED + "\nother: value\n"))
+        self.assertEqual(len(got), 2)
+
+    def test_shipped_catalog_parses_and_every_coord_is_complete(self):
+        for p in start.load_projects():
+            coord = start.coord_of(p)
+            self.assertTrue(all(coord.values()), p)
+
+
+class CoordTest(unittest.TestCase):
+    def test_coord_str_is_the_direct_coord_repro_accepts(self):
+        p = start.load_projects(_write(WELL_FORMED))[0]
+        self.assertEqual(
+            start.coord_str(start.coord_of(p)),
+            "biodynamo/v1.05-cr-20260812-01/ubuntu-24.04/x86_64")
+
+
+class RepoPinnedVersionTest(unittest.TestCase):
+    """The project, once cloned, outranks the catalog."""
+
+    def _checkout(self, workflow_text: str) -> Path:
+        root = Path(tempfile.mkdtemp())
+        wf = root / ".github" / "workflows" / "ci.yml"
+        wf.parent.mkdir(parents=True)
+        wf.write_text(workflow_text, encoding="utf-8")
+        return root
+
+    def _project(self, **over):
+        p = {"workflow": ".github/workflows/ci.yml", "row": "ubu24-gcc"}
+        p.update(over)
+        return p
+
+    def test_reads_the_pin_off_a_block_row(self):
+        # CARTopiaX's shape: `- name:` opens the row and the pin sits
+        # several keys below it. Reading only inline rows left this
+        # check inert for the project that motivated it.
+        root = self._checkout(
+            "          - name: ubu24-gcc\n"
+            "            os: ubuntu-24.04\n"
+            "            use-recipe: biodynamo\n"
+            "            recipe-version: v1.06-cr-20260901-01\n"
+            "            recipe-arch: x86_64\n"
+        )
+        self.assertEqual(start.repo_pinned_version(root, self._project()),
+                         "v1.06-cr-20260901-01")
+
+    def test_block_row_scan_stops_at_the_next_row(self):
+        root = self._checkout(
+            "          - name: ubu24-gcc\n"
+            "            os: ubuntu-24.04\n"
+            "          - name: ubu24-clang\n"
+            "            recipe-version: v9.99\n"
+        )
+        self.assertIsNone(start.repo_pinned_version(root, self._project()))
+
+    def test_reads_the_pin_off_an_inline_row(self):
+        root = self._checkout(
+            "          - { name: ubu24-gcc, recipe-version: "
+            "v1.06-cr-20260901-01, arch: x86_64 }\n"
+        )
+        self.assertEqual(start.repo_pinned_version(root, self._project()),
+                         "v1.06-cr-20260901-01")
+
+    def test_other_rows_pin_is_not_picked_up(self):
+        root = self._checkout(
+            "          - { name: other-row, recipe-version: v9.99 }\n"
+        )
+        self.assertIsNone(start.repo_pinned_version(root, self._project()))
+
+    def test_missing_workflow_is_silent(self):
+        self.assertIsNone(
+            start.repo_pinned_version(Path(tempfile.mkdtemp()),
+                                      self._project()))
+
+    def test_a_longer_row_name_is_not_mistaken_for_this_row(self):
+        # Both of these are real CppInterOp rows. A substring test read
+        # the -cppyy row's pin for the plain row and would have pinned a
+        # contributor to LLVM 21 the moment the matrix was reordered.
+        root = self._checkout(
+            "          - { name: ubu24-x86-gcc12-llvm22-cppyy, "
+            "clang-runtime: '21' }\n"
+            "          - { name: ubu24-x86-gcc12-llvm22, "
+            "clang-runtime: '22' }\n"
+        )
+        got = start.repo_pinned_version(
+            root, self._project(row="ubu24-x86-gcc12-llvm22"))
+        self.assertEqual(got, "22")
+
+    def test_a_key_merely_ending_in_name_is_not_the_row_name(self):
+        root = self._checkout(
+            "          - { flavor-name: ubu24-gcc, clang-runtime: '77' }\n"
+        )
+        self.assertIsNone(start.repo_pinned_version(root, self._project()))
+
+    def test_clang_runtime_is_read_when_that_is_what_the_row_names(self):
+        # CppInterOp names no recipe-version at all; reading only that
+        # key left this check inert for half the catalog.
+        root = self._checkout(
+            "          - { name: ubu24-gcc, clang-runtime: '22' }\n"
+        )
+        self.assertEqual(start.repo_pinned_version(root, self._project()),
+                         "22")
+
+    def test_precedence_is_by_key_not_by_line_order(self):
+        root = self._checkout(
+            "          - name: ubu24-gcc\n"
+            "            clang-runtime: '20'\n"
+            "            recipe-version: v9\n"
+        )
+        self.assertEqual(start.repo_pinned_version(root, self._project()),
+                         "v9")
+
+
+class ValueParsingTest(unittest.TestCase):
+    def test_value_after_stops_at_the_field_boundary(self):
+        self.assertEqual(
+            start._value_after("- { name: r, recipe-version: v1, a: b }",
+                               "recipe-version"), "v1")
+        self.assertEqual(
+            start._value_after("            recipe-version: 'v1'",
+                               "recipe-version"), "v1")
+
+    def test_row_name_recognises_both_matrix_shapes(self):
+        self.assertEqual(start._row_name("          - name: ubu24-gcc"),
+                         "ubu24-gcc")
+        self.assertEqual(start._row_name("  - { name: ubu24-gcc, os: x }"),
+                         "ubu24-gcc")
+        self.assertEqual(start._row_name("  - { os: x, name: ubu24-gcc }"),
+                         "ubu24-gcc")
+        self.assertIsNone(start._row_name("            os: ubuntu-24.04"))
+
+
+class RenderTest(unittest.TestCase):
+    def test_each_project_shows_its_cell_and_status(self):
+        projects = start.load_projects(_write(WELL_FORMED))
+        with redirect_stdout(io.StringIO()) as out:
+            start.render(projects, ["published -- 181 MB download",
+                                    "not published yet"])
+        text = out.getvalue()
+        self.assertIn("1  CARTopiaX", text)
+        self.assertIn("2  CppInterOp", text)
+        self.assertIn("biodynamo v1.05-cr-20260812-01", text)
+        self.assertIn("181 MB", text)
+        self.assertIn("not published yet", text)
+
+
+class CellStatusTest(unittest.TestCase):
+    """Three outcomes, three different things for the student to do."""
+
+    PROJECT = {"recipe": "biodynamo", "version": "v1", "os": "ubuntu-24.04",
+               "arch": "x86_64"}
+    CELLS = [{"recipe": "biodynamo", "version": "v1", "os": "ubuntu-24.04",
+              "arch": "x86_64"}]
+
+    def test_coord_absent_from_cells_yaml_is_called_stale(self):
+        repro = mock.Mock()
+        msg = start.cell_status(repro, "https://example/", self.PROJECT, [])
+        self.assertIn("cells.yaml", msg)
+        repro._devshell_compute_key.assert_not_called()
+
+    def test_known_cell_with_no_asset_reads_as_not_published(self):
+        repro = mock.Mock()
+        repro._devshell_compute_key.return_value = "k"
+        with mock.patch.object(start, "_asset_size", return_value=None):
+            msg = start.cell_status(repro, "https://example/",
+                                    self.PROJECT, self.CELLS)
+        self.assertIn("not published", msg)
+
+    def test_published_cell_reports_download_size_in_mib(self):
+        repro = mock.Mock()
+        repro._devshell_compute_key.return_value = "k"
+        with mock.patch.object(start, "_asset_size",
+                               return_value=181 * 1024 * 1024):
+            msg = start.cell_status(repro, "https://example/",
+                                    self.PROJECT, self.CELLS)
+        self.assertIn("181 MB", msg)
+
+
+class SelectTest(unittest.TestCase):
+    def test_accepts_a_valid_number_as_zero_based_index(self):
+        with mock.patch("builtins.input", side_effect=["2"]):
+            self.assertEqual(start.select(3), 1)
+
+    def test_reprompts_on_garbage_then_accepts(self):
+        with mock.patch("builtins.input", side_effect=["x", "9", "1"]):
+            with redirect_stdout(io.StringIO()):
+                self.assertEqual(start.select(3), 0)
+
+    def test_quit_and_eof_both_mean_no_selection(self):
+        with mock.patch("builtins.input", side_effect=["q"]):
+            self.assertIsNone(start.select(3))
+        # EOF matters on its own: a piped run must exit rather than
+        # spin on an endless stream of empty reads.
+        with mock.patch("builtins.input", side_effect=EOFError):
+            with redirect_stdout(io.StringIO()):
+                self.assertIsNone(start.select(3))
+
+
+class LaunchTest(unittest.TestCase):
+    def test_hands_cmd_devshell_every_attribute_it_reads(self):
+        repro = mock.Mock()
+        repro.cmd_devshell.return_value = 0
+        project = start.load_projects(_write(WELL_FORMED))[0]
+        coord = start.coord_of(project)
+
+        with redirect_stdout(io.StringIO()):
+            rc = start.launch(repro, project, Path("/somewhere/CARTopiaX"),
+                              coord)
+
+        self.assertEqual(rc, 0)
+        ns = repro.cmd_devshell.call_args[0][0]
+        # cmd_devshell and its helpers read exactly these; a missing one
+        # is an AttributeError deep inside provisioning.
+        for attr in ("matrix", "devshell_host_cache",
+                     "devshell_host_cache_dir", "devshell_patches_out",
+                     "devshell_image", "devshell_refetch", "devshell_rm",
+                     "devshell_script", "devshell_as_root"):
+            self.assertTrue(hasattr(ns, attr), attr)
+        self.assertEqual(
+            ns.matrix,
+            ["name:biodynamo/v1.05-cr-20260812-01/ubuntu-24.04/x86_64"])
+        # Host-cache mode is the point for a newcomer: the download has
+        # to outlive the container.
+        self.assertTrue(ns.devshell_host_cache)
+
+
+class ResolveCheckoutTest(unittest.TestCase):
+    """The one function that creates directories and runs git clone."""
+
+    PROJECT = {"name": "CARTopiaX", "recipe": "biodynamo", "version": "v1",
+               "repo": "https://github.com/compiler-research/CARTopiaX"}
+
+    def test_existing_checkout_is_reused_and_never_touched(self):
+        # .resolve(), because resolve_checkout does: on macOS /var is a
+        # symlink to /private/var and the two spellings differ.
+        dest = (Path(tempfile.mkdtemp()) / "CARTopiaX").resolve()
+        (dest / ".git").mkdir(parents=True)
+        with mock.patch("builtins.input", side_effect=[str(dest)]), \
+                mock.patch.object(start.subprocess, "run") as run, \
+                redirect_stdout(io.StringIO()):
+            got = start.resolve_checkout(self.PROJECT)
+        self.assertEqual(got, dest)
+        # No pull, no reset, no clone: it is the user's working copy.
+        run.assert_not_called()
+
+    def test_existing_non_git_directory_is_refused(self):
+        # Cloning into it would fail and mkdir-ing over it would be
+        # worse; refusing is the only safe answer.
+        dest = Path(tempfile.mkdtemp()) / "notarepo"
+        dest.mkdir()
+        with mock.patch("builtins.input", side_effect=[str(dest)]), \
+                mock.patch.object(start.subprocess, "run") as run, \
+                redirect_stdout(io.StringIO()):
+            self.assertIsNone(start.resolve_checkout(self.PROJECT))
+        run.assert_not_called()
+
+    def test_declining_the_clone_prompt_creates_nothing(self):
+        dest = Path(tempfile.mkdtemp()) / "nope" / "CARTopiaX"
+        with mock.patch("builtins.input", side_effect=[str(dest), "n"]), \
+                mock.patch.object(start.subprocess, "run") as run, \
+                redirect_stdout(io.StringIO()):
+            self.assertIsNone(start.resolve_checkout(self.PROJECT))
+        run.assert_not_called()
+        self.assertFalse(dest.parent.exists())
+
+    def test_clone_failure_reports_and_yields_no_path(self):
+        dest = Path(tempfile.mkdtemp()) / "CARTopiaX"
+        with mock.patch("builtins.input", side_effect=[str(dest), ""]), \
+                mock.patch.object(start.subprocess, "run") as run, \
+                redirect_stdout(io.StringIO()):
+            run.return_value = mock.Mock(returncode=128)
+            self.assertIsNone(start.resolve_checkout(self.PROJECT))
+
+    def test_eof_at_the_path_prompt_is_not_a_traceback(self):
+        with mock.patch("builtins.input", side_effect=EOFError), \
+                redirect_stdout(io.StringIO()):
+            self.assertIsNone(start.resolve_checkout(self.PROJECT))
+
+
+class PreflightTest(unittest.TestCase):
+    """Preflight gates everything; always-true defeats it, always-false
+    bricks the tool."""
+
+    def test_a_blocking_check_fails_preflight(self):
+        with mock.patch.object(start, "_docker_status",
+                               return_value=(False, "not installed")), \
+                redirect_stdout(io.StringIO()) as out:
+            self.assertFalse(start.preflight())
+        self.assertIn("!", out.getvalue())
+
+    def test_all_clear_passes(self):
+        with mock.patch.object(start, "_docker_status",
+                               return_value=(True, "29.4.0, daemon up")), \
+                redirect_stdout(io.StringIO()):
+            self.assertTrue(start.preflight())
+
+    def test_low_disk_reports_but_does_not_block(self):
+        # Advisory by design: preflight runs before a project is
+        # picked, and the cells differ by an order of magnitude.
+        with mock.patch.object(start.shutil, "disk_usage") as du:
+            du.return_value = mock.Mock(free=2 * 1024 ** 3)
+            ok, detail = start._disk_status()
+        self.assertTrue(ok)
+        self.assertIn("tight", detail)
+
+
+class ListModeTest(unittest.TestCase):
+    def test_list_prints_the_catalog_and_exits_without_prompting(self):
+        with mock.patch.object(start, "_load_repro") as load, \
+                mock.patch.object(start, "cell_status",
+                                  return_value="published -- 1 MB download"), \
+                mock.patch("builtins.input",
+                           side_effect=AssertionError("must not prompt")), \
+                redirect_stdout(io.StringIO()) as out:
+            load.return_value.published_cells.return_value = []
+            self.assertEqual(start.main(["--list"]), 0)
+        self.assertIn("CARTopiaX", out.getvalue())
+
+
+class AssetSizeTest(unittest.TestCase):
+    @unittest.skipIf(sys.platform == "win32",
+                     "file:// paths are POSIX-shaped here, as in cache_io")
+    def test_file_backend_reports_size_and_absence(self):
+        d = Path(tempfile.mkdtemp())
+        (d / "k.tar.zst").write_bytes(b"x" * 1234)
+        self.assertEqual(start._asset_size(f"file://{d}", "k"), 1234)
+        self.assertIsNone(start._asset_size(f"file://{d}", "absent"))
+
+    def test_unsupported_scheme_is_none_not_an_exception(self):
+        self.assertIsNone(start._asset_size("s3://bucket", "k"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bin/test_start.py
+++ b/bin/test_start.py
@@ -242,6 +242,38 @@ class RenderTest(unittest.TestCase):
         self.assertIn("not published yet", text)
 
 
+class DetectProjectTest(unittest.TestCase):
+    """Running from inside a checkout must not ask which project it is."""
+
+    def test_slug_normalises_ssh_https_and_dot_git(self):
+        for url in ("https://github.com/compiler-research/CARTopiaX",
+                    "https://github.com/compiler-research/CARTopiaX.git",
+                    "git@github.com:compiler-research/CARTopiaX.git",
+                    "https://github.com/compiler-research/CARTopiaX/"):
+            self.assertEqual(start._repo_slug(url),
+                             "compiler-research/cartopiax", url)
+
+    def test_matches_on_the_origin_remote_not_the_directory_name(self):
+        projects = start.load_projects(_write(WELL_FORMED))
+        repro = mock.Mock()
+        repro._origin_repo_slug.return_value = "compiler-research/CARTopiaX"
+        with mock.patch.object(start.subprocess, "run") as run:
+            run.return_value = mock.Mock(returncode=0,
+                                         stdout="/home/s/renamed-dir\n")
+            got = start.detect_project(repro, projects)
+        self.assertIsNotNone(got)
+        self.assertEqual(got[0]["name"], "CARTopiaX")
+        self.assertEqual(got[1], Path("/home/s/renamed-dir"))
+
+    def test_uncatalogued_or_non_git_cwd_falls_through_to_the_menu(self):
+        projects = start.load_projects(_write(WELL_FORMED))
+        repro = mock.Mock()
+        repro._origin_repo_slug.return_value = "someone/unrelated"
+        self.assertIsNone(start.detect_project(repro, projects))
+        repro._origin_repo_slug.return_value = None
+        self.assertIsNone(start.detect_project(repro, projects))
+
+
 class CellStatusTest(unittest.TestCase):
     """Three outcomes, three different things for the student to do."""
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -230,6 +230,28 @@ matching the new (version, os, arch) tuple. The push trigger
 takes care of the build on the next merge that touches the
 recipe directory or the workflow file.
 
+## Adding a project to `bin/start`
+
+Add an entry to `projects.yaml`: the clone URL, the matrix row a new
+contributor should develop against, and the cell that row resolves to.
+`verify.yml` fails the PR if the cell is not in `cells.yaml`, so a
+typo or a decommissioned cell cannot reach a student.
+
+Pick the plainest Linux row -- not a sanitizer, cross-compile or
+self-hosted one. This is the environment somebody meets the project in,
+not a matrix audit.
+
+The cell is written out rather than derived from the project's own
+workflows on purpose. There is no single convention to derive it from:
+CARTopiaX annotates its rows with `use-recipe` and `recipe-version`,
+while CppInterOp names a `clang-runtime` plus a `flavor` and leaves the
+recipe to `setup-llvm`. Re-implementing each consumer's mapping is how
+a contributor silently ends up in the wrong toolchain. The `workflow`
+and `row` fields record where the cell came from, and `bin/start` reads
+`recipe-version` back out of that row once the project is cloned -- so
+a project that bumps its pin wins over a stale entry here, and the
+catalog going a little stale is self-healing rather than harmful.
+
 ## Bumping the LLVM version
 
 Change the `version` input on the `setup-recipe` call in your
@@ -366,6 +388,48 @@ bin/repro consumes via `--ci-workflows <path>`.
   exit; if a run is killed hard, remove
   `.github/act-ci-workflows-stage/` and
   `.github/workflows/act-*-localized-*.yml` by hand.
+
+## Onboarding a contributor: `bin/start`
+
+Everything below this line assumes you know which cell you want and
+which flags make it persist. `bin/start` is the same machinery for
+somebody who does not: it reads `projects.yaml`, shows each project
+with its toolchain and whether that cell is published, and hands the
+selection to `--devshell`. It is a front end, not a second
+implementation -- `bin/repro` is imported and `cmd_devshell` called
+directly, the way `bin/test_repro.py` already imports it.
+
+Prerequisites are Docker, git and a Python 3. Not `act`: a project's
+cell is named by coordinate, and `_devshell_cell` short-circuits the
+act matrix lookup for a direct coordinate.
+
+Two entry paths, one command:
+
+```bash
+# from nothing: clone this repo, pick from the menu, it clones for you
+git clone https://github.com/compiler-research/ci-workflows
+cd ci-workflows && ./bin/start
+
+# from a checkout you already have: no menu, no prompts
+cd ~/src/CARTopiaX && ~/src/ci-workflows/bin/start
+```
+
+The second form matches on the `origin` remote rather than the
+directory name, so forks and renamed directories resolve.
+
+On selection it enables host-cache mode -- a newcomer's download should
+survive `docker volume rm` and a machine move -- binds the checkout at
+`/patches`, and lets `repro-config` do the rest: the recipe's
+`devshell-setup.sh`, the ccache wiring, and the Claude Code install.
+Nothing is copied out afterwards, because `/patches` *is* the checkout;
+git runs host-side, where the credentials are and where a container
+running an AI agent cannot reach them.
+
+`--list` prints the catalog and exits, which is also the cheap way to
+see whether a cell has actually been warmed.
+
+To add a project, see
+[Adding a project to `bin/start`](#adding-a-project-to-binstart).
 
 ## Iterating on a recipe with `--devshell`
 
@@ -565,12 +629,29 @@ Idempotent — runs once per fetch, no-ops on rebuild:
    verbatim (exported by `bin/repro` from
    `manifest.build_env.ccache.compiler_check`). Warns when the
    consumer's `$CC --version` diverges.
-5. **cmake configure**: replays the recipe's own cmake invocation
+5. **recipe host deps**: runs
+   `recipes/<recipe>/devshell-setup.sh` off the read-only
+   `/ci-workflows` bind, when the recipe ships one. Step 1 installs
+   the LLVM set and nothing else, so any recipe with dependencies
+   beyond it needs this — without it the biodynamo devshell cannot
+   configure (`We did not find any OpenMPI installation`) or build a
+   consumer against the artifact. Warns rather than aborts.
+
+   The script is deliberately outside `compute_key.py`'s hashed set
+   (`recipe.yaml`, the build script, `patches/**`,
+   `actions/lib/**.py`): it changes what a *devshell* installs, never
+   what the published artifact contains, so editing it must not
+   orphan the recipe's cells. The corollary is that it duplicates
+   `build.py`'s package list by hand — keep the two in step.
+6. **cmake configure**: replays the recipe's own cmake invocation
    from `manifest.cmake_args`, substituting
    `CMAKE_INSTALL_PREFIX` and the source path. Pre-`cmake_args`
    manifests fall back to `llvm_build.base_cmake_args() +
-   LLVM_ENABLE_PROJECTS=clang`.
-6. **smoke compile**: builds
+   LLVM_ENABLE_PROJECTS=clang`. Failure warns rather than aborting,
+   and clears the `CMakeCache.txt` cmake leaves behind on abort so a
+   later session retries — a devshell whose *recipe* source is not
+   configured is still a working devshell.
+7. **smoke compile**: builds
    `lib/Support/CMakeFiles/LLVMSupport.dir/Allocator.cpp.o`. Zero
    ccache hits ⇒ producer cache isn't reaching the consumer (drift
    the earlier checks didn't catch); surfaces a `::warning::`

--- a/projects.yaml
+++ b/projects.yaml
@@ -1,0 +1,51 @@
+# projects.yaml -- the projects `bin/start` offers a newcomer.
+#
+# cells.yaml answers "what does the cache hold"; this file answers "who
+# is it for". They are separate because the two lists diverge: most
+# cells serve several projects, and a project pins exactly one cell for
+# the environment it wants a contributor to develop in -- not
+# necessarily every cell its CI matrix touches.
+#
+# Why the cell is written out here rather than derived from the
+# project's own workflows: there is no single convention to derive it
+# from. CARTopiaX annotates its matrix rows with `use-recipe` /
+# `recipe-version`, but CppInterOp names a `clang-runtime` plus a
+# `flavor` and lets setup-llvm decide the recipe, and other consumers
+# do neither. Reading each project's workflow correctly would mean
+# reimplementing every consumer's mapping, and getting it wrong hands a
+# student a silently wrong toolchain. An explicit row is checked by
+# verify.yml against cells.yaml, so a stale one fails CI here instead.
+#
+# Adding a project:
+#   - Pick the matrix row a new contributor should develop against --
+#     the plainest Linux row, not the sanitizer or cross-compile ones.
+#   - Record its cell. It must already appear in cells.yaml; verify.yml
+#     rejects the entry otherwise.
+#   - `workflow` and `row` are provenance: they say where the cell came
+#     from, and bin/start reads `recipe-version` back out of `workflow`
+#     after cloning so a project that bumps its pin wins over a stale
+#     row here.
+#
+# Fields: name, description, repo, workflow, row, recipe, version, os,
+# arch. All required.
+
+projects:
+  - name: CARTopiaX
+    description: CAR T-cell therapy agent-based model, built on BioDynaMo
+    repo: https://github.com/compiler-research/CARTopiaX
+    workflow: .github/workflows/ci.yml
+    row: ubu24-gcc
+    recipe: biodynamo
+    version: v1.05-cr-20260812-01
+    os: ubuntu-24.04
+    arch: x86_64
+
+  - name: CppInterOp
+    description: C++ interoperability layer backing cppyy and Python bindings
+    repo: https://github.com/compiler-research/CppInterOp
+    workflow: .github/workflows/main.yml
+    row: ubu24-x86-gcc12-llvm22
+    recipe: llvm-release
+    version: '22'
+    os: ubuntu-24.04
+    arch: x86_64


### PR DESCRIPTION
Onboarding onto a ci-workflows-backed project means finding the right matrix row in that project's CI, translating it into a cell coordinate by hand, and knowing which `bin/repro --devshell` flags make the download persist — three steps that each assume familiarity with this repository, which is exactly what a new contributor does not have. `bin/start` asks instead: it lists the projects in a new `projects.yaml` with the toolchain each develops against and whether that cell is published, clones the one you pick, and hands the result to `cmd_devshell`. Run from inside a checkout you already have, it detects the project and skips the menu.

It is a front end, not a second implementation. `bin/repro` is imported the way `bin/test_repro.py` already imports it and `cmd_devshell` is called directly, so provisioning, container naming, ccache wiring and the AI setup stay in one place. Nothing under `actions/lib/` is touched, so no cache key moves and no published asset is orphaned.

**Why a catalog rather than deriving the cell from each project's workflows.** There is no single convention to derive from: CARTopiaX annotates its matrix rows with `use-recipe` / `recipe-version`, while CppInterOp names a `clang-runtime` plus a `flavor` and leaves the recipe to `setup-llvm`. Re-implementing each consumer's mapping is how a contributor ends up in a silently wrong toolchain. `verify.yml` checks every catalog entry against `cells.yaml`, and once a project is cloned its own pinned version overrides a stale row, so a version bump heals itself.

## Testing

40 unit tests across 13 classes in `bin/test_start.py`, run on Linux, macOS and Windows by the existing `python-unit-tests` matrix. The negative cases are the point:

- row `ubu24-x86-gcc12-llvm22` must not match the line for `ubu24-x86-gcc12-llvm22-cppyy` — both are real CppInterOp rows, and an earlier substring match read the wrong row's pin
- a key merely ending in `name` (`flavor-name:`) is not the row name
- version-key precedence is decided by key, not by whichever line came first
- a catalog entry missing a required field is dropped, not fatal — one bad row must not cost the whole menu
- `resolve_checkout` refuses a non-git directory, creates nothing when the clone prompt is declined, and yields no path on clone failure or EOF
- `--list` must not prompt (its `input` mock raises if anything does)

Plus a new `devshell-smoke` job that provisions a real devshell and asserts the five properties one promises: the recipe's host dependencies present, `thisbdm.sh` sets `BDMSYS`, the recipe's own build tree configured, and `claude` on `PATH`. Verified in both directions locally — all five pass, and substituting one unsatisfiable assertion makes the job exit non-zero. It uses the biodynamo cell rather than a cheaper one because that is the only recipe shipping a `devshell-setup.sh`; an LLVM cell cannot regress the hook, since `repro-config` installs LLVM's dependencies regardless. The coordinate is read out of `projects.yaml` so a version bump cannot leave the job testing a cell nobody offers.

Both entry paths were exercised end to end against CARTopiaX through a real pty, each building the project and running its suite inside the container: detection mode from an existing checkout, and menu mode with a fresh clone (which recreates the container for the new `/patches` bind and so re-runs the dependency install from scratch). 3/3 tests pass in both.

## Known limitations

- Drift detection recovers the version only. A project that changes its recipe, os or arch outruns it and needs the `projects.yaml` row updated by hand; `verify.yml` is what catches the result.
- `cell_status` is serial — one `compute_key.py` subprocess and one HTTP HEAD per project before the menu paints. Invisible at two projects, a stall at twenty.
- The smoke job costs a ~1 GB act-image pull plus the cell download on PRs touching `bin/`, `scripts/` or `recipes/`. `verify.yml`'s `paths:` filter already scopes that, and the job is bounded by `timeout-minutes: 30`.
- The smoke job has not run on a GitHub runner yet, only locally against a real container.
