### PR TITLE
Add an action that prepares a build for clang-tidy review.

### DIFF
--- a/actions/setup-clang-tidy/action.yml
+++ b/actions/setup-clang-tidy/action.yml
@@ -1,0 +1,133 @@
+name: 'Setup clang-tidy build'
+description: |
+  Provisions a toolchain and produces the compilation database clang-tidy
+  needs, so a consumer's review step only has to review.
+
+  Everything a compile command names has to sit under the workspace: the
+  review action runs in a container mounting only that, and rewrites paths
+  beneath `base_dir` to match. Hence the LLVM recipe flavor rather than
+  flavor=system, which symlinks the prefix at /usr/lib/llvm-NN.
+
+  Requires cmake on the runner, as GitHub-hosted images provide.
+
+inputs:
+  version:
+    required: true
+    description: 'LLVM major version to build and analyse against.'
+  os:
+    required: true
+    description: 'Runner-image slug for the recipe cache key, e.g. "ubuntu-24.04".'
+  arch:
+    required: false
+    default: ''
+    description: 'Architecture slug; derived from the os slug when empty.'
+  cuda-version:
+    required: false
+    default: ''
+    description: |
+      CUDA release to provision headers for, e.g. "12.8.1". Empty skips CUDA
+      entirely, and no CUDA compile commands are added.
+  source-dir:
+    required: false
+    default: '.'
+    description: 'Project source directory to configure.'
+  build-dir:
+    required: false
+    default: 'build'
+    description: 'Build directory to write, relative to the workspace.'
+  force-include:
+    required: false
+    default: ''
+    description: |
+      Header to prepend to every generated command, for sources that are not
+      self-contained -- a header written to be included after something else.
+  cmake-args:
+    required: false
+    default: ''
+    description: 'Extra arguments for the configure step.'
+  build-on-miss:
+    required: false
+    default: 'false'
+    description: 'Forwarded to the recipe actions.'
+  ref:
+    required: false
+    default: 'main'
+    description: 'ci-workflows ref the recipe actions read recipes/ from.'
+
+outputs:
+  build-dir:
+    description: 'Absolute path of the configured build directory.'
+    value: ${{ steps.configure.outputs.build-dir }}
+  llvm-prefix:
+    description: 'LLVM install prefix, under the workspace.'
+    value: ${{ steps.llvm.outputs.prefix }}
+
+runs:
+  using: composite
+  steps:
+    # flavor: '' is the recipe, a self-contained tree under the workspace.
+    # flavor=system would symlink it outside, where the review container
+    # cannot follow.
+    - name: Setup LLVM
+      id: llvm
+      uses: compiler-research/ci-workflows/actions/setup-llvm@main
+      with:
+        version:       ${{ inputs.version }}
+        os:            ${{ inputs.os }}
+        arch:          ${{ inputs.arch }}
+        flavor:        ''
+        build-on-miss: ${{ inputs.build-on-miss }}
+        ref:           ${{ inputs.ref }}
+
+    - name: Setup CUDA headers
+      if: inputs.cuda-version != ''
+      uses: compiler-research/ci-workflows/actions/setup-cuda@main
+      with:
+        version:       ${{ inputs.cuda-version }}
+        os:            ${{ inputs.os }}
+        arch:          ${{ inputs.arch }}
+        build-on-miss: ${{ inputs.build-on-miss }}
+        ref:           ${{ inputs.ref }}
+
+    - name: Configure
+      id: configure
+      shell: bash
+      env:
+        SOURCE_DIR: ${{ inputs.source-dir }}
+        BUILD_DIR: ${{ inputs.build-dir }}
+        CMAKE_ARGS: ${{ inputs.cmake-args }}
+        LLVM_PREFIX: ${{ steps.llvm.outputs.prefix }}
+        LLVM_CMAKE_DIR: ${{ steps.llvm.outputs.llvm-dir }}
+        CLANG_CMAKE_DIR: ${{ steps.llvm.outputs.clang-dir }}
+      run: |
+        set -euo pipefail
+        if ! command -v cmake >/dev/null; then
+          echo "::error title=setup-clang-tidy::cmake is not on PATH"
+          exit 1
+        fi
+        build="${GITHUB_WORKSPACE}/${BUILD_DIR}"
+        # Analyse with the toolchain we provisioned, not the runner's.
+        CC="${LLVM_PREFIX}/bin/clang" CXX="${LLVM_PREFIX}/bin/clang++" \
+        cmake -S "${SOURCE_DIR}" -B "${build}" \
+              -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
+              -DLLVM_DIR="${LLVM_CMAKE_DIR}" \
+              -DClang_DIR="${CLANG_CMAKE_DIR}" \
+              ${CMAKE_ARGS}
+        echo "build-dir=${build}" >> "$GITHUB_OUTPUT"
+
+    # CMake emits nothing for a header, or for a language the project does
+    # not compile itself -- which is every CUDA source here. Without these
+    # clang-tidy reads them in the wrong language.
+    - name: Add compile commands CMake does not emit
+      shell: bash
+      env:
+        BUILD: ${{ steps.configure.outputs.build-dir }}
+        SOURCE_DIR: ${{ inputs.source-dir }}
+        FORCE_INCLUDE: ${{ inputs.force-include }}
+      run: |
+        set -euo pipefail
+        args=("${BUILD}" "${SOURCE_DIR}")
+        if [[ -n "${FORCE_INCLUDE}" ]]; then
+          args+=(--force-include "${FORCE_INCLUDE}")
+        fi
+        python3 "${GITHUB_ACTION_PATH}/add_language_commands.py" "${args[@]}"

--- a/actions/setup-clang-tidy/add_language_commands.py
+++ b/actions/setup-clang-tidy/add_language_commands.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Adds compile commands CMake does not emit, so clang-tidy can parse them.
+
+clang-tidy is invoked per file against one compilation database and answers
+from that alone. CMake writes an entry per built source, leaving out every
+header and every language the project compiles some other way. clang-tidy
+then falls back to a neighbouring entry and reads the file in the wrong
+language, reporting errors about that rather than about the code.
+
+Generated commands inherit the flags of a C++ entry already in the database,
+so they carry the project's own includes, defines and standard rather than a
+guess at them.
+
+Usage: add_language_commands.py <build-dir> [<source-dir>] [--force-include H]
+"""
+
+import json
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+HEADER_SUFFIXES = (".h", ".hpp", ".hh", ".hxx")
+
+# Flags whose value is the next argument rather than joined to them. Keeping
+# the flag but dropping its value is how an -isystem include path silently
+# goes missing.
+VALUE_FLAGS = frozenset({
+    "-I", "-isystem", "-iquote", "-idirafter", "-include", "-imacros",
+    "-D", "-U", "-F", "-isysroot", "--sysroot", "-target", "-x", "-arch",
+})
+CXX_SUFFIXES = (".cpp", ".cc", ".cxx", ".C")
+
+# suffixes: files this language owns by name. content: what marks a header as
+# belonging to it, since a name does not. env: the variable naming the
+# toolchain root; unset means the consumer did not ask for this language.
+LANGUAGES = {
+    "cuda": {
+        "suffixes": (".cu", ".cuh"),
+        "content": re.compile(r"__device__|__global__|#\s*include\s*<thrust/"),
+        "env": "CUDA_PATH",
+        # --cuda-host-only parses device code with no nvcc, no device
+        # libraries and no GPU. -Wno-unknown-cuda-version so a toolkit newer
+        # than the analysing clang is not itself a finding.
+        "flags": lambda root: ["-xcuda", "--cuda-host-only", "-nocudalib",
+                               f"--cuda-path={root}",
+                               "-Wno-unknown-cuda-version"],
+    },
+}
+
+
+def argv_of(entry: dict) -> list[str]:
+    return entry["arguments"] if "arguments" in entry else shlex.split(entry["command"])
+
+
+def base_command(db: list[dict]) -> list[str]:
+    """Compiler and flags from a C++ entry, minus its input and output."""
+    for entry in db:
+        if Path(entry["file"]).suffix not in CXX_SUFFIXES:
+            continue
+        argv = argv_of(entry)
+        kept, i = [argv[0]], 1
+        while i < len(argv):
+            arg = argv[i]
+            if arg == "-o":
+                i += 2
+            elif arg == "-c":
+                i += 1
+            elif arg in VALUE_FLAGS and i + 1 < len(argv):
+                kept += [arg, argv[i + 1]]
+                i += 2
+            elif arg.startswith("-"):
+                kept.append(arg)
+                i += 1
+            else:
+                i += 1  # a bare path: the input file
+        return kept
+    raise SystemExit("error: no C++ entry to take flags from")
+
+
+def tracked(source: Path, patterns: list[str]) -> list[str]:
+    return subprocess.run(["git", "ls-files", *patterns], cwd=source,
+                          capture_output=True, text=True,
+                          check=True).stdout.split()
+
+
+def files_for(lang: dict, source: Path) -> list[Path]:
+    patterns = [f"*{s}" for s in (*lang["suffixes"], *HEADER_SUFFIXES)]
+    found = []
+    for rel in tracked(source, patterns):
+        path = source / rel
+        if path.suffix in lang["suffixes"]:
+            found.append(path)
+        elif lang["content"].search(path.read_text(errors="ignore")):
+            found.append(path)
+    return found
+
+
+def needs_prelude(path: Path) -> bool:
+    """A file including nothing of the project's own expects to follow one."""
+    return not re.search(r'^#\s*include\s*"', path.read_text(errors="ignore"),
+                         re.M)
+
+
+def add_commands(db: list[dict], build: Path, source: Path, environ: dict,
+                 prelude: list[str]) -> dict[str, int]:
+    base = base_command(db)
+    known = {e["file"] for e in db}
+    added = {}
+    for name, lang in LANGUAGES.items():
+        root = environ.get(lang["env"])
+        if not root:
+            continue
+        count = 0
+        for src in files_for(lang, source):
+            if str(src) in known:
+                continue
+            extra = prelude if prelude and needs_prelude(src) else []
+            db.append({
+                "directory": str(build),
+                "file": str(src),
+                "arguments": [*base, *lang["flags"](root), *extra,
+                              "-c", str(src)],
+            })
+            count += 1
+        added[name] = count
+    return added
+
+
+def main() -> int:
+    import os
+
+    args = sys.argv[1:]
+    prelude = []
+    if "--force-include" in args:
+        i = args.index("--force-include")
+        prelude = ["-include", args[i + 1]]
+        del args[i:i + 2]
+
+    build = Path(args[0]).resolve()
+    source = Path(args[1] if len(args) > 1 else ".").resolve()
+    db_path = build / "compile_commands.json"
+    if not db_path.exists():
+        print(f"error: no {db_path}; did cmake export it?", file=sys.stderr)
+        return 1
+    db = json.loads(db_path.read_text())
+
+    for name, count in add_commands(db, build, source, os.environ,
+                                    prelude).items():
+        print(f"{name}: added {count} compile commands")
+    db_path.write_text(json.dumps(db, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/actions/setup-clang-tidy/test_add_language_commands.py
+++ b/actions/setup-clang-tidy/test_add_language_commands.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Unit tests for add_language_commands."""
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import add_language_commands as alc  # noqa: E402
+
+
+class TestBaseCommand(unittest.TestCase):
+    def test_prefers_a_cxx_entry_over_whatever_is_first(self):
+        # A database can lead with the C compiler; the flags we copy have to
+        # come from a C++ entry or the generated command is a C one.
+        db = [{"file": "/p/a.c", "command": "/bin/clang -DC_ONLY -c /p/a.c"},
+              {"file": "/p/b.cpp",
+               "command": "/bin/clang++ -DCXX -I/p/inc -std=c++20 -c /p/b.cpp"}]
+        self.assertEqual(alc.base_command(db),
+                         ["/bin/clang++", "-DCXX", "-I/p/inc", "-std=c++20"])
+
+    def test_drops_the_input_and_output(self):
+        db = [{"file": "/p/b.cpp",
+               "command": "/bin/clang++ -I/p -c /p/b.cpp -o /p/b.o"}]
+        self.assertEqual(alc.base_command(db), ["/bin/clang++", "-I/p"])
+
+    def test_reads_the_arguments_form_too(self):
+        db = [{"file": "/p/b.cpp",
+               "arguments": ["/bin/clang++", "-I/p", "-c", "/p/b.cpp"]}]
+        self.assertEqual(alc.base_command(db), ["/bin/clang++", "-I/p"])
+
+    def test_keeps_the_value_of_a_separated_flag(self):
+        # -isystem's value is the next argument; dropping it is how a
+        # project's own include path goes missing.
+        db = [{"file": "/p/b.cpp",
+               "command": "/bin/clang++ -isystem /p/include -I/q -c /p/b.cpp"}]
+        self.assertEqual(alc.base_command(db),
+                         ["/bin/clang++", "-isystem", "/p/include", "-I/q"])
+
+    def test_no_cxx_entry_is_an_error_not_a_wrong_answer(self):
+        with self.assertRaises(SystemExit):
+            alc.base_command([{"file": "/p/a.c", "command": "/bin/clang -c /p/a.c"}])
+
+
+class TestPrelude(unittest.TestCase):
+    def setUp(self):
+        self.dir = Path(__file__).resolve().parent / "_t"
+        self.dir.mkdir(exist_ok=True)
+
+    def tearDown(self):
+        for f in self.dir.iterdir():
+            f.unlink()
+        self.dir.rmdir()
+
+    def test_a_header_including_its_own_needs_no_prelude(self):
+        p = self.dir / "self.cuh"
+        p.write_text('#include "project/config.h"\n__device__ void f();\n')
+        self.assertFalse(alc.needs_prelude(p))
+
+    def test_a_header_including_nothing_of_its_own_needs_one(self):
+        p = self.dir / "bare.h"
+        p.write_text("#include <thrust/reduce.h>\nCUDA_HOST_DEVICE void f();\n")
+        self.assertTrue(alc.needs_prelude(p))
+
+
+class TestAddCommands(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(__file__).resolve().parent / "_r"
+        self.root.mkdir(exist_ok=True)
+        subprocess.run(["git", "init", "-q"], cwd=self.root, check=True)
+        (self.root / "k.cu").write_text("__global__ void k() {}\n")
+        (self.root / "plain.h").write_text("int f();\n")
+        subprocess.run(["git", "add", "-A"], cwd=self.root, check=True)
+
+    def tearDown(self):
+        subprocess.run(["rm", "-rf", str(self.root)], check=True)
+
+    def _db(self):
+        return [{"file": "/p/b.cpp",
+                 "command": "/bin/clang++ -I/p -std=c++17 -c /p/b.cpp"}]
+
+    def test_adds_cuda_and_leaves_plain_headers_alone(self):
+        db = self._db()
+        added = alc.add_commands(db, Path("/b"), self.root,
+                                 {"CUDA_PATH": "/cuda"}, [])
+        self.assertEqual(added["cuda"], 1)
+        entry = db[-1]
+        self.assertTrue(entry["file"].endswith("k.cu"))
+        # Inherited from the C++ entry, not invented.
+        self.assertIn("-I/p", entry["arguments"])
+        self.assertIn("-std=c++17", entry["arguments"])
+        self.assertIn("--cuda-path=/cuda", entry["arguments"])
+
+    def test_without_the_env_the_language_is_skipped(self):
+        db = self._db()
+        self.assertEqual(alc.add_commands(db, Path("/b"), self.root, {}, []), {})
+        self.assertEqual(len(db), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
clang-tidy is invoked per file against one compilation database and answers from that alone. CMake writes an entry per built source, leaving out every header and every language the project compiles some other way -- CUDA, in the case that prompted this. clang-tidy then falls back to a neighbouring entry and reads the file in the wrong language, reporting errors about that rather than about the code. Consumers also each arrange a toolchain before handing the job to the review action.

Do both here. The action provisions LLVM and, on request, the CUDA headers, configures the project, then adds the commands CMake did not emit, one recipe per language. Generated commands inherit the flags of a C++ entry already present, so they carry the project's own includes, defines and standard rather than a guess at them. The LLVM recipe flavor is required rather than flavor=system: the review action runs in a container mounting only the workspace and rewrites paths beneath base_dir to match, so anything a compile command names has to live there.

A header written to be included after something else needs that something; --force-include names it, and it is applied only to headers that include nothing of the project's own -- prepending it to one the prelude already reaches would include the file before clang-tidy got there, leaving it nothing to report.