### PR TITLE
setup-recipe: pass the key's architecture to an inline build.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -156,8 +156,15 @@ jobs:
               fi
             done
             coord=$(yq -r ".projects[$i] | [.recipe, .version, .os, .arch] | @tsv" projects.yaml)
-            if ! yq -r '.cells[] | [.recipe, .version, .os, .arch] | @tsv' cells.yaml \
-                 | grep -qxF "$coord"; then
+            # Materialise the cell list before matching. `grep -q` exits on
+            # the first match, which SIGPIPEs yq, and `set -o pipefail` then
+            # reports the whole pipeline as failed -- so a cell that IS
+            # present reads as absent whenever it appears early enough for
+            # grep to bail before yq finishes writing. That made the check
+            # position-dependent: the last cell in the file always passed,
+            # anything nearer the top failed.
+            cells=$(yq -r '.cells[] | [.recipe, .version, .os, .arch] | @tsv' cells.yaml)
+            if ! grep -qxF "$coord" <<<"$cells"; then
               echo "::error file=projects.yaml::$name names a cell absent from cells.yaml: $coord"
               fail=1
             fi

--- a/actions/setup-recipe/action.yml
+++ b/actions/setup-recipe/action.yml
@@ -209,6 +209,7 @@ runs:
       shell: bash
       env:
         RECIPE_VERSION: ${{ inputs.version }}
+        RECIPE_ARCH: ${{ steps.slugs.outputs.arch }}
         WORK_DIR: ${{ github.workspace }}/_recipe_work
         OUT_DIR: ${{ github.workspace }}/_recipe_out
       run: |


### PR DESCRIPTION
publish-recipe exports RECIPE_ARCH so a build script can fetch the right architecture's artifacts. The inline build-on-miss path in setup-recipe never did, so a recipe that needs the arch had to guess it from the host -- and the host is not always what the cache key says. Under act on an Apple Silicon machine the container is arm64 while the consumer asks for ubuntu-24.04/x86_64, and the guess quietly files arm64 content under an x86_64 key.

No existing recipe noticed because they all build from source with the host toolchain, where host and key agree by construction. A recipe that downloads prebuilt per-architecture artifacts does not have that luxury.