### PR TITLE
setup-recipe: pass the key's OS to a build, as it does the arch.

### DIFF
--- a/actions/publish-recipe/action.yml
+++ b/actions/publish-recipe/action.yml
@@ -241,6 +241,7 @@ runs:
       env:
         RECIPE_VERSION: ${{ inputs.version }}
         RECIPE_ARCH: ${{ steps.slugs.outputs.arch }}
+        RECIPE_OS: ${{ steps.slugs.outputs.os }}
         WORK_DIR: ${{ github.workspace }}/_recipe_work
         OUT_DIR: ${{ github.workspace }}/_recipe_out
         CMAKE_C_COMPILER_LAUNCHER: ccache

--- a/actions/setup-recipe/action.yml
+++ b/actions/setup-recipe/action.yml
@@ -210,6 +210,7 @@ runs:
       env:
         RECIPE_VERSION: ${{ inputs.version }}
         RECIPE_ARCH: ${{ steps.slugs.outputs.arch }}
+        RECIPE_OS: ${{ steps.slugs.outputs.os }}
         WORK_DIR: ${{ github.workspace }}/_recipe_work
         OUT_DIR: ${{ github.workspace }}/_recipe_out
       run: |

--- a/recipes/cuda-headers/build.py
+++ b/recipes/cuda-headers/build.py
@@ -24,10 +24,8 @@ REDIST = "https://developer.download.nvidia.com/compute/cuda/redist"
 # __clang_cuda_runtime_wrapper.h reaches; cccl adds Thrust/CUB/libcu++.
 COMPONENTS = ("cuda_cudart", "cuda_nvcc", "cuda_cccl", "libcurand")
 
-# NVIDIA's platform keys, which are not the runner-image slugs. Linux only:
-# the recipe never sees the cell's OS (setup-recipe exports the arch but not
-# the slug), so a non-Linux cell would be served these silently. cells.yaml
-# is what keeps that from happening.
+# NVIDIA's platform keys, which are not the runner-image slugs. Linux only;
+# main() refuses a cell for anything else.
 ARCH_KEY = {"x86_64": "linux-x86_64", "arm64": "linux-sbsa"}
 
 
@@ -64,6 +62,15 @@ def main() -> int:
     plat = ARCH_KEY.get(arch)
     if plat is None:
         print(f"error: unsupported arch {arch!r}", file=sys.stderr)
+        return 1
+
+    # Only Linux components are mapped above, and NVIDIA ships Windows ones
+    # too, so a cell for another OS would otherwise be served Linux headers
+    # without complaint.
+    os_slug = os.environ.get("RECIPE_OS", "")
+    if os_slug and not os_slug.startswith("ubuntu"):
+        print(f"error: {os_slug} is not supported; this recipe is Linux only",
+              file=sys.stderr)
         return 1
     work.mkdir(parents=True, exist_ok=True)
     manifest_path = work / f"redistrib_{version}.json"


### PR DESCRIPTION
Both recipe actions export RECIPE_ARCH so a build script can fetch the right architecture's artifacts, but not the OS, though the cache key is computed from both. A recipe that ships prebuilt per-platform files has no way to tell which platform it is being built for, and can only assume.

cuda-headers assumed Linux, which is all it maps -- so a Windows or macOS cell would have been served Linux headers and published under that cell's key, the same shape of mislabelling RECIPE_ARCH was added to prevent. Export the slug and let the recipe refuse what it cannot serve. An unset RECIPE_OS stays permissive, so a recipe built by an older action is unaffected.