### PR TITLE
setup-clang-tidy: analyse the code OpenMP hides.

### DIFF
--- a/actions/setup-clang-tidy/action.yml
+++ b/actions/setup-clang-tidy/action.yml
@@ -27,6 +27,13 @@ inputs:
     description: |
       CUDA release to provision headers for, e.g. "12.8.1". Empty skips CUDA
       entirely, and no CUDA compile commands are added.
+  openmp:
+    required: false
+    default: 'false'
+    description: |
+      Add -fopenmp to the commands for sources that use OpenMP, so the code
+      behind _OPENMP is parsed rather than skipped. The review container
+      needs the libomp headers matching the clang-tidy that parses.
   source-dir:
     required: false
     default: '.'
@@ -124,6 +131,7 @@ runs:
         BUILD: ${{ steps.configure.outputs.build-dir }}
         SOURCE_DIR: ${{ inputs.source-dir }}
         FORCE_INCLUDE: ${{ inputs.force-include }}
+        CLANG_TIDY_OPENMP: ${{ inputs.openmp == 'true' && '1' || '' }}
       run: |
         set -euo pipefail
         args=("${BUILD}" "${SOURCE_DIR}")

--- a/actions/setup-clang-tidy/add_language_commands.py
+++ b/actions/setup-clang-tidy/add_language_commands.py
@@ -35,9 +35,10 @@ VALUE_FLAGS = frozenset({
 })
 CXX_SUFFIXES = (".cpp", ".cc", ".cxx", ".C")
 
-# suffixes: files this language owns by name. content: what marks a header as
-# belonging to it, since a name does not. env: the variable naming the
-# toolchain root; unset means the consumer did not ask for this language.
+# suffixes: files this language owns by name, if any. content: what marks a
+# header as belonging to it, since a name does not. env: the variable that
+# has to be set for the language to be considered at all -- a toolchain root
+# where one is needed, a bare marker where the language is only a flag.
 LANGUAGES = {
     "cuda": {
         "suffixes": (".cu", ".cuh"),
@@ -49,6 +50,22 @@ LANGUAGES = {
         "flags": lambda root: ["-xcuda", "--cuda-host-only", "-nocudalib",
                                f"--cuda-path={root}",
                                "-Wno-unknown-cuda-version"],
+    },
+    "openmp": {
+        # No suffix of its own: OpenMP is a flag, and the code it hides is
+        # in ordinary headers behind _OPENMP.
+        "suffixes": (),
+        # Only the forms that mean "there is OpenMP code here". A bare
+        # _OPENMP would also match `#ifndef _OPENMP`, whose branch -fopenmp
+        # would hide rather than reveal.
+        "content": re.compile(r"#\s*pragma\s+omp"
+                              r"|#\s*include\s*<omp\.h>"
+                              r"|#\s*ifdef\s+_OPENMP"
+                              r"|defined\s*\(\s*_OPENMP"),
+        "env": "CLANG_TIDY_OPENMP",
+        # Needs the libomp headers matching the clang-tidy that parses, not
+        # the compiler the commands name.
+        "flags": lambda _: ["-fopenmp"],
     },
 }
 
@@ -125,24 +142,42 @@ def add_commands(db: list[dict], build: Path, source: Path, environ: dict,
                  prelude: list[str]) -> dict[str, int]:
     base = base_command(db)
     known = {e["file"] for e in db}
-    added = {}
-    for name, lang in LANGUAGES.items():
-        root = environ.get(lang["env"])
-        if not root:
-            continue
-        count = 0
+    enabled = {n: l for n, l in LANGUAGES.items() if environ.get(l["env"])}
+
+    # A file can belong to more than one language -- a header with both a
+    # CUDA and an OpenMP region -- and needs one command carrying both.
+    # clang-tidy reads the first entry it finds for a file and ignores the
+    # rest, so a command per language would silently drop all but one.
+    #
+    # One command still means one set of macros, so a header guarding two
+    # ways on the same macro has only the branch that command selects
+    # analysed. That is why a language is recognised by the code it holds
+    # rather than by the macro it guards on: a header merely mentioning
+    # __CUDACC__ keeps its ordinary branch, and the CUDA code it reaches for
+    # is analysed where that code actually lives.
+    per_file: dict[Path, list[str]] = {}
+    for name, lang in enabled.items():
         for src in files_for(lang, source):
-            if str(src) in known:
-                continue
-            extra = prelude if prelude and needs_prelude(src) else []
-            db.append({
-                "directory": str(build),
-                "file": str(src),
-                "arguments": [*base, *lang["flags"](root), *extra,
-                              "-c", str(src)],
-            })
-            count += 1
-        added[name] = count
+            if str(src) not in known:
+                per_file.setdefault(src, []).append(name)
+
+    added = dict.fromkeys(enabled, 0)
+    for src, names in sorted(per_file.items()):
+        flags: list[str] = []
+        for name in names:
+            flags += enabled[name]["flags"](environ[enabled[name]["env"]])
+            added[name] += 1
+        # A header carries no language in its name, and clang assumes C.
+        # A language that sets one (CUDA) has already said so; otherwise say
+        # C++, or the file is parsed as C and every include fails.
+        if not any(f.startswith("-x") for f in flags):
+            flags.insert(0, "-xc++")
+        extra = prelude if prelude and needs_prelude(src) else []
+        db.append({
+            "directory": str(build),
+            "file": str(src),
+            "arguments": [*base, *flags, *extra, "-c", str(src)],
+        })
     return added
 
 

--- a/actions/setup-clang-tidy/test_add_language_commands.py
+++ b/actions/setup-clang-tidy/test_add_language_commands.py
@@ -106,3 +106,74 @@ class TestAddCommands(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestMultipleLanguages(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(__file__).resolve().parent / "_m"
+        self.root.mkdir(exist_ok=True)
+        # One header in both languages, as Differentiator.h is.
+        (self.root / "both.h").write_text(
+            '#include "own.h"\n__device__ void d();\n#pragma omp parallel for\n')
+        (self.root / "own.h").write_text("int f();\n")
+
+    def tearDown(self):
+        subprocess.run(["rm", "-rf", str(self.root)], check=True)
+
+    def test_one_entry_carrying_both_sets_of_flags(self):
+        db = [{"file": "/p/b.cpp",
+               "command": "/bin/clang++ -I/p -std=c++17 -c /p/b.cpp"}]
+        added = alc.add_commands(db, self.root / "b", self.root,
+                                 {"CUDA_PATH": "/cuda", "CLANG_TIDY_OPENMP": "1"},
+                                 [])
+        self.assertEqual(added, {"cuda": 1, "openmp": 1})
+        entries = [e for e in db if e["file"].endswith("both.h")]
+        # One entry, not one per language: clang-tidy reads only the first.
+        self.assertEqual(len(entries), 1)
+        self.assertIn("-xcuda", entries[0]["arguments"])
+        self.assertIn("-fopenmp", entries[0]["arguments"])
+
+    def test_openmp_alone_does_not_pull_in_cuda_flags(self):
+        db = [{"file": "/p/b.cpp",
+               "command": "/bin/clang++ -c /p/b.cpp"}]
+        alc.add_commands(db, self.root / "b", self.root,
+                         {"CLANG_TIDY_OPENMP": "1"}, [])
+        args = [e for e in db if e["file"].endswith("both.h")][0]["arguments"]
+        self.assertIn("-fopenmp", args)
+        self.assertNotIn("-xcuda", args)
+
+    def test_a_header_without_a_language_flag_is_told_it_is_cxx(self):
+        # clang reads a bare .h as C; without -xc++ every include fails.
+        db = [{"file": "/p/b.cpp", "command": "/bin/clang++ -c /p/b.cpp"}]
+        alc.add_commands(db, self.root / "b", self.root,
+                         {"CLANG_TIDY_OPENMP": "1"}, [])
+        args = [e for e in db if e["file"].endswith("both.h")][0]["arguments"]
+        self.assertIn("-xc++", args)
+
+    def test_cuda_supplies_its_own_language_and_is_not_overridden(self):
+        db = [{"file": "/p/b.cpp", "command": "/bin/clang++ -c /p/b.cpp"}]
+        alc.add_commands(db, self.root / "b", self.root,
+                         {"CUDA_PATH": "/cuda"}, [])
+        args = [e for e in db if e["file"].endswith("both.h")][0]["arguments"]
+        self.assertIn("-xcuda", args)
+        self.assertNotIn("-xc++", args)
+
+    def test_a_file_the_build_already_compiles_is_left_alone(self):
+        # CMake's own command is the right one; a second entry for the same
+        # file would shadow it, since clang-tidy reads only the first.
+        src = str((self.root / "both.h").resolve())
+        db = [{"file": "/p/b.cpp", "command": "/bin/clang++ -c /p/b.cpp"},
+              {"file": src, "command": "/bin/clang++ -DFROM_CMAKE -c " + src}]
+        added = alc.add_commands(db, self.root / "b", self.root,
+                                 {"CLANG_TIDY_OPENMP": "1"}, [])
+        self.assertEqual(added["openmp"], 0)
+        self.assertEqual([e for e in db if e["file"] == src][0]["command"],
+                         "/bin/clang++ -DFROM_CMAKE -c " + src)
+
+    def test_a_header_that_only_avoids_openmp_is_not_selected(self):
+        (self.root / "avoids.h").write_text(
+            '#include "own.h"\n#ifndef _OPENMP\nint serial();\n#endif\n')
+        db = [{"file": "/p/b.cpp", "command": "/bin/clang++ -c /p/b.cpp"}]
+        alc.add_commands(db, self.root / "b", self.root,
+                         {"CLANG_TIDY_OPENMP": "1"}, [])
+        self.assertEqual([e for e in db if e["file"].endswith("avoids.h")], [])


### PR DESCRIPTION
The code behind _OPENMP is invisible without -fopenmp, and CMake has no reason to put that flag on a header's command because it puts no command there at all. So a project's OpenMP regions go unread, its `#pragma omp` directives are skipped rather than checked, and the openmp-* checks have nothing to fire on.

Add OpenMP as a language beside CUDA, off unless a consumer asks. It has no files of its own -- OpenMP is a flag, and the code it hides sits in ordinary headers -- so it is recognised by content alone. The container doing the parsing needs the libomp headers matching its clang-tidy, not the compiler the commands name.

Two things follow from a header being able to hold both languages. Flags merge per file rather than one command per language, since clang-tidy reads only the first command it finds for a file and one each would silently drop all but one. And every generated command now names a language: a header carries none in its name, so clang reads a bare .h as C, and a command that happened not to set one parsed the file as C and failed on its first include.