### PR TITLE
[cppjit] Install valgrind from conda-forge on the valgrind cells

### DIFF
--- a/.github/workflows/cppjit.yml
+++ b/.github/workflows/cppjit.yml
@@ -97,11 +97,26 @@ jobs:
               cmake ninja-build g++ git \
               libedit-dev libeigen3-dev libboost-dev
             if [[ "${VALGRIND}" == "true" ]]; then
-              sudo apt-get install -y valgrind libc6-dbg
+              sudo apt-get install -y libc6-dbg
             fi
           elif [[ "${RUNNER_OS}" == "macOS" ]]; then
             brew install ninja eigen boost gnu-sed
           fi
+
+      - name: Setup valgrind
+        if: ${{ inputs.valgrind && runner.os == 'Linux' }}
+        uses: mamba-org/setup-micromamba@v3
+        with:
+          environment-name: valgrind-env
+          create-args: valgrind
+          condarc: |
+            channels:
+              - conda-forge
+
+      - name: Add valgrind to PATH
+        if: ${{ inputs.valgrind && runner.os == 'Linux' }}
+        shell: bash
+        run: echo "${MAMBA_ROOT_PREFIX:-$HOME/micromamba}/envs/valgrind-env/bin" >> "${GITHUB_PATH}"
 
       - name: Setup LLVM ${{ inputs.llvm-version }}
         uses: compiler-research/ci-workflows/actions/setup-llvm@main


### PR DESCRIPTION
ARM valgrind nightly failures in cppjit were caused by a bug **in** valgrind. They are deterministic: the same "Unrecognised instruction at 0x35b8702c" on every nightly run. The instruction is 0x38BFC108 = LDAPRB, an ARMv8.3 FEAT_LRCPC load-acquire byte, i.e. an atomic acquire load. The JIT emits it because the arm runner's CPU supports LRCPC, but Ubuntu 24.04's valgrind 3.22.0 can't decode it, so valgrind raises SIGILL and kills pytest mid-suite. Memcheck itself reports 0 errors.

Bug: https://bugs.kde.org/show_bug.cgi?id=476465
Fix: https://sourceware.org/git/?p=valgrind.git;a=commit;h=41e2f95cf129191555e0048ccbbb392ee0fb155e

The valgrind release carrying the fix is not published for the Ubuntu version on the CI runners, so
this installs valgrind from conda-forge, which packages latest valgrind for both linux-64 and
linux-aarch64. I've verified this works on compiler-research/cppjit#29: both cells install valgrind 3.27.1 and pass on both architectures, with the previously-gated concurrency tests re-enabled on arm.
