### PR TITLE
cuda-headers: take crt/ from wherever the release keeps it.

### DIFF
--- a/actions/setup-cuda/action.yml
+++ b/actions/setup-cuda/action.yml
@@ -124,7 +124,7 @@ runs:
         prefix="${GITHUB_WORKSPACE}/cuda"
         # Fail here rather than let a consumer hit clang's much vaguer
         # "cannot find CUDA installation" later.
-        for required in include/cuda.h include/crt bin nvvm/libdevice; do
+        for required in include/cuda.h include/crt bin; do
           if [[ ! -e "${prefix}/${required}" ]]; then
             echo "::error title=setup-cuda::prefix is missing ${required}"
             exit 1

--- a/recipes/cuda-headers/build.py
+++ b/recipes/cuda-headers/build.py
@@ -24,6 +24,16 @@ REDIST = "https://developer.download.nvidia.com/compute/cuda/redist"
 # __clang_cuda_runtime_wrapper.h reaches; cccl adds Thrust/CUB/libcu++.
 COMPONENTS = ("cuda_cudart", "cuda_nvcc", "cuda_cccl", "libcurand")
 
+# Present only in some releases. CUDA 12 ships the crt/ headers inside
+# cuda_nvcc; CUDA 13 split them into a component of their own. Take them
+# from wherever this release keeps them rather than pinning to one layout.
+OPTIONAL_COMPONENTS = ("cuda_crt",)
+
+# What clang's probe and its force-included wrapper actually open. Checked
+# after assembly so a release that moves things fails here, naming what is
+# missing, rather than downstream as "cannot find CUDA installation".
+REQUIRED_PATHS = ("include/cuda.h", "include/crt", "bin")
+
 # NVIDIA's platform keys, which are not the runner-image slugs. Linux only;
 # main() refuses a cell for anything else.
 ARCH_KEY = {"x86_64": "linux-x86_64", "arm64": "linux-sbsa"}
@@ -82,9 +92,11 @@ def main() -> int:
     # inside it for a host-only parse.
     out.joinpath("bin").mkdir(parents=True, exist_ok=True)
 
-    for name in COMPONENTS:
+    for name in COMPONENTS + OPTIONAL_COMPONENTS:
         comp = manifest.get(name)
         if comp is None or plat not in comp:
+            if name in OPTIONAL_COMPONENTS:
+                continue
             print(f"error: {name} has no {plat} in {version}", file=sys.stderr)
             return 1
         entry = comp[plat]
@@ -99,14 +111,17 @@ def main() -> int:
 
         if (root / "include").is_dir():
             copy_tree(root / "include", out / "include")
-        # The one non-header the probe checks for. Never read by a host-only
-        # parse.
-        if (root / "nvvm" / "libdevice").is_dir():
-            copy_tree(root / "nvvm" / "libdevice", out / "nvvm" / "libdevice")
 
     # clang itself reads CUDA_VERSION from cuda.h; this is for tooling that
     # expects the file.
     (out / "version.txt").write_text(f"CUDA Version {version}\n")
+
+    missing = [r for r in REQUIRED_PATHS if not (out / r).exists()]
+    if missing:
+        print(f"error: {version} produced no {', '.join(missing)}; the "
+              "release may have moved them to another component",
+              file=sys.stderr)
+        return 1
 
     total = sum(p.stat().st_size for p in out.rglob("*") if p.is_file())
     print(f"cuda-headers {version} ({arch}): {total / 1e6:.1f} MB", flush=True)

--- a/recipes/cuda-headers/recipe.yaml
+++ b/recipes/cuda-headers/recipe.yaml
@@ -15,7 +15,8 @@ description: |
   correctly, but draws -Wunknown-cuda-version, which a consumer enabling
   clang-diagnostic-* reports as a finding.
 
-  Linux only, and the recipe cannot enforce that itself; see build.py.
+  Linux only; build.py refuses a cell for anything else, and checks that the
+  release put the headers where clang looks before declaring success.
 
 # Not a git source. `repo` is provenance; the components and their versions
 # come from redistrib_{version}.json.


### PR DESCRIPTION
CUDA 12 ships the crt/ headers inside cuda_nvcc; CUDA 13 split them into a component of their own, so a 13.x prefix came out without them and the consumer's prefix check refused it. Take cuda_crt when the release has one.

Stop shipping nvvm/libdevice while here. It was included on the belief that clang's CUDA probe wants it, which is not so -- removing it from a working prefix, clang still finds the installation, because what the probe actually insisted on was bin/. CUDA 13 moved libdevice to a component of its own too, so this is one fewer thing to follow between releases.

Check after assembly that the release put the headers where clang looks. The consumer's check found this one, which meant a cache miss and a download before anything said what was wrong; failing in the recipe names the missing path instead.