### PR TITLE
llvm-wheel: add the wheel-toolchain recipe and manylinux image

### DIFF
--- a/.github/workflows/wheel-image.yml
+++ b/.github/workflows/wheel-image.yml
@@ -1,0 +1,73 @@
+name: wheel-image
+
+# Bakes the llvm-wheel recipe artifact into the manylinux toolchain
+# image (docker/manylinux-llvm-wheel/Dockerfile) and pushes it to
+# GHCR. Dispatch-only: the llvm-wheel cell must already be published
+# (publish-recipe warms it on merge), so run this after the cell
+# exists rather than racing the warm-up on push. The setup-recipe
+# os/arch below must match the linux llvm-wheel row in cells.yaml.
+#
+# Tags: the exact LLVM version and its major, e.g.
+#   ghcr.io/<owner>/manylinux_2_28_x86_64-llvm:21.1.8
+#   ghcr.io/<owner>/manylinux_2_28_x86_64-llvm:21
+# Consumers pin the exact-version tag (or its digest) in pyproject.
+#
+# One-time after the first push: the new GHCR package starts private;
+# make it public so consumer repos' cibuildwheel can pull it without
+# credentials.
+
+on:
+  workflow_dispatch:
+    inputs:
+      llvm-version:
+        description: "llvm-wheel recipe version (exact tag, e.g. '21.1.8')."
+        type: string
+        required: true
+        default: '21.1.8'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  image:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fetch the llvm-wheel artifact
+        id: recipe
+        uses: ./actions/setup-recipe
+        with:
+          recipe: llvm-wheel
+          version: ${{ inputs.llvm-version }}
+          os: ubuntu-24.04
+          arch: x86_64
+
+      - name: Stage the docker build context
+        env:
+          RECIPE_PATH: ${{ steps.recipe.outputs.path }}
+        run: |
+          set -euo pipefail
+          test -x "$RECIPE_PATH/bin/clang" || {
+            echo "::error::no clang under $RECIPE_PATH"; exit 1; }
+          mv "$RECIPE_PATH" docker/manylinux-llvm-wheel/install
+
+      - name: Build and push
+        env:
+          VERSION: ${{ inputs.llvm-version }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.repository }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          image="ghcr.io/${OWNER}/manylinux_2_28_x86_64-llvm"
+          major="${VERSION%%.*}"
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$OWNER" --password-stdin
+          docker build \
+            --label "org.opencontainers.image.source=https://github.com/${REPO}" \
+            --label "org.opencontainers.image.version=${VERSION}" \
+            -t "$image:$VERSION" -t "$image:$major" \
+            docker/manylinux-llvm-wheel
+          docker push "$image:$VERSION"
+          docker push "$image:$major"

--- a/README.md
+++ b/README.md
@@ -234,11 +234,14 @@ actions/
   setup-kokkos/        consumer-side: setup-recipe wrapper that installs Kokkos and exports Kokkos_ROOT
   publish-recipe/      producer-side: build under ccache + tar/zstd + upload
   wake-on-lan/         send a magic packet to wake a self-hosted runner; no-op under act
-  lib/cache-io.sh      scheme-aware probe/download/upload helpers; sourced by both actions and the CLI
-  install-build-deps/  thin composite action installing host packages
+  lib/                 python helpers: cache_io.py (scheme-aware probe/download/upload), llvm_build.py (shared LLVM build flow)
+
+docker/
+  manylinux-llvm-wheel/  bakes the llvm-wheel artifact onto the pypa manylinux base for cibuildwheel consumers
 
 bin/recipe-cache       CLI wrapping the same scripts the actions use
 
 .github/workflows/
   publish-recipe.yml   workflow_dispatch + push-on-main publisher
+  wheel-image.yml      dispatch-only: build + push the GHCR wheel-toolchain image
 ```

--- a/cells.yaml
+++ b/cells.yaml
@@ -54,6 +54,14 @@ cells:
   - { recipe: llvm-wasm,  version: '22',            os: ubuntu-24.04,    arch: x86_64 }
   - { recipe: llvm-wasm,  version: '22',            os: ubuntu-24.04-arm, arch: arm64  }
   - { recipe: llvm-wasm,  version: '22',            os: macos-26,        arch: arm64  }
+  # llvm-wheel: the wheel-building toolchain (static-only, assertions
+  # off; see the recipe). The linux cell builds inside the manylinux
+  # container for the glibc 2.28 floor; the macOS cell builds at
+  # deployment target 14.0. Versions are exact release tags — bump by
+  # editing both rows; the wheel-image workflow bakes the linux
+  # artifact into the GHCR toolchain image afterwards.
+  - { recipe: llvm-wheel, version: '21.1.8',        os: ubuntu-24.04,    arch: x86_64 }
+  - { recipe: llvm-wheel, version: '21.1.8',        os: macos-26,        arch: arm64  }
   # cpython-debug: --with-pydebug + --with-trace-refs + --with-assertions.
   # Linux x86_64 only -- macOS / Windows have stock CPython via the
   # platform package manager; the CI cost of building debug Python on

--- a/docker/manylinux-llvm-wheel/.gitignore
+++ b/docker/manylinux-llvm-wheel/.gitignore
@@ -1,0 +1,1 @@
+install/

--- a/docker/manylinux-llvm-wheel/Dockerfile
+++ b/docker/manylinux-llvm-wheel/Dockerfile
@@ -1,0 +1,12 @@
+# The wheel-building toolchain image: the pypa manylinux_2_28 base
+# with the llvm-wheel recipe artifact baked at /opt/llvm, so consumer
+# cibuildwheel builds point manylinux-x86_64-image here and need no
+# per-build provisioning. The artifact of record stays the recipe
+# tarball in the Releases cache; this image is only its delivery form.
+# Build context: a staging directory whose install/ is the recipe
+# artifact (see .github/workflows/wheel-image.yml).
+# The base must match _MANYLINUX_IMAGE in recipes/llvm-wheel/build.py.
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+COPY install/ /opt/llvm/
+ENV PATH=/opt/llvm/bin:$PATH

--- a/recipes/llvm-wheel/build.py
+++ b/recipes/llvm-wheel/build.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Builds the wheel-toolchain LLVM/Clang install tree.
+
+See recipe.yaml for the design rationale. Recipe-specific bits live
+here; the shared install-tree publish flow (env validation,
+LLVM_DISTRIBUTION_COMPONENTS, install-distribution, find_package
+smoke) lives in actions/lib/llvm_build.py.
+
+Inputs (env): see actions/lib/llvm_build.py, plus
+  RECIPE_VERSION       exact LLVM release tag suffix ('21.1.8');
+                       _source_ref refuses anything else.
+  LLVM_WHEEL_INNER     set by the docker wrapper; do not set by hand.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / ".." / ".." / "actions" / "lib"))
+
+import llvm_build  # noqa: E402
+
+# Must match the FROM in docker/manylinux-llvm-wheel/Dockerfile.
+_MANYLINUX_IMAGE = "quay.io/pypa/manylinux_2_28_x86_64"
+_MACOS_DEPLOYMENT_TARGET = "14.0"
+
+
+def _source_ref(version: str) -> str:
+    """Map the recipe version to the immutable llvmorg release tag."""
+    if not re.fullmatch(r"\d+\.\d+\.\d+(-rc\d+)?", version):
+        raise ValueError(
+            f"llvm-wheel needs an exact release tag suffix "
+            f"(e.g. '21.1.8'), not '{version}': a wheel toolchain "
+            f"names exactly what it holds")
+    return f"llvmorg-{version}"
+
+
+def _link_jobs() -> str:
+    """Cap parallel links: LLVM Release links take gigabytes each, and
+    NCPUS-wide linking OOMs 16 GB runners."""
+    ncpus = int(os.environ.get("NCPUS", "4"))
+    return str(min(4, ncpus))
+
+
+def _reexec_in_container() -> int:
+    """Run this script again inside the manylinux container.
+
+    The bind mounts keep the outer contract intact: the install tree
+    lands in the runner's OUT_DIR, and SRC_COMMIT reaches the runner's
+    GITHUB_ENV.
+    """
+    repo_root = (SCRIPT_DIR / ".." / "..").resolve()
+    work = os.environ["WORK_DIR"]
+    out = os.environ["OUT_DIR"]
+
+    cmd = ["docker", "run", "--rm",
+           "-v", f"{repo_root}:/ciwf",
+           "-v", f"{work}:/work",
+           "-v", f"{out}:/out",
+           "-e", "LLVM_WHEEL_INNER=1",
+           "-e", "WORK_DIR=/work",
+           "-e", "OUT_DIR=/out"]
+    for passthrough in ("RECIPE_VERSION", "NCPUS", "RECIPE_ARCH",
+                        "RECIPE_OS", "RECIPE_QUICK_CHECK"):
+        if os.environ.get(passthrough):
+            cmd += ["-e", f"{passthrough}={os.environ[passthrough]}"]
+    ccache_dir = os.environ.get("CCACHE_DIR", "")
+    if ccache_dir:
+        Path(ccache_dir).mkdir(parents=True, exist_ok=True)
+        cmd += ["-v", f"{ccache_dir}:/ccache", "-e", "CCACHE_DIR=/ccache"]
+        for launcher in ("CMAKE_C_COMPILER_LAUNCHER",
+                         "CMAKE_CXX_COMPILER_LAUNCHER"):
+            if os.environ.get(launcher):
+                cmd += ["-e", f"{launcher}={os.environ[launcher]}"]
+    github_env = os.environ.get("GITHUB_ENV", "")
+    if github_env:
+        cmd += ["-v", f"{github_env}:/github_env", "-e",
+                "GITHUB_ENV=/github_env"]
+
+    # The image ships several CPythons under /opt/python and a pipx
+    # cmake, but no ninja; pip-installing both into one interpreter
+    # keeps the build independent of the image's floating tool set.
+    # ccache is also absent from the image, so the launcher is dropped
+    # and linux cells build cold — acceptable for a rarely-bumped
+    # toolchain.
+    inner = (
+        "py=$(ls -d /opt/python/cp3*/bin/python | head -1); "
+        "$py -m pip install -q cmake ninja; "
+        "export PATH=$(dirname $py):$PATH; "
+        "command -v ccache >/dev/null || "
+        "unset CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER; "
+        "exec $py /ciwf/recipes/llvm-wheel/build.py"
+    )
+    cmd += [_MANYLINUX_IMAGE, "bash", "-c", inner]
+    print(f"build.py: re-executing in {_MANYLINUX_IMAGE}", flush=True)
+    return subprocess.run(cmd, check=False).returncode
+
+
+def _static_only_or_die(prefix: Path) -> None:
+    """The wheel contract: no LLVM/clang dylibs may ship."""
+    stray = [p for pat in ("libLLVM*.so*", "libLLVM*.dylib",
+                           "libclang*.so*", "libclang*.dylib")
+             for p in (prefix / "lib").glob(pat)]
+    if stray:
+        raise RuntimeError(f"static-only install violated: {stray}")
+
+
+def main() -> int:
+    llvm_build.setup_env()
+    version = os.environ["RECIPE_VERSION"]
+    try:
+        src_ref = _source_ref(version)
+    except ValueError as err:
+        print(f"::error::{err}", file=sys.stderr)
+        return 1
+
+    if sys.platform.startswith("linux") and \
+            not os.environ.get("LLVM_WHEEL_INNER"):
+        if os.environ.get("RECIPE_ARCH", "x86_64") != "x86_64":
+            print("::error::llvm-wheel linux cells are x86_64-only "
+                  "(the recipe wires only the x86_64 manylinux image)",
+                  file=sys.stderr)
+            return 1
+        if not shutil.which("docker"):
+            print("::error::llvm-wheel linux builds need docker "
+                  "(the build runs inside the manylinux container)",
+                  file=sys.stderr)
+            return 1
+        return _reexec_in_container()
+
+    work_dir = Path(os.environ["WORK_DIR"])
+    out_dir = Path(os.environ["OUT_DIR"])
+    ncpus = os.environ["NCPUS"]
+
+    os.chdir(work_dir)
+    print(f"build.py: version={version}; cloning {src_ref}", flush=True)
+    llvm_build.clone_shallow(
+        "https://github.com/llvm/llvm-project.git",
+        src_ref,
+        work_dir / "llvm-project",
+    )
+    llvm_build.record_src_commit(work_dir / "llvm-project")
+
+    build_dir = work_dir / "llvm-project" / "build"
+    build_dir.mkdir(exist_ok=True)
+    os.chdir(build_dir)
+
+    # Deliberately NOT base_cmake_args(): assertions and the dylibs
+    # diverge, and silently inheriting a flag bump meant for the CI
+    # toolchains would change what ships inside user wheels.
+    cmake_args = [
+        "cmake", "-G", "Ninja",
+        f"-DCMAKE_INSTALL_PREFIX={out_dir / 'install'}",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DLLVM_ENABLE_ASSERTIONS=OFF",
+        "-DLLVM_TARGETS_TO_BUILD=host",
+        "-DLLVM_ENABLE_PROJECTS=clang;lld",
+        "-DLLVM_ENABLE_RTTI=ON",
+        "-DLLVM_ENABLE_ZLIB=FORCE_ON",
+        "-DLLVM_ENABLE_ZSTD=OFF",
+        "-DLLVM_ENABLE_LIBXML2=OFF",
+        "-DLLVM_ENABLE_LIBEDIT=OFF",
+        f"-DLLVM_PARALLEL_LINK_JOBS={_link_jobs()}",
+        "-DCLANG_ENABLE_STATIC_ANALYZER=OFF",
+        "-DCLANG_ENABLE_ARCMT=OFF",
+        "-DCLANG_ENABLE_FORMAT=OFF",
+        "-DCLANG_ENABLE_BOOTSTRAP=OFF",
+        "-DLLVM_INCLUDE_BENCHMARKS=OFF",
+        "-DLLVM_INCLUDE_EXAMPLES=OFF",
+        "-DLLVM_INCLUDE_TESTS=OFF",
+    ]
+    if sys.platform == "darwin":
+        # The floor every produced object carries; delocate and the
+        # consumer's wheel tag verify against it downstream.
+        cmake_args.append(
+            f"-DCMAKE_OSX_DEPLOYMENT_TARGET={_MACOS_DEPLOYMENT_TARGET}")
+    cmake_args += llvm_build.cmake_extra()
+    cmake_args += ["../llvm"]
+    llvm_build.record_cmake_args(cmake_args)
+    subprocess.run(cmake_args, check=True)
+
+    llvm_build.quick_check_or_continue()
+
+    # The same library surface llvm-release builds for CppInterOp
+    # consumers, plus the lld binary.
+    subprocess.run(
+        ["ninja", "-j", ncpus,
+         "clang", "clangInterpreter", "clangStaticAnalyzerCore", "lld"],
+        check=True,
+    )
+
+    llvm_build.cleanup_intermediates()
+    llvm_build.install_distribution(extras=["lld"])
+
+    _static_only_or_die(out_dir / "install")
+    major = version.split(".")[0]
+    # install-lld ships the platform driver symlinks; assert the one a
+    # consumer's -fuse-ld=lld resolves.
+    driver = "ld64.lld" if sys.platform == "darwin" else "ld.lld"
+    llvm_build.smoke(required_files=[
+        f"lib/clang/{major}/include/stddef.h",
+        "bin/lld",
+        f"bin/{driver}",
+    ])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/recipes/llvm-wheel/recipe.yaml
+++ b/recipes/llvm-wheel/recipe.yaml
@@ -1,0 +1,32 @@
+recipe: llvm-wheel
+description: |
+  Wheel-toolchain LLVM/Clang: the build that Python wheels link
+  against, static-only and floor-pinned so the resulting wheel
+  installs on any supported machine.
+
+  Linux cells run the whole build inside the
+  quay.io/pypa/manylinux_2_28_x86_64 container with its own devtoolset
+  compiler, so archives statically linked into a wheel stay within the
+  manylinux_2_28 glibc policy (the llvmlite/Triton approach). macOS
+  cells build at CMAKE_OSX_DEPLOYMENT_TARGET=14.0: the oldest
+  Apple-supported major, and every Apple Silicon machine can run it.
+
+  Config deltas vs llvm-release, all deliberate:
+    - assertions OFF: an LLVM assertion inside a shipped wheel aborts
+      the end user's Python process.
+    - no LLVM/clang dylibs: wheel consumers link the static archives
+      and must not ship a second LLVM.
+    - RTTI ON: the cppyy-lineage bindings require it.
+    - zstd/libxml2/libedit OFF, zlib FORCE_ON: libz.so.1 is on the
+      manylinux whitelist; every other dependency would have to be
+      grafted into the consumer's wheel.
+    - lld ships: consumers linking the static archives may need
+      -fuse-ld=lld (BFD's GOTPCRELX relaxation has corrupted such
+      links before).
+
+  Versions must be exact release tags ('21.1.8'), never bare majors:
+  a wheel toolchain names exactly what it holds.
+
+source:
+  repo: https://github.com/llvm/llvm-project
+  branch_template: llvmorg-{version}

--- a/recipes/llvm-wheel/test_build.py
+++ b/recipes/llvm-wheel/test_build.py
@@ -1,0 +1,119 @@
+"""Unit tests for the llvm-wheel recipe's version, container-reexec,
+and artifact-contract logic.
+
+Loaded by path rather than imported: recipe directories are not
+packages, and every recipe's build script is called build.py, so a
+plain import would collide across recipes in sys.modules.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_SPEC = importlib.util.spec_from_file_location(
+    "llvm_wheel_build", Path(__file__).resolve().parent / "build.py")
+build = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(build)
+
+# The minimal runner-side env _reexec_in_container requires.
+_REEXEC_ENV = {
+    "WORK_DIR": "/tmp/w",
+    "OUT_DIR": "/tmp/o",
+    "RECIPE_VERSION": "21.1.8",
+    "NCPUS": "4",
+}
+
+
+class SourceRefTests(unittest.TestCase):
+    """A wheel toolchain must name exactly what it holds: only
+    immutable release tags are accepted."""
+
+    def test_exact_tag_is_accepted(self):
+        self.assertEqual(build._source_ref("21.1.8"), "llvmorg-21.1.8")
+        self.assertEqual(build._source_ref("23.1.0-rc2"),
+                         "llvmorg-23.1.0-rc2")
+
+    def test_partial_or_branch_versions_are_refused(self):
+        for bad in ("21", "21.1", "21.1.8.1", "21.1.8-rc",
+                    "release/21.x"):
+            with self.assertRaises(ValueError):
+                build._source_ref(bad)
+
+
+class LinkJobsTests(unittest.TestCase):
+    """Parallel LLVM links are the OOM vector on 16 GB runners."""
+
+    def test_caps_at_four(self):
+        with mock.patch.dict(os.environ, {"NCPUS": "16"}):
+            self.assertEqual(build._link_jobs(), "4")
+
+    def test_small_runners_keep_their_count(self):
+        with mock.patch.dict(os.environ, {"NCPUS": "2"}):
+            self.assertEqual(build._link_jobs(), "2")
+
+
+class ReexecTests(unittest.TestCase):
+    """The docker command must carry the runner-side contract into the
+    container: required env always, ccache and GITHUB_ENV only when
+    the runner provides them."""
+
+    def _docker_cmd(self, extra_env):
+        env = dict(_REEXEC_ENV, **extra_env)
+        with mock.patch.dict(os.environ, env, clear=True), \
+                mock.patch.object(build.subprocess, "run") as run:
+            run.return_value = mock.Mock(returncode=0)
+            rc = build._reexec_in_container()
+        self.assertEqual(rc, 0)
+        return run.call_args[0][0]
+
+    def test_required_mounts_and_env(self):
+        cmd = self._docker_cmd({})
+        self.assertIn("/tmp/w:/work", cmd)
+        self.assertIn("/tmp/o:/out", cmd)
+        self.assertIn("RECIPE_VERSION=21.1.8", cmd)
+        self.assertIn("NCPUS=4", cmd)
+        self.assertNotIn("CCACHE_DIR=/ccache", cmd)
+        self.assertNotIn("GITHUB_ENV=/github_env", cmd)
+
+    def test_ccache_mount_only_when_configured(self):
+        with tempfile.TemporaryDirectory() as d:
+            cmd = self._docker_cmd({
+                "CCACHE_DIR": f"{d}/cc",
+                "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+            })
+        self.assertIn(f"{d}/cc:/ccache", cmd)
+        self.assertIn("CCACHE_DIR=/ccache", cmd)
+        self.assertIn("CMAKE_C_COMPILER_LAUNCHER=ccache", cmd)
+
+    def test_github_env_is_remapped(self):
+        cmd = self._docker_cmd({"GITHUB_ENV": "/tmp/ge"})
+        self.assertIn("/tmp/ge:/github_env", cmd)
+        self.assertIn("GITHUB_ENV=/github_env", cmd)
+
+
+class StaticOnlyTests(unittest.TestCase):
+    """The wheel contract bans LLVM/clang dylibs in the artifact."""
+
+    def test_clean_prefix_passes(self):
+        with tempfile.TemporaryDirectory() as d:
+            lib = Path(d) / "lib"
+            lib.mkdir()
+            (lib / "libLLVMCore.a").touch()
+            build._static_only_or_die(Path(d))
+
+    def test_dylib_fails(self):
+        with tempfile.TemporaryDirectory() as d:
+            lib = Path(d) / "lib"
+            lib.mkdir()
+            (lib / "libLLVM-21.so").touch()
+            with self.assertRaises(RuntimeError):
+                build._static_only_or_die(Path(d))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds common wheels building infrastructure. These images should be used by cppjit to build wheels for manylinux and OS X, conforming to the PyPA ci-buildwheel standards. Adopts the support target of scipy: minimum of SDK 14 for MacOS and manylinux 2_28 for linux distributions.