### PR TITLE
setup-clang-tidy: find sources by walking, not by asking git.

### DIFF
--- a/actions/setup-clang-tidy/add_language_commands.py
+++ b/actions/setup-clang-tidy/add_language_commands.py
@@ -17,7 +17,6 @@ Usage: add_language_commands.py <build-dir> [<source-dir>] [--force-include H]
 import json
 import re
 import shlex
-import subprocess
 import sys
 from pathlib import Path
 
@@ -26,6 +25,10 @@ HEADER_SUFFIXES = (".h", ".hpp", ".hh", ".hxx")
 # Flags whose value is the next argument rather than joined to them. Keeping
 # the flag but dropping its value is how an -isystem include path silently
 # goes missing.
+# What marks a directory as generated rather than written. Any one of them
+# is enough; a half-configured tree may not have all.
+BUILD_MARKERS = ("CMakeCache.txt", "CMakeFiles", "build.ninja")
+
 VALUE_FLAGS = frozenset({
     "-I", "-isystem", "-iquote", "-idirafter", "-include", "-imacros",
     "-D", "-U", "-F", "-isysroot", "--sysroot", "-target", "-x", "-arch",
@@ -79,17 +82,32 @@ def base_command(db: list[dict]) -> list[str]:
     raise SystemExit("error: no C++ entry to take flags from")
 
 
-def tracked(source: Path, patterns: list[str]) -> list[str]:
-    return subprocess.run(["git", "ls-files", *patterns], cwd=source,
-                          capture_output=True, text=True,
-                          check=True).stdout.split()
+def iter_sources(source: Path, wanted: tuple[str, ...]):
+    """Files under source with one of these suffixes, build trees pruned.
+
+    Walks rather than asking git: a checkout is not always a repository the
+    action can query. Build trees are pruned -- the configured one, and any
+    stale sibling a developer left behind -- since nothing generated into one
+    is the project's own source, and a tree that pulled in a dependency has
+    that dependency's headers under it.
+    """
+    stack = [source]
+    while stack:
+        directory = stack.pop()
+        if directory.name == ".git" or any((directory / m).exists()
+                                           for m in BUILD_MARKERS):
+            continue
+        for path in sorted(directory.iterdir()):
+            if path.is_dir():
+                stack.append(path)
+            elif path.suffix in wanted:
+                yield path
 
 
 def files_for(lang: dict, source: Path) -> list[Path]:
-    patterns = [f"*{s}" for s in (*lang["suffixes"], *HEADER_SUFFIXES)]
+    wanted = (*lang["suffixes"], *HEADER_SUFFIXES)
     found = []
-    for rel in tracked(source, patterns):
-        path = source / rel
+    for path in iter_sources(source, wanted):
         if path.suffix in lang["suffixes"]:
             found.append(path)
         elif lang["content"].search(path.read_text(errors="ignore")):

--- a/actions/setup-clang-tidy/test_add_language_commands.py
+++ b/actions/setup-clang-tidy/test_add_language_commands.py
@@ -69,10 +69,14 @@ class TestAddCommands(unittest.TestCase):
     def setUp(self):
         self.root = Path(__file__).resolve().parent / "_r"
         self.root.mkdir(exist_ok=True)
-        subprocess.run(["git", "init", "-q"], cwd=self.root, check=True)
         (self.root / "k.cu").write_text("__global__ void k() {}\n")
         (self.root / "plain.h").write_text("int f();\n")
-        subprocess.run(["git", "add", "-A"], cwd=self.root, check=True)
+        # Both must be ignored: a build tree is anything with a
+        # CMakeCache.txt, configured or left over.
+        for stale in ("b", "build-old"):
+            (self.root / stale).mkdir(exist_ok=True)
+            (self.root / stale / "CMakeCache.txt").write_text("")
+            (self.root / stale / "generated.cu").write_text("__global__ void g(){}\n")
 
     def tearDown(self):
         subprocess.run(["rm", "-rf", str(self.root)], check=True)
@@ -83,7 +87,7 @@ class TestAddCommands(unittest.TestCase):
 
     def test_adds_cuda_and_leaves_plain_headers_alone(self):
         db = self._db()
-        added = alc.add_commands(db, Path("/b"), self.root,
+        added = alc.add_commands(db, self.root / "b", self.root,
                                  {"CUDA_PATH": "/cuda"}, [])
         self.assertEqual(added["cuda"], 1)
         entry = db[-1]
@@ -95,7 +99,8 @@ class TestAddCommands(unittest.TestCase):
 
     def test_without_the_env_the_language_is_skipped(self):
         db = self._db()
-        self.assertEqual(alc.add_commands(db, Path("/b"), self.root, {}, []), {})
+        self.assertEqual(
+            alc.add_commands(db, self.root / "b", self.root, {}, []), {})
         self.assertEqual(len(db), 1)
 
 


### PR DESCRIPTION
Listing candidate files with `git ls-files` assumes the checkout is a repository the action can query. That is not always true: a tarball checkout has no repository at all, and a checkout whose ownership does not match the user running the step makes git refuse outright, which is how this first failed.

Walk the tree instead. The answer is the same, with two differences worth having: build trees are pruned by their markers, so a stale one a developer left beside the configured one is not read, and pruning means not descending into a dependency a build pulled in. Neither changes which files are selected -- what a file contains is what decides that -- so this is work avoided rather than a wrong answer corrected.