### PR TITLE
cuda-headers: take crt/ and libdevice from wherever the release keeps…

### DIFF
--- a/actions/setup-cuda/action.yml
+++ b/actions/setup-cuda/action.yml
@@ -124,7 +124,7 @@ runs:
         prefix="${GITHUB_WORKSPACE}/cuda"
         # Fail here rather than let a consumer hit clang's much vaguer
         # "cannot find CUDA installation" later.
-        for required in include/cuda.h include/crt bin; do
+        for required in include/cuda.h include/crt bin nvvm/libdevice; do
           if [[ ! -e "${prefix}/${required}" ]]; then
             echo "::error title=setup-cuda::prefix is missing ${required}"
             exit 1

--- a/recipes/cuda-headers/build.py
+++ b/recipes/cuda-headers/build.py
@@ -24,15 +24,15 @@ REDIST = "https://developer.download.nvidia.com/compute/cuda/redist"
 # __clang_cuda_runtime_wrapper.h reaches; cccl adds Thrust/CUB/libcu++.
 COMPONENTS = ("cuda_cudart", "cuda_nvcc", "cuda_cccl", "libcurand")
 
-# Present only in some releases. CUDA 12 ships the crt/ headers inside
-# cuda_nvcc; CUDA 13 split them into a component of their own. Take them
-# from wherever this release keeps them rather than pinning to one layout.
-OPTIONAL_COMPONENTS = ("cuda_crt",)
+# Present only in some releases. CUDA 12 keeps the crt/ headers and
+# nvvm/libdevice inside cuda_nvcc; CUDA 13 split them into components of
+# their own. Take them from wherever this release keeps them.
+OPTIONAL_COMPONENTS = ("cuda_crt", "libnvvm")
 
 # What clang's probe and its force-included wrapper actually open. Checked
 # after assembly so a release that moves things fails here, naming what is
 # missing, rather than downstream as "cannot find CUDA installation".
-REQUIRED_PATHS = ("include/cuda.h", "include/crt", "bin")
+REQUIRED_PATHS = ("include/cuda.h", "include/crt", "bin", "nvvm/libdevice")
 
 # NVIDIA's platform keys, which are not the runner-image slugs. Linux only;
 # main() refuses a cell for anything else.
@@ -111,6 +111,10 @@ def main() -> int:
 
         if (root / "include").is_dir():
             copy_tree(root / "include", out / "include")
+        # Needed as soon as a device architecture is named, which every CUDA
+        # test does: clang looks for libdevice before it will parse at all.
+        if (root / "nvvm" / "libdevice").is_dir():
+            copy_tree(root / "nvvm" / "libdevice", out / "nvvm" / "libdevice")
 
     # clang itself reads CUDA_VERSION from cuda.h; this is for tooling that
     # expects the file.


### PR DESCRIPTION
… them.

CUDA 12 ships the crt/ headers and nvvm/libdevice inside cuda_nvcc. CUDA 13 split both into components of their own, cuda_crt and libnvvm, so a 13.x prefix came out without either and the consumer's prefix check refused it. Take them from whichever component this release puts them in.

libdevice is not optional despite nothing device-side being compiled: name a GPU architecture, as every CUDA test does, and clang looks for it before it will parse at all. Only -nocudalib removes that, and a consumer compiling real sources does not pass it.

Check after assembly that the release put everything where clang looks. The consumer's check found the crt/ move, which meant a cache miss and a download before anything said what was wrong; failing in the recipe names the missing path instead.