### PR TITLE
Add a headers-only CUDA recipe for jobs that only parse CUDA.

### DIFF
--- a/actions/setup-cuda/action.yml
+++ b/actions/setup-cuda/action.yml
@@ -1,0 +1,131 @@
+name: 'Setup CUDA headers'
+description: |
+  Resolves a headers-only CUDA prefix via the `cuda-headers` recipe, for jobs
+  that need clang's CUDA mode but never compile for a device -- running
+  clang-tidy over .cu/.cuh is the motivating case. ~19 MB, no nvcc, no device
+  libraries, no GPU.
+
+  The prefix lands at $GITHUB_WORKSPACE/cuda and CUDA_PATH is exported. Any
+  pre-existing install/ is preserved, so ordering against setup-llvm does not
+  matter.
+
+  Pass the prefix to clang as `--cuda-path`, with `--cuda-host-only` and
+  `-nocudalib`: there are no device libraries here to compile against.
+
+inputs:
+  version:
+    required: false
+    default: '12.8.1'
+    description: |
+      CUDA release to assemble, as it appears in NVIDIA's
+      redistrib_<version>.json. Prefer one the analysing clang recognises;
+      a newer one parses fine but draws -Wunknown-cuda-version.
+  os:
+    required: true
+    description: |
+      OS slug for the recipe cache key -- a runner-image name like
+      "ubuntu-24.04". Must match a cells.yaml entry warmed for the
+      cuda-headers recipe.
+  arch:
+    required: false
+    default: ''
+    description: |
+      Architecture slug (x86_64 / arm64). Derived from the os slug when
+      empty (ubuntu-*-arm -> arm64, else x86_64).
+  build-on-miss:
+    required: false
+    default: 'false'
+    description: 'Forwarded to setup-recipe: assemble inline on a cache miss instead of failing fast.'
+  ref:
+    required: false
+    default: 'main'
+    description: 'ci-workflows ref for setup-recipe to read recipes/ from.'
+  cache-base:
+    required: false
+    default: ''
+    description: 'Forwarded to setup-recipe: override the recipe cache backend.'
+
+outputs:
+  prefix:
+    description: 'CUDA prefix ($GITHUB_WORKSPACE/cuda); pass to clang as --cuda-path.'
+    value: ${{ steps.finalize.outputs.prefix }}
+  cache-hit:
+    description: '"true" when the recipe came from the cache, "false" when assembled inline.'
+    value: ${{ steps.recipe.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve arch
+      id: resolve
+      shell: bash
+      env:
+        OS: ${{ inputs.os }}
+        ARCH_IN: ${{ inputs.arch }}
+      run: |
+        set -euo pipefail
+        if [[ -n "${ARCH_IN}" ]]; then
+          arch="${ARCH_IN}"
+        else
+          case "${OS}" in
+            *-arm) arch=arm64 ;;
+            *)     arch=x86_64 ;;
+          esac
+        fi
+        echo "arch=${arch}" >> "$GITHUB_OUTPUT"
+
+    # setup-recipe places the recipe at $GITHUB_WORKSPACE/install and
+    # `rm -rf`s that path first. Move any pre-existing install/ (e.g.
+    # setup-llvm's) aside so setup-cuda is order-independent.
+    - name: Preserve existing install prefix
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -d "${GITHUB_WORKSPACE}/install" ]]; then
+          rm -rf "${GITHUB_WORKSPACE}/.install.pre-cuda"
+          mv "${GITHUB_WORKSPACE}/install" "${GITHUB_WORKSPACE}/.install.pre-cuda"
+        fi
+
+    - name: CUDA headers recipe (cache or inline assembly)
+      id: recipe
+      uses: compiler-research/ci-workflows/actions/setup-recipe@main
+      with:
+        recipe:        cuda-headers
+        version:       ${{ inputs.version }}
+        os:            ${{ inputs.os }}
+        arch:          ${{ steps.resolve.outputs.arch }}
+        build-on-miss: ${{ inputs.build-on-miss }}
+        ref:           ${{ inputs.ref }}
+        cache-base:    ${{ inputs.cache-base }}
+
+    - name: Relocate CUDA and restore install prefix
+      shell: bash
+      run: |
+        set -euo pipefail
+        rm -rf "${GITHUB_WORKSPACE}/cuda"
+        mv "${GITHUB_WORKSPACE}/install" "${GITHUB_WORKSPACE}/cuda"
+        if [[ -d "${GITHUB_WORKSPACE}/.install.pre-cuda" ]]; then
+          mv "${GITHUB_WORKSPACE}/.install.pre-cuda" "${GITHUB_WORKSPACE}/install"
+        fi
+
+    - name: Finalize outputs
+      id: finalize
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        RECIPE_HIT: ${{ steps.recipe.outputs.cache-hit }}
+      run: |
+        set -euo pipefail
+        prefix="${GITHUB_WORKSPACE}/cuda"
+        # Fail here rather than let a consumer hit clang's much vaguer
+        # "cannot find CUDA installation" later.
+        for required in include/cuda.h include/crt bin nvvm/libdevice; do
+          if [[ ! -e "${prefix}/${required}" ]]; then
+            echo "::error title=setup-cuda::prefix is missing ${required}"
+            exit 1
+          fi
+        done
+        echo "prefix=${prefix}"    >> "$GITHUB_OUTPUT"
+        echo "CUDA_PATH=${prefix}" >> "$GITHUB_ENV"
+        src=$([[ "${RECIPE_HIT}" == "true" ]] && echo recipe-cache || echo inline-build)
+        echo "::notice title=setup-cuda::version=${VERSION} source=${src} prefix=${prefix}"

--- a/cells.yaml
+++ b/cells.yaml
@@ -71,6 +71,9 @@ cells:
   # When LLVM 23 ships, bump the version on these rows; the LLVM 22
   # cells age out via prune-cache after grace_days.
   - { recipe: llvm-release, version: '22',         os: ubuntu-24.04,     arch: x86_64 }
+  # cuda-headers: 12.8 is the newest CUDA clang 21 recognises, which keeps
+  # -Wunknown-cuda-version out of consumers' findings.
+  - { recipe: cuda-headers, version: '12.8.1',     os: ubuntu-24.04,     arch: x86_64 }
   - { recipe: llvm-release, version: '22',         os: ubuntu-24.04-arm, arch: arm64  }
   - { recipe: llvm-release, version: '22',         os: macos-26,         arch: arm64  }
   - { recipe: llvm-release, version: '22',         os: macos-26-intel,   arch: x86_64 }

--- a/recipes/cuda-headers/build.py
+++ b/recipes/cuda-headers/build.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Assembles a headers-only CUDA prefix from NVIDIA's redistributables.
+
+See recipe.yaml for what is included and why.
+
+Inputs (env): RECIPE_VERSION / RECIPE_ARCH / WORK_DIR / OUT_DIR, per the
+contract in actions/lib/llvm_build.py.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tarfile
+import urllib.request
+from pathlib import Path
+
+REDIST = "https://developer.download.nvidia.com/compute/cuda/redist"
+
+# cudart, nvcc and curand between them hold everything clang's force-included
+# __clang_cuda_runtime_wrapper.h reaches; cccl adds Thrust/CUB/libcu++.
+COMPONENTS = ("cuda_cudart", "cuda_nvcc", "cuda_cccl", "libcurand")
+
+# NVIDIA's platform keys, which are not the runner-image slugs. Linux only:
+# the recipe never sees the cell's OS (setup-recipe exports the arch but not
+# the slug), so a non-Linux cell would be served these silently. cells.yaml
+# is what keeps that from happening.
+ARCH_KEY = {"x86_64": "linux-x86_64", "arm64": "linux-sbsa"}
+
+
+def fetch(url: str, dest: Path, sha256: str | None = None) -> None:
+    """Downloads to dest, verifying against the manifest's digest."""
+    digest = hashlib.sha256()
+    with urllib.request.urlopen(url) as r, dest.open("wb") as f:
+        while chunk := r.read(1 << 20):
+            digest.update(chunk)
+            f.write(chunk)
+    if sha256 and digest.hexdigest() != sha256:
+        raise RuntimeError(
+            f"{dest.name}: sha256 {digest.hexdigest()} != manifest {sha256}")
+
+
+def copy_tree(src: Path, dst: Path) -> None:
+    dst.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(src, dst, dirs_exist_ok=True)
+
+
+def main() -> int:
+    version = os.environ["RECIPE_VERSION"]
+    work = Path(os.environ["WORK_DIR"])
+    # setup-recipe moves exactly $OUT_DIR/install and ignores anything else.
+    out = Path(os.environ["OUT_DIR"]) / "install"
+
+    # The arch must be the one the cache key was computed from, not the
+    # host's -- guessing would file one architecture's headers under
+    # another's key.
+    arch = os.environ.get("RECIPE_ARCH")
+    if not arch:
+        print("error: RECIPE_ARCH is unset", file=sys.stderr)
+        return 1
+    plat = ARCH_KEY.get(arch)
+    if plat is None:
+        print(f"error: unsupported arch {arch!r}", file=sys.stderr)
+        return 1
+    work.mkdir(parents=True, exist_ok=True)
+    manifest_path = work / f"redistrib_{version}.json"
+    fetch(f"{REDIST}/redistrib_{version}.json", manifest_path)
+    manifest = json.loads(manifest_path.read_text())
+
+    out.joinpath("include").mkdir(parents=True, exist_ok=True)
+    # clang's probe rejects the prefix outright without bin/, but never looks
+    # inside it for a host-only parse.
+    out.joinpath("bin").mkdir(parents=True, exist_ok=True)
+
+    for name in COMPONENTS:
+        comp = manifest.get(name)
+        if comp is None or plat not in comp:
+            print(f"error: {name} has no {plat} in {version}", file=sys.stderr)
+            return 1
+        entry = comp[plat]
+        rel = entry["relative_path"]
+        print(f"{name} {comp['version']}: {rel}", flush=True)
+        tarball = work / Path(rel).name
+        fetch(f"{REDIST}/{rel}", tarball, entry.get("sha256"))
+        with tarfile.open(tarball) as tf:
+            # Pinned: the default differs across Python versions.
+            tf.extractall(work, filter="data")
+        root = work / Path(rel).name.replace(".tar.xz", "")
+
+        if (root / "include").is_dir():
+            copy_tree(root / "include", out / "include")
+        # The one non-header the probe checks for. Never read by a host-only
+        # parse.
+        if (root / "nvvm" / "libdevice").is_dir():
+            copy_tree(root / "nvvm" / "libdevice", out / "nvvm" / "libdevice")
+
+    # clang itself reads CUDA_VERSION from cuda.h; this is for tooling that
+    # expects the file.
+    (out / "version.txt").write_text(f"CUDA Version {version}\n")
+
+    total = sum(p.stat().st_size for p in out.rglob("*") if p.is_file())
+    print(f"cuda-headers {version} ({arch}): {total / 1e6:.1f} MB", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/recipes/cuda-headers/recipe.yaml
+++ b/recipes/cuda-headers/recipe.yaml
@@ -1,0 +1,24 @@
+recipe: cuda-headers
+description: |
+  The CUDA headers clang needs to parse CUDA, and nothing else: no nvcc, no
+  device libraries, no driver, ~19 MB extracted.
+
+  Analysis-only consumers -- clang-tidy over .cu/.cuh -- never compile for a
+  device and never link, but they still need clang's CUDA installation probe
+  to succeed, and that probe wants an install layout rather than a working
+  toolkit. Four of NVIDIA's per-component redistributables supply it:
+  cuda_cudart, cuda_nvcc and libcurand cover everything clang's
+  force-included wrapper header reaches, and cuda_cccl adds Thrust, CUB and
+  libcu++.
+
+  Prefer a version the analysing clang recognises. A newer CUDA still parses
+  correctly, but draws -Wunknown-cuda-version, which a consumer enabling
+  clang-diagnostic-* reports as a finding.
+
+  Linux only, and the recipe cannot enforce that itself; see build.py.
+
+# Not a git source. `repo` is provenance; the components and their versions
+# come from redistrib_{version}.json.
+source:
+  repo: https://developer.download.nvidia.com/compute/cuda/redist
+  branch_template: '{version}'


### PR DESCRIPTION
A consumer that runs clang-tidy over .cu/.cuh sources never compiles for a device and never links, but clang refuses to enter CUDA mode until its installation probe finds one. Provisioning several GB of toolkit, or an apt package whose headers land where --cuda-path cannot see them, is the wrong shape for a job that executes nothing.

Assemble the prefix from NVIDIA's per-component redistributables instead: 19 MB covering what clang's force-included wrapper header reaches, plus Thrust and CUB. The probe also insists on nvvm/libdevice and a bin/ directory, so both are present -- bin/ empty, since a host-only parse never looks inside it. Downloads are checked against the manifest's sha256.

The cell pins 12.8, the newest clang 21 recognises. Running ahead of the analyser is harmless to parsing but draws -Wunknown-cuda-version, which a consumer enabling clang-diagnostic-* would report as a finding.